### PR TITLE
Improve travis build.

### DIFF
--- a/script/test_all
+++ b/script/test_all
@@ -32,9 +32,9 @@ else
   done
 fi
 
-# Prepare RUBYOPT for scenarios that are shelling out to ruby,
-# and PATH for those that are using `rspec` or `rake`.
-RUBYOPT="-I${PWD}/bundle -rbundler/setup" \
-  PATH="${PWD}/bin:$PATH" \
-  bin/cucumber --strict
+# TODO: it would be nice to figure out how to run the cukes w/o the overhead of
+# bundler, but just running `bin/cucumber` can fail due to the fact that it
+# shells out (via aruba) and executes `rspec`--which can pick up the wrong
+# rspec version if we're not running with bundler.
+bundle exec cucumber --strict
 


### PR DESCRIPTION
- No need to bundle install twice.
- Skip one-by-one specs on JRuby.
- Run cucumber using our standalone bundle
  (rather than bundle exec).
- Bundler issue #2383 has been resolved,
  no need to work around it anymore.
