### PR TITLE
Allow custom matchers to use built-in #match

### DIFF
--- a/features/custom_matchers/define_matcher.feature
+++ b/features/custom_matchers/define_matcher.feature
@@ -339,9 +339,13 @@ Feature: define matcher
       | expected 9 to be a multiple of 2     |
       | expected 9 not to be a multiple of 3 |
 
-  Scenario: that match against a regular expression
+  Scenario: matching against a regular expression
     Given a file named "regular_expression_matcher_spec.rb" with:
       """ruby
+      # Due to Ruby's method dispatch mechanism, use the `#match_regex` alias
+      # rather than the `#match` matcher when defining custom matchers via the
+      # DSL.
+
       RSpec::Matchers.define :be_valid_us_zipcode do
         match do |actual|
           expect(actual).to match_regex(/\A\d{5}(-\d{4})?\z/)

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -493,6 +493,12 @@ module RSpec
     #   email.should match("@example.com")
     #   zipcode.should match_regex(/\A\d{5}(-\d{4})?\z/)
     #   zipcode.should match_regex("90210")
+    #
+    # @note Due to Ruby's method dispatch mechanism, using the `#match` matcher
+    # within a custom matcher defined via the matcher DSL
+    # (`RSpec::Matcher.define`) will result Ruby calling the wrong `#match`
+    # method and raising an `ArgumentError`. Instead, use the aliased
+    # `#match_regex` method.
     def match(expected)
       BuiltIn::Match.new(expected)
     end


### PR DESCRIPTION
See Issue #188.
