### PR TITLE
Better diff output for Hash

### DIFF
--- a/lib/rspec/expectations/differ.rb
+++ b/lib/rspec/expectations/differ.rb
@@ -15,15 +15,15 @@ module RSpec
         output = ""
         diffs = Diff::LCS.diff(data_old, data_new)
         return output if diffs.empty?
-        oldhunk = hunk = nil  
+        oldhunk = hunk = nil
         file_length_difference = 0
         diffs.each do |piece|
           begin
             hunk = Diff::LCS::Hunk.new(
               data_old, data_new, piece, context_lines, file_length_difference
             )
-            file_length_difference = hunk.file_length_difference      
-            next unless oldhunk      
+            file_length_difference = hunk.file_length_difference
+            next unless oldhunk
             # Hunks may overlap, which is why we need to be careful when our
             # diff includes lines of context. Otherwise, we might print
             # redundant lines.
@@ -36,14 +36,14 @@ module RSpec
             oldhunk = hunk
             output << "\n"
           end
-        end  
+        end
         #Handle the last remaining hunk
         output << oldhunk.diff(format) << "\n"
-      end  
+      end
 
       def diff_as_object(actual,expected)
-        actual = String === actual ? actual : PP.pp(actual,"")
-        expected = String === expected ? expected : PP.pp(expected,"")
+        actual = object_to_string(actual)
+        expected = object_to_string(expected)
         diff_as_string(actual, expected)
       end
 
@@ -56,7 +56,21 @@ module RSpec
       def context_lines
         3
       end
+
+      def object_to_string(object)
+        case object
+        when Hash
+          object.keys.sort_by { |k| k.to_s }.map do |k|
+            %(#{PP.singleline_pp(k, "")} => #{PP.singleline_pp(object[k], "")})
+          end.join(",\n")
+        when String
+          object
+        else
+          PP.pp(object,"")
+        end
+      end
     end
 
   end
 end
+

--- a/spec/rspec/expectations/differ_spec.rb
+++ b/spec/rspec/expectations/differ_spec.rb
@@ -93,4 +93,24 @@ EOD
     diff.should == expected_diff
   end
 
+  it "outputs unified diff message of two hashes" do
+    expected = { :foo => 'bar', :baz => 'quux', :metasyntactic => 'variable', :delta => 'charlie', :width =>'quite wide' }
+    actual   = { :foo => 'bar', :metasyntactic => 'variable', :delta => 'charlotte', :width =>'quite wide' }
+
+    expected_diff = <<'EOD'
+
+@@ -1,4 +1,5 @@
+-:delta => "charlotte",
++:baz => "quux",
++:delta => "charlie",
+ :foo => "bar",
+ :metasyntactic => "variable",
+ :width => "quite wide"
+EOD
+
+
+    diff = @differ.diff_as_object(expected,actual)
+    diff.should == expected_diff
+  end
+
 end


### PR DESCRIPTION
Hello,

I made a better diff output when comparing two hashes.

The diff was previously comparing the hashes' pretty prints. It was actually quite hard to read: the keys were not ordered and their were curly brackets surrounding the first and last line.

This patch outputs the Hash without surrounding brackets with lines sorted by keys.

Previous output:

```
@@ -1,8 +1,9 @@
-{"reference"=>"Account No. 324",
+{"name"=>nil,
+ "reference"=>"Account No. 324",
  "token"=>"ABCD1234",
  "type"=>"authorization",
  "created_by_account"=>"Quatchi Sasquatch",
- "created_by_user"=>"Quatchi Sasquatch",
+ "created_by_user"=>"1234567890",
  "message"=>"Your magazine subscription.",
  "email"=>"not-a-user@example.com",
  "state"=>"pending"}
```

Patched output:

```
  @@ -1,7 +1,8 @@
   "created_by_account" => "Quatchi Sasquatch",
  -"created_by_user" => "Quatchi Sasquatch",
  +"created_by_user" => "1234567890",
   "email" => "not-a-user@example.com",
   "message" => "Your magazine subscription.",
  +"name" => nil,
   "reference" => "Account No. 324",
   "state" => "pending",
   "token" => "ABCD1234",
```

Any questions? Just ask! :)

I hope you'll find this patch usefull.

Cheers,

Philippe
