### PR TITLE
Bugfix: makes possible to use RSpec::Matchers#include inside a custom matcher definition

### DIFF
--- a/lib/rspec/matchers/matcher.rb
+++ b/lib/rspec/matchers/matcher.rb
@@ -39,7 +39,9 @@ module RSpec
             end
             @messages = {}
             making_declared_methods_public do
+              @called_from_define = true
               instance_eval_with_args(*@expected, &@declarations)
+              @called_from_define = false
             end
             self
           end
@@ -246,7 +248,7 @@ module RSpec
         end
 
         def trying_to_include_a_module?(*args)
-          args.first.is_a?(Module)
+          @called_from_define == true
         end
 
         def define_method(name, &block)

--- a/spec/rspec/matchers/matcher_spec.rb
+++ b/spec/rspec/matchers/matcher_spec.rb
@@ -327,15 +327,18 @@ module RSpec::Matchers::DSL
       expect(matcher.matches?(8)).to be_true
     end
 
-    it "has access to the built in include matcher" do
-      matcher = RSpec::Matchers::DSL::Matcher.new(:ignore) do |expected|
-        match do |actual|
-          extend RSpec::Matchers
-          expect(actual).to include(expected)
+    context "dealing with the clash caused by the private method include" do
+      it "will work as the include matcher when inside the match block" do
+        RSpec::Matchers.define(:descend_from) do |mod|
+          match do |klass|
+            expect(klass.ancestors).to include(mod)
+          end
         end
-      end.for_expected(3)
 
-      expect(matcher.matches?([1, 2, 3])).to be_true
+        expect {
+          expect(Fixnum).to descend_from(BasicObject)
+        }.not_to raise_error
+      end
     end
 
     context 'when multiple instances of the same matcher are used in the same example' do


### PR DESCRIPTION
This PR introduces a bugfix. That bug was happening because `RSpec::Matchers::DSL::Matcher` has a `include` private method that was overriding the `include` method included from `RSpec::Matchers`. (I know, too much include words in just one phrase =p)

I got that problem while trying to write the following custom matcher:

``` ruby
RSpec::Matchers.define :contain_products do |*products|
  match do |category|
    subcategories_products = category.subcategories.map { |sub|
      sub.products
    }
    subcategories_products.flatten!

    # calling include(*products) breaks here because it's actually calling
    # Module#include instead of RSpec::Matchers#include
    expect(subcategories_products).to include(*products)
  end
end
```

I think this is a bug because it is part of the spec of `RSpec::Matchers::DSL::Matcher` to allow us to [use the built-in matchers inside a custom matcher definition](https://github.com/rspec/rspec-expectations/blob/master/spec/rspec/matchers/matcher_spec.rb#L319-L328).
