### PR TITLE
Fix JRuby handling of EncodedStrings

### DIFF
--- a/lib/rspec/expectations/encoded_string.rb
+++ b/lib/rspec/expectations/encoded_string.rb
@@ -22,7 +22,7 @@ module RSpec
       if String.method_defined?(:encoding)
         def matching_encoding(string)
           string.encode(@encoding)
-        rescue Encoding::UndefinedConversionError
+        rescue Encoding::UndefinedConversionError, Encoding::InvalidByteSequenceError
           normalize_missing(string.encode(@encoding, :invalid => :replace, :undef => :replace))
         rescue Encoding::ConverterNotFoundError
           normalize_missing(string.force_encoding(@encoding).encode(:invalid => :replace))


### PR DESCRIPTION
JRuby throws Encoding::InvalidByteSequenceError instead of Encoding::UndefinedConversionError for our ASCII-8BIT strings
