### PR TITLE
Update cukes to new syntax

### DIFF
--- a/features/built_in_matchers/be.feature
+++ b/features/built_in_matchers/be.feature
@@ -3,28 +3,28 @@ Feature: "be" matchers
   There are several related "be" matchers:
 
     ```ruby
-    obj.should be_truthy  # passes if obj is truthy (not nil or false)
-    obj.should be_falsey # passes if obj is falsy (nil or false)
-    obj.should be_nil   # passes if obj is nil
-    obj.should be       # passes if obj is truthy (not nil or false)
+    expect(obj).to be_truthy  # passes if obj is truthy (not nil or false)
+    expect(obj).to be_falsey # passes if obj is falsy (nil or false)
+    expect(obj).to be_nil   # passes if obj is nil
+    expect(obj).to be       # passes if obj is truthy (not nil or false)
     ```
 
   Scenario: be_truthy matcher
     Given a file named "be_truthy_spec.rb" with:
       """ruby
       describe "be_truthy matcher" do
-        specify { true.should be_truthy }
-        specify { 7.should be_truthy }
-        specify { "foo".should be_truthy }
-        specify { nil.should_not be_truthy }
-        specify { false.should_not be_truthy }
+        specify { expect(true).to be_truthy }
+        specify { expect(7).to be_truthy }
+        specify { expect("foo").to be_truthy }
+        specify { expect(nil).not_to be_truthy }
+        specify { expect(false).not_to be_truthy }
 
         # deliberate failures
-        specify { true.should_not be_truthy }
-        specify { 7.should_not be_truthy }
-        specify { "foo".should_not be_truthy }
-        specify { nil.should be_truthy }
-        specify { false.should be_truthy }
+        specify { expect(true).not_to be_truthy }
+        specify { expect(7).not_to be_truthy }
+        specify { expect("foo").not_to be_truthy }
+        specify { expect(nil).to be_truthy }
+        specify { expect(false).to be_truthy }
       end
       """
     When I run `rspec be_truthy_spec.rb`
@@ -59,18 +59,18 @@ Feature: "be" matchers
     Given a file named "be_falsey_spec.rb" with:
       """ruby
       describe "be_falsey matcher" do
-        specify { nil.should be_falsey }
-        specify { false.should be_falsey }
-        specify { true.should_not be_falsey }
-        specify { 7.should_not be_falsey }
-        specify { "foo".should_not be_falsey }
+        specify { expect(nil).to be_falsey }
+        specify { expect(false).to be_falsey }
+        specify { expect(true).not_to be_falsey }
+        specify { expect(7).not_to be_falsey }
+        specify { expect("foo").not_to be_falsey }
 
         # deliberate failures
-        specify { nil.should_not be_falsey }
-        specify { false.should_not be_falsey }
-        specify { true.should be_falsey }
-        specify { 7.should be_falsey }
-        specify { "foo".should be_falsey }
+        specify { expect(nil).not_to be_falsey }
+        specify { expect(false).not_to be_falsey }
+        specify { expect(true).to be_falsey }
+        specify { expect(7).to be_falsey }
+        specify { expect("foo").to be_falsey }
       end
       """
     When I run `rspec be_falsey_spec.rb`
@@ -105,18 +105,18 @@ Feature: "be" matchers
     Given a file named "be_nil_spec.rb" with:
       """ruby
       describe "be_nil matcher" do
-        specify { nil.should be_nil }
-        specify { false.should_not be_nil }
-        specify { true.should_not be_nil }
-        specify { 7.should_not be_nil }
-        specify { "foo".should_not be_nil }
+        specify { expect(nil).to be_nil }
+        specify { expect(false).not_to be_nil }
+        specify { expect(true).not_to be_nil }
+        specify { expect(7).not_to be_nil }
+        specify { expect("foo").not_to be_nil }
 
         # deliberate failures
-        specify { nil.should_not be_nil }
-        specify { false.should be_nil }
-        specify { true.should be_nil }
-        specify { 7.should be_nil }
-        specify { "foo".should be_nil }
+        specify { expect(nil).not_to be_nil }
+        specify { expect(false).to be_nil }
+        specify { expect(true).to be_nil }
+        specify { expect(7).to be_nil }
+        specify { expect("foo").to be_nil }
       end
       """
     When I run `rspec be_nil_spec.rb`
@@ -151,18 +151,18 @@ Feature: "be" matchers
     Given a file named "be_spec.rb" with:
       """ruby
       describe "be_matcher" do
-        specify { true.should be }
-        specify { 7.should be }
-        specify { "foo".should be }
-        specify { nil.should_not be }
-        specify { false.should_not be }
+        specify { expect(true).to be }
+        specify { expect(7).to be }
+        specify { expect("foo").to be }
+        specify { expect(nil).not_to be }
+        specify { expect(false).not_to be }
 
         # deliberate failures
-        specify { true.should_not be }
-        specify { 7.should_not be }
-        specify { "foo".should_not be }
-        specify { nil.should be }
-        specify { false.should be }
+        specify { expect(true).not_to be }
+        specify { expect(7).not_to be }
+        specify { expect("foo").not_to be }
+        specify { expect(nil).to be }
+        specify { expect(false).to be }
       end
       """
     When I run `rspec be_spec.rb`

--- a/features/built_in_matchers/be_within.feature
+++ b/features/built_in_matchers/be_within.feature
@@ -14,7 +14,7 @@ Feature: be_within matcher
   is within a delta of your expected value:
 
     ```ruby
-    area_of_circle.should be_within(0.1).of(28.3)
+    expect(area_of_circle).to be_within(0.1).of(28.3)
     ```
 
   Note that the difference between the actual and expected values must be

--- a/features/built_in_matchers/cover.feature
+++ b/features/built_in_matchers/cover.feature
@@ -6,9 +6,9 @@ Feature: cover matcher
   as a Range):
 
     ```ruby
-    (1..10).should cover(5)
-    (1..10).should cover(4, 6)
-    (1..10).should_not cover(11)
+    expect(1..10).to cover(5)
+    expect(1..10).to cover(4, 6)
+    expect(1..10).not_to cover(11)
     ```
 
   Scenario: range usage

--- a/features/built_in_matchers/end_with.feature
+++ b/features/built_in_matchers/end_with.feature
@@ -4,9 +4,9 @@ Feature: end_with matcher
   expected characters or elements.
 
     ```ruby
-    "this string".should end_with "string"
-    "this string".should_not end_with "stringy"
-    [0, 1, 2].should end_with 1, 2
+    expect("this string").to end_with "string"
+    expect("this string").not_to end_with "stringy"
+    expect([0, 1, 2]).to end_with 1, 2
     ```
 
   Scenario: string usage

--- a/features/built_in_matchers/equality.feature
+++ b/features/built_in_matchers/equality.feature
@@ -13,16 +13,16 @@ Feature: equality matchers
   rspec-expectations ships with matchers that align with each of these methods:
 
     ```ruby
-    a.should equal(b) # passes if a.equal?(b)
-    a.should eql(b)   # passes if a.eql?(b)
-    a.should == b     # passes if a == b
+    expect(a).to equal(b) # passes if a.equal?(b)
+    expect(a).to eql(b)   # passes if a.eql?(b)
+    expect(a).to be == b     # passes if a == b
     ```
 
   It also ships with two matchers that have more of a DSL feel to them:
 
     ```ruby
-    a.should be(b) # passes if a.equal?(b)
-    a.should eq(b) # passes if a == b
+    expect(a).to be(b) # passes if a.equal?(b)
+    expect(a).to eq(b) # passes if a == b
     ```
 
   These are a useful pair if you wish to avoid the warning that Ruby emits on
@@ -33,17 +33,17 @@ Feature: equality matchers
       """ruby
       describe "a string" do
         it "is equal to another string of the same value" do
-          "this string".should eq("this string")
+          expect("this string").to eq("this string")
         end
 
         it "is not equal to another string of a different value" do
-          "this string".should_not eq("a different string")
+          expect("this string").not_to eq("a different string")
         end
       end
 
       describe "an integer" do
         it "is equal to a float of the same value" do
-          5.should eq(5.0)
+          expect(5).to eq(5.0)
         end
       end
       """
@@ -55,17 +55,17 @@ Feature: equality matchers
       """ruby
       describe "a string" do
         it "is equal to another string of the same value" do
-          "this string".should == "this string"
+          expect("this string").to be == "this string"
         end
 
         it "is not equal to another string of a different value" do
-          "this string".should_not == "a different string"
+          expect("this string").not_to be == "a different string"
         end
       end
 
       describe "an integer" do
         it "is equal to a float of the same value" do
-          5.should == 5.0
+          expect(5).to be == 5.0
         end
       end
       """
@@ -77,15 +77,15 @@ Feature: equality matchers
       """ruby
       describe "an integer" do
         it "is equal to another integer of the same value" do
-          5.should eql(5)
+          expect(5).to eql(5)
         end
 
         it "is not equal to another integer of a different value" do
-          5.should_not eql(6)
+          expect(5).not_to eql(6)
         end
 
         it "is not equal to a float of the same value" do
-          5.should_not eql(5.0)
+          expect(5).not_to eql(5.0)
         end
 
       end
@@ -99,15 +99,15 @@ Feature: equality matchers
       describe "a string" do
         it "is equal to itself" do
           string = "this string"
-          string.should equal(string)
+          expect(string).to equal(string)
         end
 
         it "is not equal to another string of the same value" do
-          "this string".should_not equal("this string")
+          expect("this string").not_to equal("this string")
         end
 
         it "is not equal to another string of a different value" do
-          "this string".should_not equal("a different string")
+          expect("this string").not_to equal("a different string")
         end
 
       end
@@ -121,15 +121,15 @@ Feature: equality matchers
       describe "a string" do
         it "is equal to itself" do
           string = "this string"
-          string.should be(string)
+          expect(string).to be(string)
         end
 
         it "is not equal to another string of the same value" do
-          "this string".should_not be("this string")
+          expect("this string").not_to be("this string")
         end
 
         it "is not equal to another string of a different value" do
-          "this string".should_not be("a different string")
+          expect("this string").not_to be("a different string")
         end
 
       end

--- a/features/built_in_matchers/exist.feature
+++ b/features/built_in_matchers/exist.feature
@@ -4,7 +4,7 @@ Feature: exist matcher
   (as indicated by #exist? or #exists?):
 
     ```ruby
-    obj.should exist # passes if obj.exist? or obj.exists?
+    expect(obj).to exist # passes if obj.exist? or obj.exists?
     ```
 
   Scenario: basic usage
@@ -28,14 +28,14 @@ Feature: exist matcher
 
       describe "Earth" do
         let(:earth) { Planet.new("Earth") }
-        specify { earth.should exist }
-        specify { earth.should_not exist } # deliberate failure
+        specify { expect(earth).to exist }
+        specify { expect(earth).not_to exist } # deliberate failure
       end
 
       describe "Tatooine" do
         let(:tatooine) { Planet.new("Tatooine") }
-        it { tatooine.should exist } # deliberate failure
-        it { tatooine.should_not exist }
+        it { expect(tatooine).to exist } # deliberate failure
+        it { expect(tatooine).not_to exist }
       end
       """
     When I run `rspec exist_matcher_spec.rb`

--- a/features/built_in_matchers/expect_error.feature
+++ b/features/built_in_matchers/expect_error.feature
@@ -110,7 +110,7 @@ Feature: raise_error matcher
       describe "#foo" do
         it "raises NameError" do
           expect { Object.new.foo }.to raise_error { |error|
-            error.should be_a(NameError)
+            expect(error).to be_a(NameError)
           }
         end
       end

--- a/features/built_in_matchers/include.feature
+++ b/features/built_in_matchers/include.feature
@@ -5,26 +5,26 @@ Feature: include matcher
   as a string or array):
 
     ```ruby
-    "a string".should include("a")
-    "a string".should include("str")
-    "a string".should include("str", "g")
-    "a string".should_not include("foo")
+    expect("a string").to include("a")
+    expect("a string").to include("str")
+    expect("a string").to include("str", "g")
+    expect("a string").not_to include("foo")
 
-    [1, 2].should include(1)
-    [1, 2].should include(1, 2)
-    [1, 2].should_not include(17)
+    expect([1, 2]).to include(1)
+    expect([1, 2]).to include(1, 2)
+    expect([1, 2]).not_to include(17)
     ```
 
   The matcher also provides flexible handling for hashes:
 
     ```ruby
-    {:a => 1, :b => 2}.should include(:a)
-    {:a => 1, :b => 2}.should include(:a, :b)
-    {:a => 1, :b => 2}.should include(:a => 1)
-    {:a => 1, :b => 2}.should include(:b => 2, :a => 1)
-    {:a => 1, :b => 2}.should_not include(:c)
-    {:a => 1, :b => 2}.should_not include(:a => 2)
-    {:a => 1, :b => 2}.should_not include(:c => 3)
+    expect({:a => 1, :b => 2}).to include(:a)
+    expect({:a => 1, :b => 2}).to include(:a, :b)
+    expect({:a => 1, :b => 2}).to include(:a => 1)
+    expect({:a => 1, :b => 2}).to include(:b => 2, :a => 1)
+    expect({:a => 1, :b => 2}).not_to include(:c)
+    expect({:a => 1, :b => 2}).not_to include(:a => 2)
+    expect({:a => 1, :b => 2}).not_to include(:c => 3)
     ```
 
   Scenario: array usage

--- a/features/built_in_matchers/match.feature
+++ b/features/built_in_matchers/match.feature
@@ -5,10 +5,10 @@ Feature: match matcher
   method.
 
     ```ruby
-    "a string".should match(/str/) # passes
-    "a string".should match(/foo/) # fails
-    /foo/.should match("food")     # passes
-    /foo/.should match("drinks")   # fails
+    expect("a string").to match(/str/) # passes
+    expect("a string").to match(/foo/) # fails
+    expect(/foo/).to match("food")     # passes
+    expect(/foo/).to match("drinks")   # fails
     ```
 
   This is equivalent to using the =~ matcher (see the operator matchers

--- a/features/built_in_matchers/operators.feature
+++ b/features/built_in_matchers/operators.feature
@@ -5,35 +5,35 @@ Feature: operator matchers
   pass:
 
     ```ruby
-    7.should == 7
-    [1, 2, 3].should == [1, 2, 3]
-    "this is a string".should =~ /^this/
-    "this is a string".should_not =~ /^that/
-    String.should === "this is a string"
+    expect(7).to == 7
+    expect([1, 2, 3]).to == [1, 2, 3]
+    expect("this is a string").to =~ /^this/
+    expect("this is a string").not_to =~ /^that/
+    expect(String).to === "this is a string"
     ```
 
   You can also use comparison operators combined with the "be" matcher like
   this:
 
     ```ruby
-    37.should be < 100
-    37.should be <= 38
-    37.should be >= 2
-    37.should be > 7
+    expect(37).to be < 100
+    expect(37).to be <= 38
+    expect(37).to be >= 2
+    expect(37).to be > 7
     ```
 
   RSpec also provides a `=~` matcher for arrays that disregards differences in
   the ordering between the actual and expected array.  For example:
 
     ```ruby
-    [1, 2, 3].should =~ [2, 3, 1] # pass
-    [:a, :c, :b].should =~ [:a, :c] # fail
+    expect([1, 2, 3]).to =~ [2, 3, 1] # pass
+    expect([:a, :c, :b]).to =~ [:a, :c] # fail
     ```
   However, we recommend the use of `match_array` instead:
 
     ```ruby
-    [1, 2, 3].should match_array [2, 3, 1] # pass
-    [:a, :c, :b].should match_array [:a, :c] # fail
+    expect([1, 2, 3]).to match_array [2, 3, 1] # pass
+    expect([:a, :c, :b]).to match_array [:a, :c] # fail
     ```
   Scenario: numeric operator matchers
     Given a file named "numeric_operator_matchers_spec.rb" with:
@@ -111,7 +111,7 @@ Feature: operator matchers
         it { should_not =~ /apple/ }
 
         it "reports that it is a string using ===" do
-          String.should === subject
+          expect(String).to be === subject
         end
 
         # deliberate failures
@@ -126,7 +126,7 @@ Feature: operator matchers
         it { should_not =~ /berry/ }
 
         it "fails a spec asserting that it is a symbol" do
-          Symbol.should === subject
+          expect(Symbol).to be === subject
         end
       end
       """
@@ -182,9 +182,9 @@ Feature: operator matchers
       """
       And the output should contain:
       """
-           Failure/Error: Symbol.should === subject
-             expected: "Strawberry"
-                  got: Symbol (using ===)
+           Failure/Error: expect(Symbol).to be === subject
+             expected: === "Strawberry"
+                  got:     Symbol
       """
 
   Scenario: array operator matchers

--- a/features/built_in_matchers/predicates.feature
+++ b/features/built_in_matchers/predicates.feature
@@ -14,7 +14,7 @@ Feature: predicate matchers
   You could use a basic equality matcher to set expectations on these:
 
     ```ruby
-    7.zero?.should == true # fails with "expected true, got false (using ==)"
+    expect(7.zero?).to == true # fails with "expected true, got false (using ==)"
     ```
 
   ...but RSpec provides dynamic predicate matchers that are more readable and
@@ -24,9 +24,9 @@ Feature: predicate matchers
   prefix the method with `be_` and remove the question mark.  Examples:
 
     ```ruby
-    7.should_not be_zero       # calls 7.zero?
-    [].should be_empty         # calls [].empty?
-    x.should be_multiple_of(3) # calls x.multiple_of?(3)
+    expect(7).not_to be_zero       # calls 7.zero?
+    expect([]).to be_empty         # calls [].empty?
+    expect(x).to be_multiple_of(3) # calls x.multiple_of?(3)
     ```
 
   Alternately, for a predicate method that begins with `has_` like
@@ -34,8 +34,8 @@ Feature: predicate matchers
   makes no sense.
 
     ```ruby
-    hash.should have_key(:foo)       # calls hash.has_key?(:foo)
-    array.should_not have_odd_values # calls array.has_odd_values?
+    expect(hash).to have_key(:foo)       # calls hash.has_key?(:foo)
+    expect(array).not_to have_odd_values # calls array.has_odd_values?
     ```
 
   In either case, RSpec provides nice, clear error messages, such as:

--- a/features/built_in_matchers/respond_to.feature
+++ b/features/built_in_matchers/respond_to.feature
@@ -4,22 +4,22 @@ Feature: respond_to matcher
   its most basic form:
 
     ```ruby
-    obj.should respond_to(:foo) # pass if obj.respond_to?(:foo)
+    expect(obj).to respond_to(:foo) # pass if obj.respond_to?(:foo)
     ```
 
   You can specify that an object responds to multiple messages in a single
   statement with multiple arguments passed to the matcher:
 
     ```ruby
-    obj.should respond_to(:foo, :bar) # passes if obj.respond_to?(:foo) && obj.respond_to?(:bar)
+    expect(obj).to respond_to(:foo, :bar) # passes if obj.respond_to?(:foo) && obj.respond_to?(:bar)
     ```
 
   If the number of arguments accepted by the method is important to you,
   you can specify that as well:
 
     ```ruby
-    obj.should respond_to(:foo).with(1).argument
-    obj.should respond_to(:bar).with(2).arguments
+    expect(obj).to respond_to(:foo).with(1).argument
+    expect(obj).to respond_to(:bar).with(2).arguments
     ```
 
   Note that this matcher relies entirely upon #respond_to?.  If an object

--- a/features/built_in_matchers/satisfy.feature
+++ b/features/built_in_matchers/satisfy.feature
@@ -4,8 +4,8 @@ Feature: satisfy matcher
   you want to specify.  It passes if the block you provide returns true:
 
     ```ruby
-    10.should satisfy { |v| v % 5 == 0 }
-    7.should_not satisfy { |v| v % 5 == 0 }
+    expect(10).to satisfy { |v| v % 5 == 0 }
+    expect(7).not_to satisfy { |v| v % 5 == 0 }
     ```
 
   This flexibility comes at a cost, however: the failure message

--- a/features/built_in_matchers/start_with.feature
+++ b/features/built_in_matchers/start_with.feature
@@ -4,9 +4,9 @@ Feature: start_with matcher
   the expected characters or elements.
 
     ```ruby
-    "this string".should start_with("this")
-    "this string".should_not start_with("that")
-    [0,1,2].should start_with(0, 1)
+    expect("this string").to start_with("this")
+    expect("this string").not_to start_with("that")
+    expect([0,1,2]).to start_with(0, 1)
     ```
 
   Scenario: with a string

--- a/features/built_in_matchers/types.feature
+++ b/features/built_in_matchers/types.feature
@@ -2,19 +2,19 @@ Feature: specify types of objects
 
   rspec-expectations includes two matchers to specify types of objects:
 
-    * `obj.should be_kind_of(type)`: calls `obj.kind_of?(type)`, which returns
+    * `expect(obj).to be_kind_of(type)`: calls `obj.kind_of?(type)`, which returns
       true if type is in obj's class hierarchy or is a module and is
       included in a class in obj's class hierarchy.
-    * `obj.should be_instance_of(type)`: calls `obj.instance_of?(type)`, which
+    * `expect(obj).to be_instance_of(type)`: calls `obj.instance_of?(type)`, which
       returns true if and only if type if obj's class.
 
   Both of these matchers have aliases:
 
     ```ruby
-    obj.should be_a_kind_of(type)      # same as obj.should be_kind_of(type)
-    obj.should be_a(type)              # same as obj.should be_kind_of(type)
-    obj.should be_an(type)             # same as obj.should be_kind_of(type)
-    obj.should be_an_instance_of(type) # same as obj.should be_instance_of(type)
+    expect(obj).to be_a_kind_of(type)      # same as expect(obj).to be_kind_of(type)
+    expect(obj).to be_a(type)              # same as expect(obj).to be_kind_of(type)
+    expect(obj).to be_an(type)             # same as expect(obj).to be_kind_of(type)
+    expect(obj).to be_an_instance_of(type) # same as expect(obj).to be_instance_of(type)
     ```
 
   Scenario: be_(a_)kind_of matcher

--- a/features/custom_matchers/access_running_example.feature
+++ b/features/custom_matchers/access_running_example.feature
@@ -24,7 +24,7 @@ Feature: access running example
         end
 
         it "does something" do
-          "foo".should bar
+          expect("foo").to bar
         end
       end
       """
@@ -42,7 +42,7 @@ Feature: access running example
 
       describe "something" do
         it "does something" do
-          "foo".should bar
+          expect("foo").to bar
         end
       end
       """

--- a/features/custom_matchers/define_matcher.feature
+++ b/features/custom_matchers/define_matcher.feature
@@ -183,7 +183,7 @@ Feature: define matcher
 
       describe "these two arrays" do
         specify "should be similar" do
-          [1,2,3].should have_same_elements_as([2,3,1])
+          expect([1,2,3]).to have_same_elements_as([2,3,1])
         end
       end
       """
@@ -207,14 +207,14 @@ Feature: define matcher
       describe "group with MyHelpers" do
         include MyHelpers
         it "has access to the defined matcher" do
-          5.should be_just_like(5)
+          expect(5).to be_just_like(5)
         end
       end
 
       describe "group without MyHelpers" do
         it "does not have access to the defined matcher" do
           expect do
-            5.should be_just_like(5)
+            expect(5).to be_just_like(5)
           end.to raise_exception
         end
       end
@@ -234,12 +234,12 @@ Feature: define matcher
         end
 
         it "has access to the defined matcher" do
-          5.should be_just_like(5)
+          expect(5).to be_just_like(5)
         end
 
         describe "nested group" do
           it "has access to the defined matcher" do
-            5.should be_just_like(5)
+            expect(5).to be_just_like(5)
           end
         end
 
@@ -248,7 +248,7 @@ Feature: define matcher
       describe "group without matcher" do
         it "does not have access to the defined matcher" do
           expect do
-            5.should be_just_like(5)
+            expect(5).to be_just_like(5)
           end.to raise_exception
         end
       end

--- a/features/custom_matchers/define_matcher_outside_rspec.feature
+++ b/features/custom_matchers/define_matcher_outside_rspec.feature
@@ -23,11 +23,11 @@ Feature: define matcher outside rspec
       class TestMultiples < Test::Unit::TestCase
 
         def test_9_should_be_a_multiple_of_3
-          9.should be_a_multiple_of(3)
+          expect(9).to be_a_multiple_of(3)
         end
 
         def test_9_should_be_a_multiple_of_4
-          9.should be_a_multiple_of(4)
+          expect(9).to be_a_multiple_of(4)
         end
 
       end

--- a/features/diffing.feature
+++ b/features/diffing.feature
@@ -17,7 +17,7 @@ Feature: diffing
         actual
           string
       ACTUAL
-          actual.should eq(expected)
+          expect(actual).to eq(expected)
         end
       end
       """
@@ -65,7 +65,7 @@ Feature: diffing
         it "is like another string" do
           expected = "this string"
           actual   = "that string"
-          actual.should eq(expected)
+          expect(actual).to eq(expected)
         end
       end
       """
@@ -77,7 +77,7 @@ Feature: diffing
       """ruby
       describe "a number" do
         it "is like another number" do
-          1.should eq(2)
+          expect(1).to eq(2)
         end
       end
       """

--- a/features/implicit_docstrings.feature
+++ b/features/implicit_docstrings.feature
@@ -9,11 +9,11 @@ Feature: implicit docstrings
     """ruby
     describe "Examples with no docstrings generate their own:" do
 
-      specify { 3.should be < 5 }
+      specify { expect(3).to be < 5 }
 
-      specify { [1,2,3].should include(2) }
+      specify { expect([1,2,3]).to include(2) }
 
-      specify { [1,2,3].should respond_to(:size) }
+      specify { expect([1,2,3]).to respond_to(:size) }
 
     end
     """
@@ -29,17 +29,17 @@ Feature: implicit docstrings
     """ruby
     describe "Failing examples with no descriptions" do
 
-      # description is auto-generated as "should equal(5)" based on the last #should
+      # description is auto-generated as "to equal(5)" based on the last #expect
       it do
-        3.should equal(2)
-        5.should equal(5)
+        expect(3).to equal(2)
+        expect(5).to equal(5)
       end
 
-      it { 3.should be > 5 }
+      it { expect(3).to be > 5 }
 
-      it { [1,2,3].should include(4) }
+      it { expect([1,2,3]).to include(4) }
 
-      it { [1,2,3].should_not respond_to(:size) }
+      it { expect([1,2,3]).not_to respond_to(:size) }
 
     end
     """


### PR DESCRIPTION
Part of https://github.com/rspec/rspec-core/issues/1055

Pretty much everything in the "built_in_matchers" directory uses `it { should }` style assertions, which have no corresponding `expect` equivalent, so I just left those alone.

I opened #333 because I couldn't change that spec, seems the new `expect().to match(regexp)` equivalent doesn't do the same diffing upon failure.

In https://github.com/rspec/rspec-expectations/blob/master/features/built_in_matchers/equality.feature there is some discussion about how `should be(b)` and `should eq(b)` are good substitutes if you want to avoid the warning for `should ==`, I left that in but changed all the examples to use `expect`. Not sure if that still makes any sense.

I also changed the examples in the equality file that were talking specifically about `.should ==` to use the awkward `.to be ==`. Not sure if we want to keep that around, since `.to be` ends up being the same thing.
