### PR TITLE
Fix fail_with so it handles strings in any encoding.

### DIFF
--- a/lib/rspec/expectations/fail_with.rb
+++ b/lib/rspec/expectations/fail_with.rb
@@ -44,11 +44,27 @@ module RSpec
       end
 
       def any_multiline_strings?(*args)
-        all_strings?(*args) && args.any? {|a| a =~ /\n/}
+        all_strings?(*args) && args.flatten.any? { |a| multiline?(a) }
       end
 
       def no_numbers?(*args)
         args.flatten.none? {|a| Numeric === a}
+      end
+
+      LINEBREAK = "\n"
+
+      if String.method_defined?(:codepoints)
+        # If the string is a different encoding, we may get Encoding::CompatibilityError
+        # if we try `string.include?("\n")` or `string =~ /\n/`, so we use the codepoints.
+        LINEBREAK_CODEPOINT = LINEBREAK.codepoints.first
+
+        def multiline?(string)
+          string.codepoints.include?(LINEBREAK_CODEPOINT)
+        end
+      else
+        def multiline?(string)
+          string.include?(LINEBREAK)
+        end
       end
     end
   end

--- a/spec/rspec/expectations/fail_with_spec.rb
+++ b/spec/rspec/expectations/fail_with_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'spec_helper'
 
 describe RSpec::Expectations, "#fail_with with diff" do
@@ -39,6 +40,30 @@ describe RSpec::Expectations, "#fail_with with diff" do
         expect {
           RSpec::Expectations.fail_with("the message", "expected", "actual")
         }.to fail_with("the message")
+      end
+    end
+
+    context "and they are UTF-16LE encoded", :if => String.method_defined?(:encode) do
+      it 'does not diff when they are not multiline' do
+        differ.should_not_receive(:diff_as_string)
+
+        str_1 = "This is a pile of poo: 💩".encode("UTF-16LE")
+        str_2 = "This is a pile of poo: 💩".encode("UTF-16LE")
+
+        expect {
+          RSpec::Expectations.fail_with("the message", str_1, str_2)
+        }.to fail_with("the message")
+      end
+
+      it 'diffs when they are multiline' do
+        differ.should_receive(:diff_as_string).and_return("diff")
+
+        str_1 = "This is a pile of poo:\n💩".encode("UTF-16LE")
+        str_2 = "This is a pile of poo:\n💩".encode("UTF-16LE")
+
+        expect {
+          RSpec::Expectations.fail_with("the message", str_1, str_2)
+        }.to fail_with("the message\nDiff:diff")
       end
     end
   end


### PR DESCRIPTION
Previously we would get an Encoding::CompatibilityError if
an encoding was used that's not ASCII compatible.

Fixes #201.

@alindeman -- care to review this?

I'm slightly concerned about a possible perf degredation here (as I imagine converting to codepoints on a large string and checking if it has `\n` could be slower than what was here previously) but I haven't thought of a better way to do this.
