### PR TITLE
Remove confusing empty diff message.

### DIFF
--- a/lib/rspec/expectations/differ.rb
+++ b/lib/rspec/expectations/differ.rb
@@ -48,13 +48,7 @@ module RSpec
       def diff_as_object(actual, expected)
         actual_as_string = object_to_string(actual)
         expected_as_string = object_to_string(expected)
-        diff = diff_as_string(actual_as_string, expected_as_string)
-
-        if diff.empty?
-          "#{actual}.==(#{expected}) returned false even though the diff " \
-          "between #{actual} and #{expected} is empty. Check the " \
-          "implementation of #{actual}.==."
-        else
+        if diff = diff_as_string(actual_as_string, expected_as_string)
           color_diff diff
         end
       end

--- a/spec/rspec/expectations/differ_spec.rb
+++ b/spec/rspec/expectations/differ_spec.rb
@@ -74,14 +74,6 @@ EOD
           expect(diff).to eq expected_diff
         end
 
-        it "outputs a message if the diff is empty" do
-          diff = differ.diff_as_object('foo', 'foo')
-          expect(diff).to eq(
-            "foo.==(foo) returned false even though the diff between " \
-            "foo and foo is empty. Check the implementation of foo.==."
-          )
-        end
-
         it "outputs unified diff message of two arrays" do
           expected = [ :foo, 'bar', :baz, 'quux', :metasyntactic, 'variable', :delta, 'charlie', :width, 'quite wide' ]
           actual   = [ :foo, 'bar', :baz, 'quux', :metasyntactic, 'variable', :delta, 'tango'  , :width, 'very wide'  ]
@@ -175,3 +167,4 @@ EOD
     end
   end
 end
+


### PR DESCRIPTION
The existing message made assumptions (e.g. that `==` was used for comparison)
there were not always true, causing confusion.

Fixes #143.

Note that this reverts the fix for #123.  I think that in the context of the differ, it does not have enough context (e.g. about what matcher was used) to give a message that makes sense in all situations.  @alindeman / @dchelimsky -- are you guys OK with this?  Or is there a better way to solve this issue?
