### PR TITLE
Warn when raise_error receives non-proc object

### DIFF
--- a/lib/rspec/matchers/built_in/raise_error.rb
+++ b/lib/rspec/matchers/built_in/raise_error.rb
@@ -26,7 +26,6 @@ module RSpec
           @eval_block_passed = false
           unless given_proc.respond_to?(:call)
             ::Kernel.warn "`raise_error` was called with non-proc object #{given_proc.inspect}"
-            return false
           end
           begin
             given_proc.call

--- a/spec/rspec/matchers/raise_error_spec.rb
+++ b/spec/rspec/matchers/raise_error_spec.rb
@@ -430,10 +430,8 @@ describe "expect { ... }.to_not raise_error(NamedError, error_message) with Rege
 end
 
 describe "misuse of raise_error, with (), not {}" do
-  it "fails with warning" do
-    ::Kernel.should_receive(:warn).with /`raise_error` was called with non-proc object 1\.7/
-    expect {
-      expect(Math.sqrt(3)).to raise_error
-    }.to fail_with(/nothing was raised/)
+  it "warns that the given object was not proc" do
+    ::Kernel.should_receive(:warn).with /`raise_error` was called with non-proc object 5/
+    expect(5).to raise_error
   end
 end


### PR DESCRIPTION
When a non-proc object is given, `given_proc.call` fails, then `raise_error`
or
`raise_error(NoMethodError)` passes.

This behaviour is dangerous and there is actually no error, so it should warn 
and fail.
