### PR TITLE
Fixes some weird travis failures noted on master and in #236

### DIFF
--- a/lib/rspec/expectations/differ.rb
+++ b/lib/rspec/expectations/differ.rb
@@ -16,6 +16,9 @@ module RSpec
         file_length_difference = 0
         diffs.each do |piece|
           begin
+            if data_old == []
+              data_old = [""]
+            end
             hunk = Diff::LCS::Hunk.new(
               data_old, data_new, piece, context_lines, file_length_difference
             )


### PR DESCRIPTION
On [this line](https://github.com/rspec/rspec-expectations/blob/master/lib/rspec/expectations/differ.rb#L20) we diff data_old with some other things. Diff-lcs does that[0].encoding which it can't get if it's empty. This pull takes an empty list and puts a single empty string in. This passes the specs but is ugly.
