### PR TITLE
Encode diff literals according to the actual output encoding.

### DIFF
--- a/spec/rspec/expectations/differ_spec.rb
+++ b/spec/rspec/expectations/differ_spec.rb
@@ -40,14 +40,25 @@ EOD
         end
         if RUBY_VERSION.to_f > 1.9
           it 'copes with encoded strings' do
+            pending "awaiting patch on diff-lcs"
             @expected="Tu avec carté {count} itém has".encode('UTF-16LE')
-            @actual="Tu avec carté {count} itém has".encode('UTF-16LE')
-            expect(subject).to eql("")
+            @actual="Tu avec carte {count} item has".encode('UTF-16LE')
+            expect(subject).to eql(<<-EOD.encode('UTF-16LE'))
+
+@@ -1,2 +1,2 @@
+-Tu avec carté {count} itém has
++Tu avec carte {count} item has
+EOD
           end
-          it 'copes with differently encoded strings' do
+          it 'copes with encoded strings' do
+            @expected="Tu avec carté {count} itém has".encode('UTF-16LE')
+            @actual="Tu avec carte {count} item has".encode('UTF-16LE')
+            expect(subject).to eql 'Could not produce a diff because of the encoding of the string (UTF-16LE)'
+          end
+          it 'ouputs a message when encountering differently encoded strings' do
             @expected="Tu avec carté {count} itém has".encode('UTF-16LE')
             @actual="Tu avec carte {count} item has"
-            expect { subject }.to raise_error Encoding::CompatibilityError
+            expect(subject).to eql 'Could not produce a diff because the encoding of the actual string (UTF-8) differs from the encoding of the expected string (UTF-16LE)'
           end
         end
       end


### PR DESCRIPTION
This is a partial fix for Issue #219, it forces the internal literals to use a matching encoding to one of the diffed encoding, reducing the chance of an encoding error being raised by RSpec. It doens't solve this for all, for example using mismatched encoded strings will still cause this error, but in such cases it won't be RSpec at fault but the user supplying differently encoded strings to comparison. It would be possible to rescue the encoding exception elsewhere in a matcher but that shouldn't be done in the diff IMO.
