### PR TITLE
Fixing Differ to use RSpec::Expectations module namespace

### DIFF
--- a/lib/rspec/expectations/differ.rb
+++ b/lib/rspec/expectations/differ.rb
@@ -1,40 +1,44 @@
-class Differ
-  def initialize(actual, expected)
-    @actual = actual
-    @expected = expected
-  end
+module RSpec
+  module Expectations
+    class Differ
+      def initialize(actual, expected)
+        @actual = actual
+        @expected = expected
+      end
 
-  def hunks
-    @file_length_difference = 0
-    @hunks ||= diffs.map do |piece|
-      build_hunk(piece)
+      def hunks
+        @file_length_difference = 0
+        @hunks ||= diffs.map do |piece|
+          build_hunk(piece)
+        end
+      end
+
+      private
+
+      def diffs
+        Diff::LCS.diff(expected_lines, actual_lines)
+      end
+
+      def expected_lines
+        @expected.split("\n").map! { |e| e.chomp }
+      end
+
+      def actual_lines
+        @actual.split("\n").map! { |e| e.chomp }
+      end
+
+      def build_hunk(piece)
+        Diff::LCS::Hunk.new(
+          expected_lines, actual_lines, piece, context_lines, @file_length_difference
+        ).tap do |h|
+          @file_length_difference = h.file_length_difference
+        end
+      end
+
+      def context_lines
+        3
+      end
+
     end
   end
-
-private
-
-  def diffs
-    Diff::LCS.diff(expected_lines, actual_lines)
-  end
-
-  def expected_lines
-    @expected.split("\n").map! { |e| e.chomp }
-  end
-
-  def actual_lines
-    @actual.split("\n").map! { |e| e.chomp }
-  end
-
-  def build_hunk(piece)
-    Diff::LCS::Hunk.new(
-      expected_lines, actual_lines, piece, context_lines, @file_length_difference
-    ).tap do |h|
-      @file_length_difference = h.file_length_difference
-    end
-  end
-
-  def context_lines
-    3
-  end
-
 end


### PR DESCRIPTION
Hi. Seems that Differ class need to be wrapped with modules declaration. I got troubles when using standalone differ gem.

Regards
