### PR TITLE
Block expectations should default to subject block

### DIFF
--- a/lib/rspec/matchers/block_aliases.rb
+++ b/lib/rspec/matchers/block_aliases.rb
@@ -13,6 +13,7 @@ module RSpec
     #   expect { this_block }.to change{this.expression}.from(old_value).to(new_value)
     #   expect { this_block }.to raise_error
     def expect(&block)
+      block ||= proc { subject }
       block.extend BlockAliases
     end
   end


### PR DESCRIPTION
I would like to be able to

``` ruby
describe MyController, "#create" do
  subject { post :create, :model => {:thing => "blah"} }
  specify { expect.to change { Model.count }.by 1 }
end
```

or something similar, not sure if this is the best syntactic approach. It fits what I currently do (`expect { subject }.to ...`).

Can't use a plain `#should` here because it calls the subject block before the matcher gets involved.

Not sure where the specs should go, I can't see a spec file for block aliases, maybe should create one?
