### PR TITLE
Support do..end style block with raise_error matcher

### DIFF
--- a/lib/rspec/matchers/built_in/raise_error.rb
+++ b/lib/rspec/matchers/built_in/raise_error.rb
@@ -13,7 +13,7 @@ module RSpec
           end
         end
 
-        def matches?(given_proc, negative_expectation = false)
+        def matches?(given_proc, negative_expectation = false, &block)
           if negative_expectation && (expecting_specific_exception? || @expected_message)
             what_to_deprecate = if expecting_specific_exception? && @expected_message
                                   "`expect { }.not_to raise_error(SpecificErrorClass, message)`"
@@ -24,6 +24,7 @@ module RSpec
                                 end
             RSpec.deprecate(what_to_deprecate, :replacement => "`expect { }.not_to raise_error()`")
           end
+          @block ||= block
           @raised_expected_error = false
           @with_expected_message = false
           @eval_block = false

--- a/spec/rspec/matchers/raise_error_spec.rb
+++ b/spec/rspec/matchers/raise_error_spec.rb
@@ -60,6 +60,30 @@ describe "expect { ... }.to raise_error {|err| ... }" do
   end
 end
 
+describe "expect { ... }.to raise_error do |err| ... end" do
+  it "passes the error to the block" do
+    error = nil
+    expect { non_existent_method }.to raise_error do |e|
+      error = e
+    end
+    expect(error).to be_kind_of(NameError)
+  end
+end
+
+describe "expect { ... }.to(raise_error { |err| ... }) do |err| ... end" do
+  it "passes the error only to the block taken directly by #raise_error" do
+    error_passed_to_curly = nil
+    error_passed_to_do_end = nil
+
+    expect { non_existent_method }.to(raise_error { |e| error_passed_to_curly = e }) do |e|
+      error_passed_to_do_end = e
+    end
+
+    expect(error_passed_to_curly).to be_kind_of(NameError)
+    expect(error_passed_to_do_end).to be_nil
+  end
+end
+
 describe "expect { ... }.not_to raise_error" do
 
   context "with a specific error class" do


### PR DESCRIPTION
Currently `raise_error` matcher accepts only `{..}` style blocks, this is because `{..}` blocks have higher precedence over `do..end` blocks. This may be a common pitfall.

``` ruby
expect { do_something }.to raise_error do |error|
  expect(error.some_value).to eq(1)
end
```

In this case, the `do..end` block is taken by the `#to` method and the `#raise_error` gets no block.

This change makes `raise_error` matcher to use the block passed from `#to` if it didn't take a block directly.
