### PR TITLE
Fix throw_symbol matcher and add cuke for it.

### DIFF
--- a/features/matchers/throw_symbol.feature
+++ b/features/matchers/throw_symbol.feature
@@ -1,0 +1,85 @@
+Feature: Throw symbol matcher
+
+  The throw_symbol matcher is used to specify that a block of code
+  throws a symbol.  The most basic form passes if any symbol is thrown:
+
+    expect { throw :foo }.to throw_symbol
+
+  You'll often want to specify that a particular symbol is thrown:
+
+    expect { throw :foo }.to throw_symbol(:foo)
+
+  If you care about the additional argument given to throw, you can
+  specify that as well:
+
+    expect { throw :foo, 7 }.to throw_symbol(:foo, 7)
+
+  Scenario: basic usage
+    Given a file named "throw_symbol_matcher_spec.rb" with:
+      """
+      describe "throw" do
+        specify { expect { throw :foo    }.to     throw_symbol }
+        specify { expect { throw :bar, 7 }.to     throw_symbol }
+        specify { expect { 5 + 5         }.to_not throw_symbol }
+
+        # deliberate failures
+        specify { expect { throw :foo    }.to_not throw_symbol }
+        specify { expect { throw :bar, 7 }.to_not throw_symbol }
+        specify { expect { 5 + 5         }.to     throw_symbol }
+      end
+      """
+    When I run "rspec throw_symbol_matcher_spec.rb"
+    Then the output should contain all of these:
+      | 6 examples, 3 failures                      |
+      | expected no Symbol to be thrown, got :foo   |
+      | expected no Symbol to be thrown, got :bar   |
+      | expected a Symbol to be thrown, got nothing |
+
+  Scenario: specify thrown symbol
+    Given a file named "throw_symbol_matcher_spec.rb" with:
+      """
+      describe "throw symbol" do
+        specify { expect { throw :foo    }.to     throw_symbol(:foo) }
+        specify { expect { throw :foo, 7 }.to     throw_symbol(:foo) }
+        specify { expect { 5 + 5         }.to_not throw_symbol(:foo) }
+        specify { expect { throw :bar    }.to_not throw_symbol(:foo) }
+
+        # deliberate failures
+        specify { expect { throw :foo    }.to_not throw_symbol(:foo) }
+        specify { expect { throw :foo, 7 }.to_not throw_symbol(:foo) }
+        specify { expect { 5 + 5         }.to     throw_symbol(:foo) }
+        specify { expect { throw :bar    }.to     throw_symbol(:foo) }
+      end
+      """
+    When I run "rspec throw_symbol_matcher_spec.rb"
+    Then the output should contain all of these:
+      | 8 examples, 4 failures                          |
+      | expected :foo not to be thrown, got :foo        |
+      | expected :foo not to be thrown, got :foo with 7 |
+      | expected :foo to be thrown, got nothing         |
+      | expected :foo to be thrown, got :bar            |
+
+  Scenario: specify thrown symbol and argument
+    Given a file named "throw_symbol_argument_matcher_spec.rb" with:
+      """
+      describe "throw symbol with argument" do
+        specify { expect { throw :foo, 7 }.to     throw_symbol(:foo, 7) }
+        specify { expect { throw :foo, 8 }.to_not throw_symbol(:foo, 7) }
+        specify { expect { throw :bar, 7 }.to_not throw_symbol(:foo, 7) }
+        specify { expect { throw :foo    }.to_not throw_symbol(:foo, 7) }
+
+        # deliberate failures
+        specify { expect { throw :foo, 7 }.to_not throw_symbol(:foo, 7) }
+        specify { expect { throw :foo, 8 }.to     throw_symbol(:foo, 7) }
+        specify { expect { throw :bar, 7 }.to     throw_symbol(:foo, 7) }
+        specify { expect { throw :foo    }.to     throw_symbol(:foo, 7) }
+      end
+      """
+    When I run "rspec throw_symbol_argument_matcher_spec.rb"
+    Then the output should contain all of these:
+      | 8 examples, 4 failures                                       |
+      | expected :foo with 7 not to be thrown, got :foo with 7       |
+      | expected :foo with 7 to be thrown, got :foo with 8           |
+      | expected :foo with 7 to be thrown, got :bar                  |
+      | expected :foo with 7 to be thrown, got :foo with no argument |
+

--- a/spec/rspec/matchers/throw_symbol_spec.rb
+++ b/spec/rspec/matchers/throw_symbol_spec.rb
@@ -17,11 +17,11 @@ module RSpec
         end
         it "provides a failure message" do
           @matcher.matches?(lambda{})
-          @matcher.failure_message_for_should.should == "expected a Symbol but nothing was thrown"
+          @matcher.failure_message_for_should.should == "expected a Symbol to be thrown, got nothing"
         end
         it "provides a negative failure message" do
           @matcher.matches?(lambda{ throw :sym})
-          @matcher.failure_message_for_should_not.should == "expected no Symbol, got :sym"
+          @matcher.failure_message_for_should_not.should == "expected no Symbol to be thrown, got :sym"
         end
       end
           
@@ -42,15 +42,15 @@ module RSpec
         end
         it "provides a failure message when no Symbol is thrown" do
           @matcher.matches?(lambda{})
-          @matcher.failure_message_for_should.should == "expected :sym but nothing was thrown"
+          @matcher.failure_message_for_should.should == "expected :sym to be thrown, got nothing"
         end
         it "provides a failure message when wrong Symbol is thrown" do
           @matcher.matches?(lambda{ throw :other_sym })
-          @matcher.failure_message_for_should.should == "expected :sym, got :other_sym"
+          @matcher.failure_message_for_should.should == "expected :sym to be thrown, got :other_sym"
         end
         it "provides a negative failure message" do
           @matcher.matches?(lambda{ throw :sym })
-          @matcher.failure_message_for_should_not.should == "expected :sym not to be thrown"
+          @matcher.failure_message_for_should_not.should == "expected :sym not to be thrown, got :sym"
         end
         it "only matches NameErrors raised by uncaught throws" do
           expect {
@@ -79,15 +79,23 @@ module RSpec
         end
         it "provides a failure message when no Symbol is thrown" do
           @matcher.matches?(lambda{})
-          @matcher.failure_message_for_should.should == %q[expected :sym with "a" but nothing was thrown]
+          @matcher.failure_message_for_should.should == %q[expected :sym with "a" to be thrown, got nothing]
         end
         it "provides a failure message when wrong Symbol is thrown" do
           @matcher.matches?(lambda{ throw :other_sym })
-          @matcher.failure_message_for_should.should == %q[expected :sym with "a", got :other_sym]
+          @matcher.failure_message_for_should.should == %q[expected :sym with "a" to be thrown, got :other_sym]
+        end
+        it "provides a failure message when wrong arg is thrown" do
+          @matcher.matches?(lambda{ throw :sym, "b" })
+          @matcher.failure_message_for_should.should == %q[expected :sym with "a" to be thrown, got :sym with "b"]
+        end
+        it "provides a failure message when no arg is thrown" do
+          @matcher.matches?(lambda{ throw :sym })
+          @matcher.failure_message_for_should.should == %q[expected :sym with "a" to be thrown, got :sym with no argument]
         end
         it "provides a negative failure message" do
           @matcher.matches?(lambda{ throw :sym })
-          @matcher.failure_message_for_should_not.should == %q[expected :sym with "a" not to be thrown]
+          @matcher.failure_message_for_should_not.should == %q[expected :sym with "a" not to be thrown, got :sym with no argument]
         end
         it "only matches NameErrors raised by uncaught throws" do
           expect {


### PR DESCRIPTION
Note that the first commit changes the behavior of the matcher a bit; before it swallowed all exceptions, which I felt was a bug.  Since there's a slight chance this could break someone's specs, you might consider putting that commit in master but not the 2-0 stable branch.
