### PR TITLE
Fix wrong auto-generated descriptions with falsey expected value

### DIFF
--- a/lib/rspec/matchers/built_in/base_matcher.rb
+++ b/lib/rspec/matchers/built_in/base_matcher.rb
@@ -14,10 +14,12 @@ module RSpec
       class BaseMatcher
         include RSpec::Matchers::Pretty
 
+        UNDEFINED = Object.new.freeze
+
         attr_reader :actual, :expected, :rescued_exception
 
-        def initialize(expected = nil)
-          @expected = expected
+        def initialize(expected = UNDEFINED)
+          @expected = expected unless UNDEFINED.equal?(expected)
         end
 
         def matches?(actual)
@@ -36,17 +38,17 @@ module RSpec
         end
 
         def failure_message_for_should
-          assert_ivars :@actual, :@expected
+          assert_ivars :@actual
           "expected #{@actual.inspect} to #{name_to_sentence}#{expected_to_sentence}"
         end
 
         def failure_message_for_should_not
-          assert_ivars :@actual, :@expected
+          assert_ivars :@actual
           "expected #{@actual.inspect} not to #{name_to_sentence}#{expected_to_sentence}"
         end
 
         def description
-          expected ? "#{name_to_sentence} #{@expected.inspect}" : name_to_sentence
+          defined?(@expected) ? "#{name_to_sentence} #{@expected.inspect}" : name_to_sentence
         end
 
         def diffable?

--- a/spec/rspec/matchers/base_matcher_spec.rb
+++ b/spec/rspec/matchers/base_matcher_spec.rb
@@ -39,6 +39,27 @@ module RSpec::Matchers::BuiltIn
 
     end
 
+    describe "#failure_message_for_should" do
+      context "when the parameter to .new is omitted" do
+        it "describes what was expected" do
+          matcher_class = Class.new(BaseMatcher) do
+            def name=(name)
+              @name = name
+            end
+
+            def match(expected, actual)
+              false
+            end
+          end
+
+          matcher = matcher_class.new
+          matcher.name = "be something"
+          matcher.matches?("foo")
+          expect(matcher.failure_message_for_should).to eq('expected "foo" to be something')
+        end
+      end
+    end
+
     describe "#==" do
       it "responds the same way as matches?" do
         matcher = Class.new(BaseMatcher) do

--- a/spec/rspec/matchers/equal_spec.rb
+++ b/spec/rspec/matchers/equal_spec.rb
@@ -24,6 +24,32 @@ module RSpec
         expect(matcher.description).to eq "equal 1"
       end
 
+      context "when the expected object is falsey in conditinal semantics" do
+        it "describes itself with the expected object" do
+          matcher = equal(nil)
+          matcher.matches?(nil)
+          expect(matcher.description).to eq "equal nil"
+        end
+      end
+
+      context "when the expected object's #equal? always returns true" do
+        let(:strange_string) do
+          string = "foo"
+
+          def string.equal?(other)
+            true
+          end
+
+          string
+        end
+
+        it "describes itself with the expected object" do
+          matcher = equal(strange_string)
+          matcher.matches?(strange_string)
+          expect(matcher.description).to eq 'equal "foo"'
+        end
+      end
+
       it "suggests the `eq` matcher on failure" do
         expected, actual = "1", "1"
         expect {


### PR DESCRIPTION
Currently this spec example:

``` ruby
describe 'wrong auto-generated descriptions' do
  subject { nil }
  it { should be nil }
end
```

generates the following description:

``` bash
$ rspec --format documentation test_spec.rb 

wrong auto-generated descriptions
  should equal
#              ^^^ Missing "nil"!
```

This is because `BaseMatcher#description` checks whether expected value is set or not by checking if the value is truthy in conditional semantics. However this does not work if the expected value is `false` or `nil`.

This change fixes the issue by checking whether ivar `@expected` is defined or not and skip definition of `@expected` if the parameter to `BaseMatcher.new` is omitted.

I've confirmed `2-99-maintenance` and `2-14-maintenance` branches also have this issue.
