### PR TITLE
Spec for deprecaton call site

### DIFF
--- a/spec/rspec/matchers/be_spec.rb
+++ b/spec/rspec/matchers/be_spec.rb
@@ -268,6 +268,11 @@ describe "expect(...).to be_false" do
     expect(false).to be_false
   end
 
+  it "has the correct call site in the deprecation message" do
+    expect_deprecation_with_call_site(__FILE__, __LINE__ + 1)
+    expect(false).to be_false
+  end
+
   it "still passes" do
     allow(RSpec).to receive(:deprecate)
     expect(false).to be_false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,8 @@ RSpec::configure do |config|
     $default_expectation_syntax = expectations.syntax
     expectations.syntax = :expect
   end
+
+  config.include SpecHelperMethods
 end
 
 shared_context "with #should enabled", :uses_should do

--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -1,0 +1,11 @@
+module SpecHelperMethods
+  def expect_deprecation_with_call_site(file, line)
+    expect(RSpec.configuration.reporter).to receive(:deprecation) do |options|
+      expect(options[:call_site]).to include([file, line].join(':'))
+    end
+  end
+
+  def allow_deprecation
+    allow(RSpec.configuration.reporter).to receive(:deprecation)
+  end
+end


### PR DESCRIPTION
This is actually what started all my `CallerFilter` changes tonight:
- I was in rspec-mocks, backporting Jon's recent PR to the 2-99-maintenance branch.
- We haven't updated it for the latest deprecation warnings (we still should), including `be_false`, and I noticed that the call site printed for that was in `rspec/matchers.rb` -- which is wrong.
- I traced it down to this line in rspec-core's `deprecate`:

``` ruby
call_site = caller.find { |line| line !~ %r{/lib/rspec/(core|mocks|expectations|matchers|rails)/} }
```

The problem is that this will grab a line like `rspec/core.rb` or `rspec/matchers.rb`.  I realized that it's fixed in the `CallerFilter` thing so figured it was time to make that consistent everywhere :).

Anyhow, this'll fail until rspec-core's PR is merged (I plan to merge it tomorrow), but I wanted to open this and add the spec before I forgot.
