### PR TITLE
be_within(x).percent_of(y) with negative y

### DIFF
--- a/lib/rspec/matchers/built_in/be_within.rb
+++ b/lib/rspec/matchers/built_in/be_within.rb
@@ -23,7 +23,7 @@ module RSpec
 
         def percent_of(expected)
           @expected  = expected
-          @tolerance = @delta * @expected / 100.0
+          @tolerance = @delta * @expected.abs / 100.0
           @unit      = '%'
           self
         end

--- a/spec/rspec/matchers/be_within_spec.rb
+++ b/spec/rspec/matchers/be_within_spec.rb
@@ -31,6 +31,10 @@ module RSpec
         expect(1.0001).to be_within(5).percent_of(1)
       end
 
+      it "passes with negative arguments" do
+        expect(-1.0001).to be_within(5).percent_of(-1)
+      end
+
       it "fails when actual < (expected - delta)" do
         expect {
           expect(4.49).to be_within(0.5).of(5.0)


### PR DESCRIPTION
Hi. 

I've encountered a false failing result when specify a `be_within(x).percent_of(y)` matcher
with negative y.

Here I send a patch adding a test for this issue and fixing it.

I hope it will help you.
