### PR TITLE
Upgrade to diff-lcs 1.2.2

### DIFF
--- a/lib/rspec/expectations/differ.rb
+++ b/lib/rspec/expectations/differ.rb
@@ -16,9 +16,6 @@ module RSpec
         file_length_difference = 0
         diffs.each do |piece|
           begin
-            if data_old == []
-              data_old = [""]
-            end
             hunk = Diff::LCS::Hunk.new(
               data_old, data_new, piece, context_lines, file_length_difference
             )

--- a/spec/rspec/expectations/fail_with_spec.rb
+++ b/spec/rspec/expectations/fail_with_spec.rb
@@ -5,16 +5,15 @@ require 'spec_helper'
 describe RSpec::Expectations, "#fail_with with diff of arrays" do
   before { RSpec::Matchers.configuration.stub(:color? => false) }
 
-  # Diff::LCS 1.2.2 required for this pattern
-  it "splits items with newlines", :pending => (Diff::LCS::VERSION < '1.2.2') do
-    expected_diff = "\nDiff:\n@@ -1,2 +1,4 @@\n+a\\nb\n+c\\nd\n \n"
+  it "splits items with newlines" do
+    expected_diff = "\nDiff:\n@@ -1 +1,3 @@\n+a\\nb\n+c\\nd\n"
     expect {
       RSpec::Expectations.fail_with("", [], ["a\nb", "c\nd"])
     }.to fail_with(expected_diff)
   end
 
-  it "shows inner arrays on a single line", :pending => (Diff::LCS::VERSION < '1.2.2') do
-    expected_diff = "\nDiff:\n@@ -1,2 +1,4 @@\n+a\\nb\n+[\"c\\nd\"]\n \n"
+  it "shows inner arrays on a single line" do
+    expected_diff = "\nDiff:\n@@ -1 +1,3 @@\n+a\\nb\n+[\"c\\nd\"]\n"
     expect {
       RSpec::Expectations.fail_with("", [], ["a\nb", ["c\nd"]])
     }.to fail_with(expected_diff)


### PR DESCRIPTION
Force upgrade to diff-lcs 1.2.2
Fix the specs that we deliberatly pending until diff-lcs was updated to v1.2.2
Fix the diff's from @samphippen's work in #238

This aparently should fix travis failures on master and #236
