### PR TITLE
Limit diff-lcs to 1.x series only

### DIFF
--- a/rspec-expectations.gemspec
+++ b/rspec-expectations.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.rdoc_options     = ["--charset=UTF-8"]
   s.require_path     = "lib"
 
-  s.add_runtime_dependency     'diff-lcs', '>= 1.1.3'
+  s.add_runtime_dependency     'diff-lcs', '>= 1.1.3, < 2.0'
 
   s.add_development_dependency 'rake',     '~> 10.0.0'
   s.add_development_dependency 'cucumber', '~> 1.1.9'


### PR DESCRIPTION
I have some experimental code that I am working with that may change the Diff::LCS interface in version 2.0 (whenever that drops). I would like to encourage the adoption of the (currently bug-free) 1.2 release as much as possible, but I don't want to cause other problems if the future release changes.
