### PR TITLE
Test for function_returning_nil.should have(x).items

### DIFF
--- a/features/built_in_matchers/have.feature
+++ b/features/built_in_matchers/have.feature
@@ -101,3 +101,17 @@ Feature: have(n).items matcher
       And the output should contain "expected at least 6 words, got 5"
       And the output should contain "expected at most 4 words, got 5"
 
+  Scenario: have(n).items returns an intellegent error
+    Given a file named "nil_have_items_spec.rb" with:
+      """
+      def foo
+        nil
+      end
+
+      describe "foo" do
+        it { foo.should have(3).items }
+      end
+      """
+    When I run `rspec nil_have_items_spec.rb`
+    Then the output should contain "1 example, 1 failure"
+     And the output should contain "expected 3 items, got 0"


### PR DESCRIPTION
`nil.should have(8).items` returns the expected output:
    expected 8, got 0

You should get the same if you call it on a function that
returns `nil`.  However, you get `undefined method .items`.
