### PR TITLE
Add the ability to pass a Fixnum to the match method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gemspec
   end
 end
 
+gem 'minitest'
+
 ### deps for rdoc.info
 gem 'yard',          '0.8.0', :require => false
 gem 'redcarpet',     '2.1.1'

--- a/features/built_in_matchers/match.feature
+++ b/features/built_in_matchers/match.feature
@@ -48,3 +48,20 @@ Feature: match matcher
       | expected /foo/ not to match "food" |
       | expected /foo/ to match "drinks"   |
 
+  Scenario: fixnum usage
+    Given a file named "fixnum_match_spec.rb" with:
+      """
+      describe "3 pigs" do
+        it { should match(3) }
+        it { should_not match(10) }
+
+        # deliberate failures
+        it { should_not match(3) }
+        it { should match(40) }
+      end
+      """
+    When I run `rspec fixnum_match_spec.rb`
+    Then the output should contain all of these:
+      | 4 examples, 2 failures             |
+      | expected "3 pigs" not to match /3/ |
+      | expected "3 pigs" to match /40/    |

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -492,7 +492,11 @@ module RSpec
     #   email.should match(/^([^\s]+)((?:[-a-z0-9]+\.)+[a-z]{2,})$/i)
     #   email.should match("@example.com")
     def match(expected)
-      BuiltIn::Match.new(expected)
+      if expected.kind_of?(Fixnum)
+        BuiltIn::Match.new(Regexp.new(expected.to_s))
+      else
+        BuiltIn::Match.new(expected)
+      end
     end
 
     # With no args, matches if any error is raised.


### PR DESCRIPTION
Hello,

It's just a little pull request that allow users to pass a Fixnum to the match method. It's quite useful when we write specs for decorators in Rails application ; we want to check if the returned HTML element match a number of comments or articles for example.

I don't know if I have write the feature the right way, I don't used to use Cucumber so if I should edit something, please let me know.

I also allow myself to put minitest to the Gemfile because I'm a Fedora user and Fedora has got a bug, even with 1.9.3, we should gem install minitest or add it to the Gemfile. It's a bit of a pain because some features aren't passing. 

Have a nice day.
