### PR TITLE
has.feature

### DIFF
--- a/features/built_in_matchers/has.feature
+++ b/features/built_in_matchers/has.feature
@@ -1,0 +1,33 @@
+Feature: has_SOMETHING() matcher
+
+  RSpec provides a helper such that:
+
+    * subject.should have_key(x)
+    * subject.should have_item_with_name(x)
+
+  call the appropriate predicate method.
+
+  Scenario: have_item_with_name(x) on an object that implements #has_item_with_name?
+    Given a file named "have_item_with_name_spec.rb" with:
+      """
+      class O
+        def initialize(array)
+          @array = array
+        end
+
+        def has_item_with_name?(name)
+          @array.include?(name)
+        end
+      end
+
+      describe O.new(%w(francois jake)) do
+        it { should     have_item_with_name("francois") }
+        it { should_not have_item_with_name("john") }
+      end
+      """
+
+     When I run `rspec --format doc have_item_with_name_spec.rb`
+     Then the examples should all pass
+      And the output should contain all of these:
+        | should have item with name "francois" |
+        | should not have item with name "john" |


### PR DESCRIPTION
Using 2.5.0, running specs using the doc formatter, the following matcher:

```
it { should have_persona(message[:persona]) }
```

generates a misleading message:

```
should have key {:type=>"twitter", :screen_name=>"fbeausoleil"}
```

I expected a message that included the method's name, something like this:

```
should have persona {:type=>"twitter", :screen_name=>"fbeausoleil"}
```

When I tried using HEAD, I got the message I expected. This feature confirms and ensures the message will stay as-is.
