### PR TITLE
Fix a backtrace cleaning related spec.

### DIFF
--- a/spec/rspec/matchers/configuration_spec.rb
+++ b/spec/rspec/matchers/configuration_spec.rb
@@ -22,7 +22,12 @@ module RSpec
         end
 
         before do
-          RSpec.configuration.stub(:backtrace_clean_patterns) { [/clean-me/] }
+          @old_patterns = RSpec.configuration.backtrace_exclusion_patterns
+          RSpec.configuration.backtrace_exclusion_patterns = [/clean-me/]
+        end
+
+        after do
+          RSpec.configuration.backtrace_exclusion_patterns = @old_patterns
         end
 
         it "defaults to rspec-core's backtrace formatter when rspec-core is loaded" do


### PR DESCRIPTION
This spec failed when I did a fresh clean of rspec-expectations. It looks like stubbing `backtrace_clean_patterns` doesn't work now, this seems pretty sensible as these are now delegated to another object. I elected to just assign it in the before block. Is this sensible? Should I stub it on the backtrace cleaner instead?
