### PR TITLE
Give priority to pluralised collection method in have matcher

### DIFF
--- a/lib/rspec/matchers/built_in/have.rb
+++ b/lib/rspec/matchers/built_in/have.rb
@@ -33,10 +33,10 @@ module RSpec
         end
 
         def determine_collection(collection_or_owner)
-          if collection_or_owner.respond_to?(@collection_name)
-            collection_or_owner.send(@collection_name, *@args, &@block)
-          elsif (@plural_collection_name && collection_or_owner.respond_to?(@plural_collection_name))
+          if (@plural_collection_name && collection_or_owner.respond_to?(@plural_collection_name))
             collection_or_owner.send(@plural_collection_name, *@args, &@block)
+          elsif collection_or_owner.respond_to?(@collection_name)
+            collection_or_owner.send(@collection_name, *@args, &@block)
           elsif determine_query_method(collection_or_owner)
             collection_or_owner
           else

--- a/spec/rspec/matchers/have_spec.rb
+++ b/spec/rspec/matchers/have_spec.rb
@@ -122,6 +122,18 @@ describe "have matcher" do
       owner.should have(1).item
     end
 
+    context "when the target defines methods for the singular and plural form of the collection name" do
+
+      it 'uses the plural form' do
+        owner = create_collection_owner_with(1)
+        def owner.item
+          :not_a_collection
+        end
+
+        owner.should have(1).item
+      end
+    end
+
     after(:each) do
       unless @inflector_was_defined
         Object.__send__ :remove_const, :Inflector


### PR DESCRIPTION
If the target defines both the singular and plural form of a collection name the singular form will be used for the have(1) case.

``` ruby
target.respond_to?(:versions) #=> true
target.respond_to?(:version) #=> true, but does not return a collection

target.should have(1).version # fails because it uses version method 
```

Giving priority to the pluralised collection name solves this issue.
