### PR TITLE
Improve constant assignment to handle numbers better.

### DIFF
--- a/lib/rspec/matchers/matcher.rb
+++ b/lib/rspec/matchers/matcher.rb
@@ -299,7 +299,7 @@ module RSpec
             define_method(:name) { name }
             @declarations = declarations
           end.tap do |klass|
-            const_name = ('_' + name.to_s).gsub(/_+([[:alpha:]])/) { $1.upcase }
+            const_name = ('_' + name.to_s).gsub(/_+(\w)/) { $1.upcase }
 
             const_name.gsub!(/\A_+/, '')             # Remove any leading underscores
             const_name.gsub!(/\W/, '')               # JRuby, RBX and others don't like non-ascii in const names

--- a/spec/rspec/matchers/matcher_spec.rb
+++ b/spec/rspec/matchers/matcher_spec.rb
@@ -60,7 +60,7 @@ module RSpec::Matchers::DSL
 
       it 'assigns a constant even when there are extra leading underscores' do
         matcher = new_matcher(:__foo__bar__) { }
-        expect(matcher).to have_class_const(:FooBar__)
+        expect(matcher).to have_class_const(:FooBar_)
       end
 
       it 'differentiates redefinitions by appending a number' do
@@ -71,6 +71,11 @@ module RSpec::Matchers::DSL
         expect(m1).to have_class_const(:FooRedef)
         expect(m2).to have_class_const(:FooRedef2)
         expect(m3).to have_class_const(:FooRedef3)
+      end
+
+      it 'handles numbers in the name' do
+        m1 = new_matcher(:has_4_things) { }
+        expect(m1).to have_class_const(:Has4Things)
       end
 
       it 'supports non-ascii characters', :if => (RUBY_VERSION.to_f > 1.8) do


### PR DESCRIPTION
Before, a matcher like `has_4_things` would get
assigned a constant like `Has_4Things`.  Now it gets
`Has4Things`.
