### PR TITLE
Fix broken link to Should.md in features/built-ins README

### DIFF
--- a/features/built_in_matchers/README.md
+++ b/features/built_in_matchers/README.md
@@ -4,7 +4,7 @@ rspec-expectations ships with a number of built-in matchers.
 Each matcher can be used with `expect(..).to` or `expect(..).not_to` to define
 positive and negative expectations respectively on an object. Most matchers can
 also be accessed using the `(...).should` and `(...).should_not` syntax, see
-[using should syntax](https://github.com/rspec/rspec-rails/blob/master/Should.md)
+[using should syntax](https://github.com/rspec/rspec-expectations/blob/master/Should.md)
 for why we recommend using `expect`.
 
 e.g.


### PR DESCRIPTION
Another broken link here.

Missed it when doing #242 
