### PR TITLE
rescue Encoding::UndefinedConversionError

### DIFF
--- a/lib/rspec/expectations/differ.rb
+++ b/lib/rspec/expectations/differ.rb
@@ -127,6 +127,8 @@ module RSpec
       if String.method_defined?(:encoding)
         def matching_encoding(string, source)
           string.encode(source.encoding)
+        rescue Encoding::UndefinedConversionError
+          string          
         end
       else
         def matching_encoding(string, source)


### PR DESCRIPTION
matching_encoding method raises Encoding::UndefinedConversionError on my failing spec.
it should not try to encode with source.encoding

``` ruby
  it 'Encoding::UndefinedConversionError' do
    {a: "한글"}.should == {a: "한글2"}
  end
```
