### PR TITLE
Warn about should syntax when it is enabled on a non-default syntax host

### DIFF
--- a/lib/rspec/expectations/syntax.rb
+++ b/lib/rspec/expectations/syntax.rb
@@ -61,7 +61,7 @@ module RSpec
       # @api private
       # Enables the `should` syntax.
       def enable_should(syntax_host = default_should_host)
-        @warn_about_should = false
+        @warn_about_should = false if syntax_host == default_should_host
         return if should_enabled?(syntax_host)
 
         syntax_host.module_exec do

--- a/spec/rspec/expectations/syntax_spec.rb
+++ b/spec/rspec/expectations/syntax_spec.rb
@@ -73,6 +73,18 @@ module RSpec
         end
       end
 
+      describe "enabling the should syntax on something other than the default syntax host" do
+        include_context "with the default expectation syntax"
+
+        it "continues to warn about the should syntax" do
+          my_host = Class.new
+          expect(RSpec).to receive(:deprecate)
+          Syntax.enable_should(my_host)
+
+          3.should eq 3
+        end
+      end
+
       describe "expression generation" do
         let(:target) { "foo" }
         let(:expectation) { "eq('bar')" }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,20 @@ shared_context "with #should enabled", :uses_should do
   end
 end
 
+shared_context "with the default expectation syntax" do
+  orig_syntax = nil
+
+  before(:all) do
+    orig_syntax = RSpec::Matchers.configuration.syntax
+    RSpec::Matchers.configuration.reset_syntaxes_to_default
+  end
+
+  after(:all) do
+    RSpec::Matchers.configuration.syntax = orig_syntax
+  end
+
+end
+
 
 shared_context "with #should exclusively enabled", :uses_only_should do
   orig_syntax = nil


### PR DESCRIPTION
Attempted fix for https://github.com/rspec/rspec-rails/issues/851
