### PR TITLE
Provide a clear failure message when using `{}.should =~ {}`.

### DIFF
--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -684,6 +684,6 @@ module RSpec
       BuiltIn::MatchArray.new(array)
     end
 
-    OperatorMatcher.register(Array, '=~', BuiltIn::MatchArray)
+    OperatorMatcher.register(Enumerable, '=~', BuiltIn::MatchArray)
   end
 end

--- a/spec/rspec/matchers/match_array_spec.rb
+++ b/spec/rspec/matchers/match_array_spec.rb
@@ -113,6 +113,17 @@ the missing elements were:      [1]
 MESSAGE
   end
 
+  context "when the array defines a `=~` method" do
+    it 'delegates to that method rather than using the match_array matcher' do
+      array = []
+      def array.=~(other)
+        other == :foo
+      end
+
+      array.should =~ :foo
+      expect { array.should =~ :bar }.to fail_with(/expected: :bar/)
+    end
+  end
 end
 
 describe "should_not =~ [:with, :multiple, :args]" do
@@ -134,5 +145,9 @@ describe "matching against things that aren't arrays" do
 
   it "fails with a string and the expected error message is given" do
     expect { "I like turtles".should match_array([1,2,3]) }.to fail_with(/expected an array/)
+  end
+
+  it 'fails with a clear message when given a hash using the `should =~` syntax' do
+    expect { {}.should =~ {} }.to fail_with(/expected an array/)
   end
 end


### PR DESCRIPTION
The match_array matcher (delegated to by `=~` for enumerables) is
not meant to be used for hashes, but the `should =~` syntax doesn't
make that obvious. Previously, you would get a failure like:

```
 Failure/Error: actual.should =~ actual
   expected: {:foo=>"bar"}
        got: {:foo=>"bar"} (using =~)
```

...which is pretty confusing. Our `match_array` matcher already
includes handling for invalid arguments (such as hashes) to return
a clear failure message, but it wasn't being used for an expression
like `{}.should =~ {}` because it was only registered as an operator
matcher for `Array`. This changes it so that it is registered as an
operator matcher for any Enumerable. This improves the failure message
for enumerable types like hash and set, but on its own, it could cause
breakage for things like 1.8 strings that are Enumerable but also
define a reasonable `=~`.  The fix here changes the operator matcher
delegation logic so that it only delegates to the registered matcher
if the object has the generic Kernel implementation of the operator.
If it has a more specific implementation, we assume the user actually
wants to match using the given operator itself.

Fixes #191.

Can I get a code review? /cc @alindeman @phiggins
