### PR TITLE
Ensure OperatorMatcher works with overriden method

### DIFF
--- a/lib/rspec/matchers/operator_matcher.rb
+++ b/lib/rspec/matchers/operator_matcher.rb
@@ -63,7 +63,7 @@ module RSpec
       private
 
       def uses_generic_implementation_of?(op)
-        @actual.method(op).owner == ::Kernel
+        Object.instance_method(:method).bind(@actual).call(op).owner == ::Kernel
       end
 
       def eval_match(actual, operator, expected)

--- a/spec/rspec/matchers/operator_matcher_spec.rb
+++ b/spec/rspec/matchers/operator_matcher_spec.rb
@@ -1,5 +1,11 @@
 require 'spec_helper'
 
+class MethodOverrideObject
+  def method
+    :foo
+  end
+end
+
 describe "operator matchers", :uses_should do
   describe "should ==" do
     it "delegates message to target" do
@@ -17,6 +23,13 @@ describe "operator matchers", :uses_should do
       subject = "apple"
       RSpec::Expectations.should_receive(:fail_with).with(%[expected: "orange"\n     got: "apple" (using ==)], "orange", "apple")
       subject.should == "orange"
+    end
+
+    it "works when #method is overriden" do
+      myobj = MethodOverrideObject.new
+      expect {
+        myobj.should == myobj
+      }.to_not raise_error
     end
   end
 


### PR DESCRIPTION
Operator matchers break if comparing an object that overrides the `method` method.  Consider this example:

``` ruby
require 'rspec/autorun'

class HttpModel
  def method
    :get
  end
end

describe HttpModel do
  it 'compares objects with overriden method' do
    myhttp = HttpModel.new
    myhttp.should == myhttp
  end
end
```

After upgrading to 2.14, this caused some of my tests to fail with the following error:

```
1) HttpModel compares objects with overriden method
   Failure/Error: Unable to find matching line from backtrace
   ArgumentError:
     wrong number of arguments (1 for 0)
   # override-method.rb:4:in `method'
   # override-method.rb:12:in `block (2 levels) in <main>'
```

This pull request fixes this by always using `Object#method` instead of `instance.method`.
