### PR TITLE
Add rspec-collection_matchers to the "Also see" links section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,3 +183,4 @@ See [detailed information on the `should` syntax and its usage.](https://github.
 * [http://github.com/rspec/rspec](http://github.com/rspec/rspec)
 * [http://github.com/rspec/rspec-core](http://github.com/rspec/rspec-core)
 * [http://github.com/rspec/rspec-mocks](http://github.com/rspec/rspec-mocks)
+* [http://github.com/rspec/rspec-collection_matchers](https://github.com/rspec/rspec-collection_matchers)


### PR DESCRIPTION
Since rspec-collection_matchers was extracted from rspec-expectations and extends it, I think it makes sense to list
it in the "Also see" links at the bottom of the README
