### PR TITLE
Add support for diff-lcs 1.2.x while maintaining backwards compatibility with 1.1.3

### DIFF
--- a/lib/rspec/expectations/differ.rb
+++ b/lib/rspec/expectations/differ.rb
@@ -25,7 +25,13 @@ module RSpec
             # diff includes lines of context. Otherwise, we might print
             # redundant lines.
             if (context_lines > 0) and hunk.overlaps?(oldhunk)
-              hunk.unshift(oldhunk)
+              if hunk.respond_to?(:merge)
+                # diff-lcs 1.2.x
+                hunk.merge(oldhunk)
+              else
+                # diff-lcs 1.1.3
+                hunk.unshift(oldhunk)
+              end
             else
               output << oldhunk.diff(format)
             end

--- a/rspec-expectations.gemspec
+++ b/rspec-expectations.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.rdoc_options     = ["--charset=UTF-8"]
   s.require_path     = "lib"
 
-  s.add_runtime_dependency     'diff-lcs', '~> 1.1.3'
+  s.add_runtime_dependency     'diff-lcs', '>= 1.1.3'
 
   s.add_development_dependency 'rake',     '~> 10.0.0'
   s.add_development_dependency 'cucumber', '~> 1.1.9'


### PR DESCRIPTION
diff-lcs 1.2.0 has recently been released, and all users have been encouraged to upgrade.  rspec-expectations has a gemspec which specifies ~> 1.1.3, which makes this upgrade impossible for rspec users.

There is an API incompatibility (basically a method name change) between the two diff-lcs versions that materially affects rspec-expectations, although the underlying functionality is essentially unchanged.  So I added a respond_to? call to determine if the diff-lcs gem is 1.2.x or 1.1.3, and which calls the appropriate method for the library version.

This is a very limited change, although there's no easy way to test the gem's compatibility against both versions of diff-lcs as part of the specs.
