### PR TITLE
have_{more/less}_than matchers

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 
 Enhancements
 
+* Add `have_more_than` and `have_less_than` matchers. (christhekeele)
 * Expand `yield_control` so that you can specify an exact or relative
   number of times: `expect { }.to yield_control.exactly(3).times`,
   `expect { }.to yield_control.at_least(2).times`, etc (Bartek

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -462,6 +462,18 @@ module RSpec
       BuiltIn::Have.new(n, :at_most)
     end
 
+    # Exactly like have() with >.
+    #
+    # @example
+    #   expect("this").to have_more_than(3).letters
+    #
+    # ### Warning:
+    #
+    # `expect(..).not_to have_more_than` is not supported
+    def have_more_than(n)
+      BuiltIn::Have.new(n, :more_than)
+    end
+
     # Passes if actual includes expected. This works for
     # collections and Strings. You can also pass in multiple args
     # and it will only pass if all args are found in collection.

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -474,6 +474,18 @@ module RSpec
       BuiltIn::Have.new(n, :more_than)
     end
 
+    # Exactly like have() with <.
+    #
+    # @example
+    #   expect("this").to have_less_than(4).letters
+    #
+    # ### Warning:
+    #
+    # `expect(..).not_to have_at_most` is not supported
+    def have_less_than(n)
+      BuiltIn::Have.new(n, :less_than)
+    end
+
     # Passes if actual includes expected. This works for
     # collections and Strings. You can also pass in multiple args
     # and it will only pass if all args are found in collection.

--- a/lib/rspec/matchers/built_in/have.rb
+++ b/lib/rspec/matchers/built_in/have.rb
@@ -20,6 +20,7 @@ module RSpec
             :at_least => "at least ",
             :at_most => "at most ",
             :more_than => "more than ",
+            :less_than => "less than "
           }
         end
 
@@ -42,6 +43,7 @@ module RSpec
           when :at_least  then @actual >= @expected
           when :at_most   then @actual <= @expected
           when :more_than then @actual >  @expected
+          when :less_than then @actual <  @expected
           else                 @actual == @expected
           end
         end

--- a/lib/rspec/matchers/built_in/have.rb
+++ b/lib/rspec/matchers/built_in/have.rb
@@ -74,25 +74,29 @@ module RSpec
         end
 
         def failure_message_for_should_not
-          if @relativity == :exactly
-            return "expected target not to have #{@expected} #{@collection_name}, got #{@actual}"
-          elsif @relativity == :at_most
-            return <<-EOF
-Isn't life confusing enough?
-Instead of having to figure out the meaning of this:
-  #{Expectations::Syntax.negative_expression("actual", "have_at_most(#{@expected}).#{@collection_name}")}
-We recommend that you use this instead:
-  #{Expectations::Syntax.positive_expression("actual", "have_at_least(#{@expected + 1}).#{@collection_name}")}
-EOF
-          elsif @relativity == :at_least
-            return <<-EOF
-Isn't life confusing enough?
-Instead of having to figure out the meaning of this:
-  #{Expectations::Syntax.negative_expression("actual", "have_at_least(#{@expected}).#{@collection_name}")}
-We recommend that you use this instead:
-  #{Expectations::Syntax.positive_expression("actual", "have_at_most(#{@expected - 1}).#{@collection_name}")}
-EOF
+          collective_expectation = "(#{@expected}).#{@collection_name}"
+          case @relativity
+          when :exactly
+            "expected target not to have #{@expected} #{@collection_name}, got #{@actual}"
+          when :at_most
+            contrapositive_message("have_at_most", "have_less_than", collective_expectation)
+          when :at_least
+            contrapositive_message("have_at_least", "have_more_than", collective_expectation)
+          when :more_than
+            contrapositive_message("have_more_than", "have_at_least", collective_expectation)
+          when :less_than
+            contrapositive_message("have_less_than", "have_at_most", collective_expectation)
           end
+        end
+
+        def contrapositive_message(negation, contrapositive, expectation)
+          <<-EOF
+Isn't life confusing enough?
+Instead of having to figure out the meaning of this:
+  #{Expectations::Syntax.negative_expression("actual", negation + expectation)}
+We recommend that you use this instead:
+  #{Expectations::Syntax.positive_expression("actual", contrapositive + expectation)}
+EOF
         end
 
         def description

--- a/lib/rspec/matchers/built_in/have.rb
+++ b/lib/rspec/matchers/built_in/have.rb
@@ -79,13 +79,13 @@ module RSpec
           when :exactly
             "expected target not to have #{@expected} #{@collection_name}, got #{@actual}"
           when :at_most
-            contrapositive_message("have_at_most", "have_less_than", collective_expectation)
+            contrapositive_message("have_at_most", "have_more_than", collective_expectation)
           when :at_least
-            contrapositive_message("have_at_least", "have_more_than", collective_expectation)
+            contrapositive_message("have_at_least", "have_less_than", collective_expectation)
           when :more_than
-            contrapositive_message("have_more_than", "have_at_least", collective_expectation)
+            contrapositive_message("have_more_than", "have_at_most", collective_expectation)
           when :less_than
-            contrapositive_message("have_less_than", "have_at_most", collective_expectation)
+            contrapositive_message("have_less_than", "have_at_least", collective_expectation)
           end
         end
 

--- a/lib/rspec/matchers/built_in/have.rb
+++ b/lib/rspec/matchers/built_in/have.rb
@@ -18,7 +18,8 @@ module RSpec
           @relativities ||= {
             :exactly => "",
             :at_least => "at least ",
-            :at_most => "at most "
+            :at_most => "at most ",
+            :more_than => "more than ",
           }
         end
 
@@ -38,9 +39,10 @@ module RSpec
             @actual = collection.__send__(query_method)
           end
           case @relativity
-          when :at_least then @actual >= @expected
-          when :at_most  then @actual <= @expected
-          else                @actual == @expected
+          when :at_least  then @actual >= @expected
+          when :at_most   then @actual <= @expected
+          when :more_than then @actual >  @expected
+          else                 @actual == @expected
           end
         end
         alias == matches?

--- a/spec/rspec/matchers/have_spec.rb
+++ b/spec/rspec/matchers/have_spec.rb
@@ -237,7 +237,7 @@ Isn't life confusing enough?
 Instead of having to figure out the meaning of this:
   expect(actual).not_to have_at_least(3).items_in_collection_with_length_method
 We recommend that you use this instead:
-  expect(actual).to have_more_than(3).items_in_collection_with_length_method
+  expect(actual).to have_less_than(3).items_in_collection_with_length_method
 EOF
 
       expect(size_matcher.failure_message_for_should_not).to eq <<-EOF
@@ -245,14 +245,14 @@ Isn't life confusing enough?
 Instead of having to figure out the meaning of this:
   expect(actual).not_to have_at_least(3).items_in_collection_with_size_method
 We recommend that you use this instead:
-  expect(actual).to have_more_than(3).items_in_collection_with_size_method
+  expect(actual).to have_less_than(3).items_in_collection_with_size_method
 EOF
       expect(count_matcher.failure_message_for_should_not).to eq <<-EOF
 Isn't life confusing enough?
 Instead of having to figure out the meaning of this:
   expect(actual).not_to have_at_least(3).items_in_collection_with_count_method
 We recommend that you use this instead:
-  expect(actual).to have_more_than(3).items_in_collection_with_count_method
+  expect(actual).to have_less_than(3).items_in_collection_with_count_method
 EOF
     end
   end
@@ -303,7 +303,7 @@ Isn't life confusing enough?
 Instead of having to figure out the meaning of this:
   expect(actual).not_to have_at_most(3).items_in_collection_with_length_method
 We recommend that you use this instead:
-  expect(actual).to have_less_than(3).items_in_collection_with_length_method
+  expect(actual).to have_more_than(3).items_in_collection_with_length_method
 EOF
 
       expect(size_matcher.failure_message_for_should_not).to eq <<-EOF
@@ -311,7 +311,7 @@ Isn't life confusing enough?
 Instead of having to figure out the meaning of this:
   expect(actual).not_to have_at_most(3).items_in_collection_with_size_method
 We recommend that you use this instead:
-  expect(actual).to have_less_than(3).items_in_collection_with_size_method
+  expect(actual).to have_more_than(3).items_in_collection_with_size_method
 EOF
 
       expect(count_matcher.failure_message_for_should_not).to eq <<-EOF
@@ -319,7 +319,7 @@ Isn't life confusing enough?
 Instead of having to figure out the meaning of this:
   expect(actual).not_to have_at_most(3).items_in_collection_with_count_method
 We recommend that you use this instead:
-  expect(actual).to have_less_than(3).items_in_collection_with_count_method
+  expect(actual).to have_more_than(3).items_in_collection_with_count_method
 EOF
     end
   end
@@ -377,7 +377,7 @@ Isn't life confusing enough?
 Instead of having to figure out the meaning of this:
   expect(actual).not_to have_more_than(3).items_in_collection_with_length_method
 We recommend that you use this instead:
-  expect(actual).to have_at_least(3).items_in_collection_with_length_method
+  expect(actual).to have_at_most(3).items_in_collection_with_length_method
 EOF
 
       expect(size_matcher.failure_message_for_should_not).to eq <<-EOF
@@ -385,14 +385,14 @@ Isn't life confusing enough?
 Instead of having to figure out the meaning of this:
   expect(actual).not_to have_more_than(3).items_in_collection_with_size_method
 We recommend that you use this instead:
-  expect(actual).to have_at_least(3).items_in_collection_with_size_method
+  expect(actual).to have_at_most(3).items_in_collection_with_size_method
 EOF
       expect(count_matcher.failure_message_for_should_not).to eq <<-EOF
 Isn't life confusing enough?
 Instead of having to figure out the meaning of this:
   expect(actual).not_to have_more_than(3).items_in_collection_with_count_method
 We recommend that you use this instead:
-  expect(actual).to have_at_least(3).items_in_collection_with_count_method
+  expect(actual).to have_at_most(3).items_in_collection_with_count_method
 EOF
     end
   end
@@ -450,7 +450,7 @@ Isn't life confusing enough?
 Instead of having to figure out the meaning of this:
   expect(actual).not_to have_less_than(3).items_in_collection_with_length_method
 We recommend that you use this instead:
-  expect(actual).to have_at_most(3).items_in_collection_with_length_method
+  expect(actual).to have_at_least(3).items_in_collection_with_length_method
 EOF
 
       expect(size_matcher.failure_message_for_should_not).to eq <<-EOF
@@ -458,14 +458,14 @@ Isn't life confusing enough?
 Instead of having to figure out the meaning of this:
   expect(actual).not_to have_less_than(3).items_in_collection_with_size_method
 We recommend that you use this instead:
-  expect(actual).to have_at_most(3).items_in_collection_with_size_method
+  expect(actual).to have_at_least(3).items_in_collection_with_size_method
 EOF
       expect(count_matcher.failure_message_for_should_not).to eq <<-EOF
 Isn't life confusing enough?
 Instead of having to figure out the meaning of this:
   expect(actual).not_to have_less_than(3).items_in_collection_with_count_method
 We recommend that you use this instead:
-  expect(actual).to have_at_most(3).items_in_collection_with_count_method
+  expect(actual).to have_at_least(3).items_in_collection_with_count_method
 EOF
     end
   end

--- a/spec/rspec/matchers/have_spec.rb
+++ b/spec/rspec/matchers/have_spec.rb
@@ -237,7 +237,7 @@ Isn't life confusing enough?
 Instead of having to figure out the meaning of this:
   expect(actual).not_to have_at_least(3).items_in_collection_with_length_method
 We recommend that you use this instead:
-  expect(actual).to have_at_most(2).items_in_collection_with_length_method
+  expect(actual).to have_more_than(3).items_in_collection_with_length_method
 EOF
 
       expect(size_matcher.failure_message_for_should_not).to eq <<-EOF
@@ -245,14 +245,14 @@ Isn't life confusing enough?
 Instead of having to figure out the meaning of this:
   expect(actual).not_to have_at_least(3).items_in_collection_with_size_method
 We recommend that you use this instead:
-  expect(actual).to have_at_most(2).items_in_collection_with_size_method
+  expect(actual).to have_more_than(3).items_in_collection_with_size_method
 EOF
       expect(count_matcher.failure_message_for_should_not).to eq <<-EOF
 Isn't life confusing enough?
 Instead of having to figure out the meaning of this:
   expect(actual).not_to have_at_least(3).items_in_collection_with_count_method
 We recommend that you use this instead:
-  expect(actual).to have_at_most(2).items_in_collection_with_count_method
+  expect(actual).to have_more_than(3).items_in_collection_with_count_method
 EOF
     end
   end
@@ -320,6 +320,79 @@ Instead of having to figure out the meaning of this:
   expect(actual).not_to have_at_most(3).items_in_collection_with_count_method
 We recommend that you use this instead:
   expect(actual).to have_at_least(4).items_in_collection_with_count_method
+EOF
+    end
+  end
+
+  describe "expect(...).to have_more_than(n).items" do
+
+    it "passes if target has a collection of items with > n members" do
+      owner = create_collection_owner_with(3)
+      expect(owner).to have_more_than(2).items_in_collection_with_length_method
+      expect(owner).to have_more_than(2).items_in_collection_with_size_method
+      expect(owner).to have_more_than(2).items_in_collection_with_count_method
+    end
+
+    it "fails if target has a collection of items with n members" do
+      owner = create_collection_owner_with(3)
+      expect {
+        expect(owner).to have_more_than(3).items_in_collection_with_length_method
+      }.to fail_with("expected more than 3 items_in_collection_with_length_method, got 3")
+      expect {
+        expect(owner).to have_more_than(3).items_in_collection_with_size_method
+      }.to fail_with("expected more than 3 items_in_collection_with_size_method, got 3")
+      expect {
+        expect(owner).to have_more_than(3).items_in_collection_with_count_method
+      }.to fail_with("expected more than 3 items_in_collection_with_count_method, got 3")
+    end
+
+    it "fails if target has a collection of items with < n members" do
+      owner = create_collection_owner_with(3)
+      expect {
+        expect(owner).to have_more_than(4).items_in_collection_with_length_method
+      }.to fail_with("expected more than 4 items_in_collection_with_length_method, got 3")
+      expect {
+        expect(owner).to have_more_than(4).items_in_collection_with_size_method
+      }.to fail_with("expected more than 4 items_in_collection_with_size_method, got 3")
+      expect {
+        expect(owner).to have_more_than(4).items_in_collection_with_count_method
+      }.to fail_with("expected more than 4 items_in_collection_with_count_method, got 3")
+    end
+
+    it "provides educational negative failure messages" do
+      #given
+      owner = create_collection_owner_with(3)
+      length_matcher = have_more_than(3).items_in_collection_with_length_method
+      size_matcher = have_more_than(3).items_in_collection_with_size_method
+      count_matcher = have_more_than(3).items_in_collection_with_count_method
+
+      #when
+      length_matcher.matches?(owner)
+      size_matcher.matches?(owner)
+      count_matcher.matches?(owner)
+
+      #then
+      expect(length_matcher.failure_message_for_should_not).to eq <<-EOF
+Isn't life confusing enough?
+Instead of having to figure out the meaning of this:
+  expect(actual).not_to have_more_than(3).items_in_collection_with_length_method
+We recommend that you use this instead:
+  expect(actual).to have_at_least(3).items_in_collection_with_length_method
+EOF
+
+      expect(size_matcher.failure_message_for_should_not).to eq <<-EOF
+Isn't life confusing enough?
+Instead of having to figure out the meaning of this:
+  expect(actual).not_to have_more_than(3).items_in_collection_with_size_method
+We recommend that you use this instead:
+  expect(actual).to have_at_least(3).items_in_collection_with_size_method
+EOF
+      expect(count_matcher.failure_message_for_should_not).to eq <<-EOF
+Isn't life confusing enough?
+Instead of having to figure out the meaning of this:
+  expect(actual).not_to have_more_than(3).items_in_collection_with_count_method
+We recommend that you use this instead:
+  expect(actual).to have_at_least(3).items_in_collection_with_count_method
 EOF
     end
   end

--- a/spec/rspec/matchers/have_spec.rb
+++ b/spec/rspec/matchers/have_spec.rb
@@ -303,7 +303,7 @@ Isn't life confusing enough?
 Instead of having to figure out the meaning of this:
   expect(actual).not_to have_at_most(3).items_in_collection_with_length_method
 We recommend that you use this instead:
-  expect(actual).to have_at_least(4).items_in_collection_with_length_method
+  expect(actual).to have_less_than(3).items_in_collection_with_length_method
 EOF
 
       expect(size_matcher.failure_message_for_should_not).to eq <<-EOF
@@ -311,7 +311,7 @@ Isn't life confusing enough?
 Instead of having to figure out the meaning of this:
   expect(actual).not_to have_at_most(3).items_in_collection_with_size_method
 We recommend that you use this instead:
-  expect(actual).to have_at_least(4).items_in_collection_with_size_method
+  expect(actual).to have_less_than(3).items_in_collection_with_size_method
 EOF
 
       expect(count_matcher.failure_message_for_should_not).to eq <<-EOF
@@ -319,7 +319,7 @@ Isn't life confusing enough?
 Instead of having to figure out the meaning of this:
   expect(actual).not_to have_at_most(3).items_in_collection_with_count_method
 We recommend that you use this instead:
-  expect(actual).to have_at_least(4).items_in_collection_with_count_method
+  expect(actual).to have_less_than(3).items_in_collection_with_count_method
 EOF
     end
   end
@@ -393,6 +393,79 @@ Instead of having to figure out the meaning of this:
   expect(actual).not_to have_more_than(3).items_in_collection_with_count_method
 We recommend that you use this instead:
   expect(actual).to have_at_least(3).items_in_collection_with_count_method
+EOF
+    end
+  end
+
+  describe "expect(...).to have_less_than(n).items" do
+
+    it "passes if target has a collection of items with < n members" do
+      owner = create_collection_owner_with(3)
+      expect(owner).to have_less_than(4).items_in_collection_with_length_method
+      expect(owner).to have_less_than(4).items_in_collection_with_size_method
+      expect(owner).to have_less_than(4).items_in_collection_with_count_method
+    end
+
+    it "fails if target has a collection of items with n members" do
+      owner = create_collection_owner_with(3)
+      expect {
+        expect(owner).to have_less_than(3).items_in_collection_with_length_method
+      }.to fail_with("expected less than 3 items_in_collection_with_length_method, got 3")
+      expect {
+        expect(owner).to have_less_than(3).items_in_collection_with_size_method
+      }.to fail_with("expected less than 3 items_in_collection_with_size_method, got 3")
+      expect {
+        expect(owner).to have_less_than(3).items_in_collection_with_count_method
+      }.to fail_with("expected less than 3 items_in_collection_with_count_method, got 3")
+    end
+
+    it "fails if target has a collection of items with > n members" do
+      owner = create_collection_owner_with(3)
+      expect {
+        expect(owner).to have_less_than(2).items_in_collection_with_length_method
+      }.to fail_with("expected less than 2 items_in_collection_with_length_method, got 3")
+      expect {
+        expect(owner).to have_less_than(2).items_in_collection_with_size_method
+      }.to fail_with("expected less than 2 items_in_collection_with_size_method, got 3")
+      expect {
+        expect(owner).to have_less_than(2).items_in_collection_with_count_method
+      }.to fail_with("expected less than 2 items_in_collection_with_count_method, got 3")
+    end
+
+    it "provides educational negative failure messages" do
+      #given
+      owner = create_collection_owner_with(3)
+      length_matcher = have_less_than(3).items_in_collection_with_length_method
+      size_matcher = have_less_than(3).items_in_collection_with_size_method
+      count_matcher = have_less_than(3).items_in_collection_with_count_method
+
+      #when
+      length_matcher.matches?(owner)
+      size_matcher.matches?(owner)
+      count_matcher.matches?(owner)
+
+      #then
+      expect(length_matcher.failure_message_for_should_not).to eq <<-EOF
+Isn't life confusing enough?
+Instead of having to figure out the meaning of this:
+  expect(actual).not_to have_less_than(3).items_in_collection_with_length_method
+We recommend that you use this instead:
+  expect(actual).to have_at_most(3).items_in_collection_with_length_method
+EOF
+
+      expect(size_matcher.failure_message_for_should_not).to eq <<-EOF
+Isn't life confusing enough?
+Instead of having to figure out the meaning of this:
+  expect(actual).not_to have_less_than(3).items_in_collection_with_size_method
+We recommend that you use this instead:
+  expect(actual).to have_at_most(3).items_in_collection_with_size_method
+EOF
+      expect(count_matcher.failure_message_for_should_not).to eq <<-EOF
+Isn't life confusing enough?
+Instead of having to figure out the meaning of this:
+  expect(actual).not_to have_less_than(3).items_in_collection_with_count_method
+We recommend that you use this instead:
+  expect(actual).to have_at_most(3).items_in_collection_with_count_method
 EOF
     end
   end


### PR DESCRIPTION
I frequently find myself using `have_at_least(3+1)`, when what I really want is `have_more_than(3)`, so I have to add one to my expected value. Eventually I'll introduce an off-by-one error into my tests and lose a little time debugging. It's the same story with `have_at_most` => `have_less_than`. So, I added these two new matchers.

An added benefit of these matchers is that the helpful negative failure messages for the `have_relative` family can recommend contrapositives that don't require you to change the expected value by one. I implemented this too:

```
FactoryGirl.create_list(:user, 5)
expect( User.all ).not_to have_at_most(5).users

# Used to report on failure:
Failure/Error: expect( User.all ).not_to have_at_most(5).users
   Isn't life confusing enough?
   Instead of having to figure out the meaning of this:
     expect(actual).not_to have_at_most(5).users
   We recommend that you use this instead:
     expect(actual).to have_at_least(6).users

# Now reports on failure:
Failure/Error: expect( User.all ).not_to have_at_most(5).users
   Isn't life confusing enough?
   Instead of having to figure out the meaning of this:
     expect(actual).not_to have_at_most(5).users
   We recommend that you use this instead:
     expect(actual).to have_more_than(5).users
```

And etcetera for the other three `have_relative` helpers.
