### PR TITLE
Fix operator matcher when operator implemented via method_missing

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,8 @@ Bug fixes
 * Fix operator matchers (`should` syntax) when `method` is redefined on target.
   (Brandon Turner)
 * Fix diffing of hashes with object based keys. (Jon Rowe)
+* Fix operator matchers (`should` syntax) when operator is defined via
+  `method_missing` (Jon Rowe)
 
 ### 2.14.2 / 2013-08-14
 [full changelog](http://github.com/rspec/rspec-expectations/compare/v2.14.1...v2.14.2)

--- a/lib/rspec/matchers/operator_matcher.rb
+++ b/lib/rspec/matchers/operator_matcher.rb
@@ -64,6 +64,8 @@ module RSpec
 
       def uses_generic_implementation_of?(op)
         Expectations.method_handle_for(@actual, op).owner == ::Kernel
+      rescue NameError
+        false
       end
 
       def eval_match(actual, operator, expected)

--- a/spec/rspec/matchers/operator_matcher_spec.rb
+++ b/spec/rspec/matchers/operator_matcher_spec.rb
@@ -6,6 +6,14 @@ class MethodOverrideObject
   end
 end
 
+class MethodMissingObject < Struct.new(:original)
+  undef ==
+
+  def method_missing(name, *args, &block)
+    original.__send__ name, *args, &block
+  end
+end
+
 describe "operator matchers", :uses_should do
   describe "should ==" do
     it "delegates message to target" do
@@ -30,6 +38,14 @@ describe "operator matchers", :uses_should do
       expect {
         myobj.should == myobj
       }.to_not raise_error
+    end
+
+    it "works when implemented via method_missing" do
+      obj = Object.new
+
+      myobj = MethodMissingObject.new(obj)
+      myobj.should == obj
+      myobj.should_not == Object.new
     end
   end
 


### PR DESCRIPTION
The bug fix for operator matchers using method introduced a subtle bug where by objects implementing the operator via `method_missing` would blow up with a `NameError`, this fixes that and correctly uses the existing fallback for such situtations.

This fixes the `rspec-rails` build.
