### PR TITLE
Fix warning in matchers/dsl.rb

### DIFF
--- a/lib/rspec/matchers/dsl.rb
+++ b/lib/rspec/matchers/dsl.rb
@@ -7,7 +7,7 @@ module RSpec
         matcher = RSpec::Matchers::Matcher.new(name, &declarations)
         define_method name do |*expected|
           $matcher_execution_context = self
-          matcher.for_expected *expected
+          matcher.for_expected(*expected)
         end
       end
 


### PR DESCRIPTION
lib/rspec/matchers/dsl.rb:10: warning: `*' interpreted as argument prefix
