### PR TITLE
[minor] improved documentation for change method

### DIFF
--- a/lib/rspec/matchers/change.rb
+++ b/lib/rspec/matchers/change.rb
@@ -130,6 +130,9 @@ MESSAGE
     #
     # Allows you to specify that a Proc will cause some value to change.
     #
+    # You can either pass <tt>receiver</tt> and <tt>message</tt>, or a block,
+    # but not both.
+    #
     # == Examples
     #
     #   lambda {


### PR DESCRIPTION
The documentation for `change` confused me, so I added a paragraph at the bottom:

```
# :call-seq:
#   should change(receiver, message, &block)
#   should change(receiver, message, &block).by(value)
#   should change(receiver, message, &block).from(old).to(new)
#   should_not change(receiver, message, &block)
#
# Allows you to specify that a Proc will cause some value to change.
#
# You can either pass <tt>receiver</tt> and <tt>message</tt>, or a block,
# but not both.
```

There's an obscure feature that lets you write `change(nil, 'my result') { ... }` to get a custom `message`, but I don't think it's worth cluttering the docs with this.

This is my first pull request ever -- let me know if I'm doing it right, please! :-)
