### PR TITLE
Fix confusing error message in `be_within`

### DIFF
--- a/lib/rspec/matchers/built_in/be_within.rb
+++ b/lib/rspec/matchers/built_in/be_within.rb
@@ -14,6 +14,9 @@ module RSpec
           unless defined?(@expected)
             raise ArgumentError.new("You must set an expected value using #of: be_within(#{delta}).of(expected_value)")
           end
+          unless actual.is_a? Numeric
+            raise ArgumentError, "Expected a numeric value be within #{delta} of #{expected} but got #{actual.inspect}"
+          end
           (super(actual) - expected).abs <= delta
         end
 

--- a/spec/rspec/matchers/be_within_spec.rb
+++ b/spec/rspec/matchers/be_within_spec.rb
@@ -59,6 +59,10 @@ module RSpec
         matcher = be_within(0.5)
         expect { matcher.matches?(5.1) }.to raise_error(ArgumentError, /must set an expected value using #of/)
       end
+
+      it "raises an error if the actual value is not numeric" do
+        expect { be_within(0.1).of(0).matches?(nil) }.to raise_error(ArgumentError, /Expected a numeric value be within/)
+      end
     end
   end
 end


### PR DESCRIPTION
This is a patch for [this issue](https://github.com/rspec/rspec-expectations/issues/92).

It is possible to have duck typing for numerical operations, but the minus
sign is often used for other operations as well such as the set
difference that Array#- performs. In that case, even if it does not fail
on the :- method, it will probably fail on the subsequent :abs and :<=
calls.
