### PR TITLE
fix: missing underscores escaping in "have" feature description 

### DIFF
--- a/features/built_in_matchers/have.feature
+++ b/features/built_in_matchers/have.feature
@@ -4,8 +4,8 @@ Feature: have(n).items matcher
   size of a collection.  There are three basic forms:
 
     * collection.should have(x).items
-    * collection.should have_at_least(x).items
-    * collection.should have_at_most(x).items
+    * collection.should have\_at\_least(x).items
+    * collection.should have\_at\_most(x).items
 
   In addition, #have_exactly is provided as an alias to #have.
 


### PR DESCRIPTION
Hi,

I think the commit message is self explanatory.
There is a tiny typo in the doc, underscores of the `have_at_least` method are interpreted as italic

 http://relishapp.com/rspec/rspec-expectations/v/2-6/dir/built-in-matchers/have-n-items-matcher
