### PR TITLE
Require the "message" param passed to a should[_not] call to be a string

### DIFF
--- a/lib/rspec/expectations/handler.rb
+++ b/lib/rspec/expectations/handler.rb
@@ -7,7 +7,7 @@ module RSpec
       end
 
       def self.check_message(message=nil)
-        raise message_must_be_string unless message == nil or String === message
+        ::Kernel.warn message_must_be_string unless message == nil or String === message
       end
     end
 

--- a/spec/rspec/expectations/syntax_spec.rb
+++ b/spec/rspec/expectations/syntax_spec.rb
@@ -6,21 +6,25 @@ module RSpec
       describe "the should and should_not expectations" do
         describe "#should" do
           it "raises an error when the message object isn't a String" do
-            expect {3.should eq(3), :not_a_string}.to raise_error /The value passed as the message/
+            ::Kernel.should_receive(:warn).with /The value passed as the message/
+            3.should eq(3), :not_a_string
           end
 
           it "doesn't raise an error when message is a String" do
-            expect {3.should eq(3), "a string"}.to_not raise_error /The value passed as the message/
+            ::Kernel.should_not_receive(:warn).with /The value passed as the message/
+            3.should eq(3), "a string"
           end
         end
 
         describe "#should_not" do
           it "raises an error when the message object isn't a String" do
-            expect {3.should_not eq(4), :not_a_string}.to raise_error /The value passed as the message/
+            ::Kernel.should_receive(:warn).with /The value passed as the message/
+            3.should_not eq(4), :not_a_string
           end
 
           it "doesn't raise an error when message is a String" do
-            expect {3.should_not eq(4), "a string"}.to_not raise_error /The value passed as the message/
+            ::Kernel.should_not_receive(:warn).with /The value passed as the message/
+            3.should_not eq(4), "a string"
           end
         end
       end


### PR DESCRIPTION
Hi, this is related to #142.

I've added errors that will get thrown when message parameters aren't strings. I couldn't find any specs dedicated to the should method so I didn't add any specs. If someone can suggest a place where they should go I'll totally add them.
