### PR TITLE
Custom failure message for satisfy

### DIFF
--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -546,8 +546,8 @@ module RSpec
     # @example
     #
     #   expect(5).to satisfy { |n| n > 3 }
-    def satisfy(&block)
-      BuiltIn::Satisfy.new(&block)
+    def satisfy(failure_message=nil, &block)
+      BuiltIn::Satisfy.new(failure_message, &block)
     end
 
     # Matches if the actual value starts with the expected value(s). In the

--- a/lib/rspec/matchers/built_in/satisfy.rb
+++ b/lib/rspec/matchers/built_in/satisfy.rb
@@ -2,7 +2,8 @@ module RSpec
   module Matchers
     module BuiltIn
       class Satisfy
-        def initialize(&block)
+        def initialize(failure_message = nil, &block)
+          @failure_message = failure_message
           @block = block
         end
 
@@ -14,11 +15,11 @@ module RSpec
         alias == matches?
 
         def failure_message_for_should
-          "expected #{@actual} to satisfy block"
+          @failure_message || "expected #{@actual} to satisfy block"
         end
 
         def failure_message_for_should_not
-          "expected #{@actual} not to satisfy block"
+          @failure_message || "expected #{@actual} not to satisfy block"
         end
 
         def description

--- a/spec/rspec/matchers/satisfy_spec.rb
+++ b/spec/rspec/matchers/satisfy_spec.rb
@@ -26,6 +26,18 @@ describe "expect(...).to satisfy { block }" do
       end
     end.to fail_with("expected false to satisfy block")
   end
+  
+  it "fails with custom failure message if block returns false" do
+    expect {
+      expect(false).to satisfy("should be false") { |val| val }
+    }.to fail_with("should be false")
+
+    expect do
+      expect(false).to satisfy("should be false") do |val|
+        val
+      end
+    end.to fail_with("should be false")
+  end
 end
 
 describe "expect(...).not_to satisfy { block }" do
@@ -40,5 +52,11 @@ describe "expect(...).not_to satisfy { block }" do
     expect {
       expect(true).not_to satisfy { |val| val }
     }.to fail_with("expected true not to satisfy block")
+  end
+
+  it "fails with custom failure message if block returns true" do
+    expect {
+      expect(true).not_to satisfy("should not satisty") { |val| val }
+    }.to fail_with("should not satisty")
   end
 end


### PR DESCRIPTION
"expected value to safisty block" is not always the best message ;)

``` ruby
describe Stuff do
  it "fails with custom failure message if block returns false" do
    expect {
      expect(false).to satisfy("should be false") { |val| val }
    }.to fail_with("should be false")

    expect do
      expect(false).to satisfy("should be false") do |val|
        val
      end
    end.to fail_with("should be false")
  end
end
```
