### PR TITLE
Allow the expect change matcher to take regexps in to and from

### DIFF
--- a/lib/rspec/matchers/change.rb
+++ b/lib/rspec/matchers/change.rb
@@ -32,9 +32,9 @@ MESSAGE
       end
       
       def failure_message_for_should
-        if @given_from && !matches_pattern?(@from, @before)
+        if @given_from && !given_matches_actual?(@from, @before)
           "#{message} should have initially been #{@from.inspect}, but was #{@before.inspect}"
-        elsif @given_to && !matches_pattern?(@to, @after)
+        elsif @given_to && !given_matches_actual?(@to, @after)
           "#{message} should have been changed to #{@to.inspect}, but is now #{@after.inspect}"
         elsif @amount
           "#{message} should have been changed by #{@amount.inspect}, but was changed by #{actual_delta.inspect}"
@@ -101,15 +101,15 @@ MESSAGE
       end
 
       def matches_before?
-        @given_from ? matches_pattern?(@from, @before) : true
+        @given_from ? given_matches_actual?(@from, @before) : true
       end
 
       def matches_after?
-        @given_to ? matches_pattern?(@to, @after) : true
+        @given_to ? given_matches_actual?(@to, @after) : true
       end
 
-      def matches_pattern?(given, actual)
-        given.is_a?(Regexp) ? (given =~ actual) : (given == actual)
+      def given_matches_actual?(given, actual)
+        given === actual
       end
 
       def matches_amount?
@@ -181,6 +181,11 @@ MESSAGE
     #   lambda {
     #     doctor.leave_office
     #   }.should change(doctor, :sign).from(/is in/).to(/is out/)
+    #
+    #   user = User.new(:type => "admin")
+    #   lambda {
+    #     user.symbolize_type
+    #   }.should change(user, :type).from(String).to(Symbol)
     #
     # == Notes
     #

--- a/spec/rspec/matchers/change_spec.rb
+++ b/spec/rspec/matchers/change_spec.rb
@@ -273,24 +273,20 @@ describe "should change(actual, message).from(old)" do
       @instance.some_value = 'string'
     end
 
-    it "passes when attribute is == to expected value before executing block" do
+    it "passes when attribute is === to expected value before executing block" do
       expect { @instance.some_value = "astring" }.to change(@instance, :some_value).from("string")
     end
 
-    it "passes when the expected regexp =~ attribute before executing block" do
-      expect { @instance.some_value = "astring" }.to change(@instance, :some_value).from(/^string/)
+    it "compares the expected and actual values with ===" do
+      expected = "string"
+      expected.should_receive(:===).and_return true
+      expect { @instance.some_value = "astring" }.to change(@instance, :some_value).from(expected)
     end
 
-    it "fails when attribute is not == to expected value before executing block" do
+    it "fails when attribute is not === to expected value before executing block" do
       expect do
         expect { @instance.some_value = "knot" }.to change(@instance, :some_value).from("cat")
       end.to fail_with("some_value should have initially been \"cat\", but was \"string\"")
-    end
-
-    it "fails when the expected regexp !~ attribute before executing block" do
-      expect do
-        expect { @instance.some_value = "knot" }.to change(@instance, :some_value).from(/cat/)
-      end.to fail_with("some_value should have initially been /cat/, but was \"string\"")
     end
   end
 end
@@ -301,24 +297,20 @@ describe "should change{ block }.from(old)" do
     @instance.some_value = 'string'
   end
 
-  it "passes when attribute is == to expected value before executing block" do
+  it "passes when attribute is === to expected value before executing block" do
     expect { @instance.some_value = "astring" }.to change{@instance.some_value}.from("string")
   end
 
-  it "passes when the expected regexp =~ attribute before executing block" do
-    expect { @instance.some_value = "astring" }.to change{@instance.some_value}.from(/^string/)
+  it "compares the expected and actual values with ===" do
+    expected = "string"
+    expected.should_receive(:===).and_return true
+    expect { @instance.some_value = "astring" }.to change{@instance.some_value}.from(expected)
   end
 
-  it "fails when attribute is not == to expected value before executing block" do
+  it "fails when attribute is not === to expected value before executing block" do
     expect do
       expect { @instance.some_value = "knot" }.to change{@instance.some_value}.from("cat")
     end.to fail_with("result should have initially been \"cat\", but was \"string\"")
-  end
-
-  it "fails when the expected regexp !~ attribute before executing block" do
-    expect do
-      expect { @instance.some_value = "knot" }.to change{@instance.some_value}.from(/cat/)
-    end.to fail_with("result should have initially been /cat/, but was \"string\"")
   end
 end
 
@@ -345,24 +337,20 @@ describe "should change(actual, message).to(new)" do
       @instance.some_value = 'string'
     end
     
-    it "passes when attribute is == to expected value after executing block" do
+    it "passes when attribute is === to expected value after executing block" do
       expect { @instance.some_value = "cat" }.to change(@instance, :some_value).to("cat")
     end
 
-    it "passes when the expected regexp =~ attribute after executing block" do
-      expect { @instance.some_value = "cat" }.to change(@instance, :some_value).to(/cat/)
+    it "compares the expected and actual values with ===" do
+      expected = "cat"
+      expected.should_receive(:===).and_return true
+      expect { @instance.some_value = "cat" }.to change(@instance, :some_value).to(expected)
     end
 
-    it "fails when attribute is not == to expected value after executing block" do
+    it "fails when attribute is not === to expected value after executing block" do
       expect do
         expect { @instance.some_value = "cat" }.to change(@instance, :some_value).from("string").to("dog")
       end.to fail_with("some_value should have been changed to \"dog\", but is now \"cat\"")
-    end
-
-    it "fails when the expected regexp !~ attribute after executing block" do
-      expect do
-        expect { @instance.some_value = "cat" }.to change(@instance, :some_value).from("string").to(/dog/)
-      end.to fail_with("some_value should have been changed to /dog/, but is now \"cat\"")
     end
   end
 end
@@ -373,24 +361,20 @@ describe "should change{ block }.to(new)" do
     @instance.some_value = 'string'
   end
   
-  it "passes when attribute is == to expected value after executing block" do
+  it "passes when attribute is === to expected value after executing block" do
     expect { @instance.some_value = "cat" }.to change{@instance.some_value}.to("cat")
   end
 
-  it "passes when the expected regexp =~ attribute after executing block" do
-    expect { @instance.some_value = "cat" }.to change{@instance.some_value}.to(/cat/)
+  it "compares the expected and actual values with ===" do
+    expected = "cat"
+    expected.should_receive(:===).and_return true
+    expect { @instance.some_value = "cat" }.to change{@instance.some_value}.to(expected)
   end
 
-  it "fails when attribute is not == to expected value after executing block" do
+  it "fails when attribute is not === to expected value after executing block" do
     expect do
       expect { @instance.some_value = "cat" }.to change{@instance.some_value}.from("string").to("dog")
     end.to fail_with("result should have been changed to \"dog\", but is now \"cat\"")
-  end
-
-  it "fails when the expected regexp !~ attribute after executing block" do
-    expect do
-      expect { @instance.some_value = "cat" }.to change{@instance.some_value}.from("string").to(/dog/)
-    end.to fail_with("result should have been changed to /dog/, but is now \"cat\"")
   end
 end
 


### PR DESCRIPTION
It would often be handy to pass a regular expression to the expect change matcher's from and to methods, when you want to verify that some portion of a string is changed but don't care about the rest.

For example, I was recently writing specs for the 'slug' of an ActiveRecord, the string that gets appended to the record ID in the URL. (In "http://www.example.com/things/23-my-thing", the part generated by #to_param is "23-my-thing" where "my-thing" is the slug, based on some attribute.) In this example, I don't care what the ID is, but I want to make sure the slug is updated when something special happens:

```
expect {
    thing.rename "Estes Kefauver"
}.to change { thing.to_param }.from(/krazy-and-ignatz/).to(/estes-kefauver/)
```

This small commit makes it possible. Does it make sense to roll up?

Rob
