### PR TITLE
Matcher for Range#cover?.

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,3 +1,10 @@
-default: --require features --tags ~@wip --format progress
-wip: --require features --tags @wip:3 --wip features
+<%
+def tags(tag)
+  tags = [tag]
+  tags << "~@ruby-1.9" if RUBY_VERSION.to_f < 1.9
+  tags.join(" --tags ")
+end
+%>
 
+default: --require features --tags <%= tags("~@wip") %> --format progress
+wip: --require features --tags <%= tags("@wip:3") --wip features

--- a/features/built_in_matchers/cover.feature
+++ b/features/built_in_matchers/cover.feature
@@ -1,0 +1,45 @@
+@ruby-1.9
+Feature: cover matcher
+
+  Use the cover matcher to specify that a range covers one or more
+  expected objects.  This works on any object that responds to #cover?  (such
+  as a Range):
+
+    (1..10).should cover(5)
+    (1..10).should cover(4, 6)
+    (1..10).should_not cover(11)
+
+  Scenario: range usage
+    Given a file named "range_cover_matcher_spec.rb" with:
+      """
+      describe (1..10) do
+        it { should cover(4) }
+        it { should cover(6) }
+        it { should cover(8) }
+        it { should cover(4, 6) }
+        it { should cover(4, 6, 8) }
+        it { should_not cover(11) }
+        it { should_not cover(11, 12) }
+
+        # deliberate failures
+        it { should cover(11) }
+        it { should_not cover(4) }
+        it { should_not cover(6) }
+        it { should_not cover(8) }
+        it { should_not cover(4, 6, 8) }
+
+        # both of these should fail since it covers 1 but not 9
+        it { should cover(5, 11) }
+        it { should_not cover(5, 11) }
+      end
+      """
+    When I run `rspec range_cover_matcher_spec.rb`
+    Then the output should contain all of these:
+      | 14 examples, 7 failures                 |
+      | expected 1..10 to cover 11              |
+      | expected 1..10 not to cover 4           |
+      | expected 1..10 not to cover 6           |
+      | expected 1..10 not to cover 8           |
+      | expected 1..10 not to cover 4, 6, and 8 |
+      | expected 1..10 to cover 5 and 11        |
+      | expected 1..10 not to cover 5 and 11    |

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -181,6 +181,7 @@ require 'rspec/matchers/be_kind_of'
 require 'rspec/matchers/be_within'
 require 'rspec/matchers/block_aliases'
 require 'rspec/matchers/change'
+require 'rspec/matchers/cover' if (1..2).respond_to? :cover?
 require 'rspec/matchers/eq'
 require 'rspec/matchers/eql'
 require 'rspec/matchers/equal'

--- a/lib/rspec/matchers/cover.rb
+++ b/lib/rspec/matchers/cover.rb
@@ -1,0 +1,36 @@
+module RSpec
+  module Matchers
+    # :call-seq:
+    #   should cover(expected)
+    #   should_not cover(expected)
+    #
+    # Passes if actual covers expected. This works for
+    # Ranges. You can also pass in multiple args
+    # and it will only pass if all args are found in Range.
+    #
+    # == Examples
+    #   (1..10).should cover(5)
+    #   (1..10).should cover(4, 6)
+    #   (1..10).should cover(4, 6, 11) # will fail
+    #   (1..10).should_not cover(11)
+    #   (1..10).should_not cover(5) # will fail
+    def cover(*expected)
+      Matcher.new :cover, *expected do |*_expected|
+
+        match_for_should do |actual|
+          perform_match(:all?, actual, _expected)
+        end
+
+        match_for_should_not do |actual|
+          perform_match(:none?, actual, _expected)
+        end
+
+        def perform_match(predicate, actual, _expected)
+          _expected.send(predicate) do |expected|
+              actual.cover?(expected)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rspec/matchers/cover_spec.rb
+++ b/spec/rspec/matchers/cover_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+describe "should cover(expected)", :if => RSpec::Matchers.respond_to?(:cover) do
+  context "for a range target" do
+    it "passes if target covers expected" do
+      (1..10).should cover(5)
+    end
+
+    it "fails if target does not cover expected" do
+      lambda {
+        (1..10).should cover(11)
+      }.should fail_with("expected 1..10 to cover 11")
+    end
+  end
+end
+
+describe "should cover(with, multiple, args)", :if => RSpec::Matchers.respond_to?(:cover) do
+  context "for a range target" do
+    it "passes if target covers all items" do
+      (1..10).should cover(4, 6)
+    end
+
+    it "fails if target does not cover any one of the items" do
+      lambda {
+        (1..10).should cover(4, 6, 11)
+      }.should fail_with("expected 1..10 to cover 4, 6, and 11")
+    end
+  end
+end
+
+describe "should_not cover(expected)", :if => RSpec::Matchers.respond_to?(:cover) do
+  context "for a range target" do
+    it "passes if target does not cover expected" do
+      (1..10).should_not cover(11)
+    end
+
+    it "fails if target covers expected" do
+      lambda {
+        (1..10).should_not cover(5)
+      }.should fail_with("expected 1..10 not to cover 5")
+    end
+  end
+end
+
+describe "should_not cover(with, multiple, args)", :if => RSpec::Matchers.respond_to?(:cover) do
+  context "for a range target" do
+    it "passes if the target does not cover any of the expected" do
+      (1..10).should_not include(11, 12, 13)
+    end
+
+    it "fails if the target covers all of the expected" do
+      expect {
+        (1..10).should_not include(4, 6)
+      }.to fail_with("expected 1..10 not to include 4 and 6")
+    end
+
+    it "fails if the target covers some (but not all) of the expected" do
+      expect {
+        (1..10).should_not include(5, 11)
+      }.to fail_with("expected 1..10 not to include 5 and 11")
+    end
+  end
+end
+
+


### PR DESCRIPTION
The implementation of Range#include? has changed in Ruby 1.9.x, thus the need for a matcher which operates on Range#cover? (only available in Ruby 1.9.x).

The matcher is only included (and the RSpec test run) if Range responds to #cover?. Also, the Cucumber feature test is only run if Ruby version is less than 1.9. This is implemented via a tag in cucumber.yml.

Feel free to bash and/or enlighten me; ruby is not my native language.
