### PR TITLE
Deprecate uses of `expect { }.not_to change` that RSpec 3 won't support.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,22 @@
+### 2.99.0.beta2 Development
+[full changelog](http://github.com/rspec/rspec-expectations/compare/v2.99.0.beta1...v2.99.0.beta2)
+
+Deprecations:
+
+* Deprecate chaining `by`, `by_at_least`, `by_at_most` or `to` off of
+  `expect { }.not_to change { }`. The docs have always said these are
+  not supported for the negative form but now they explicitly raise
+  errors in RSpec 3. (Myron Marston)
+* Change the semantics of `expect { }.not_to change { x }.from(y)`.
+  In RSpec 2.x, this expectation would only fail if `x` started with
+  the value of `y` and changed. If it started with a different value
+  and changed, it would pass. In RSpec 3, it will pass only if the
+  value starts at `y` and it does not change. (Myron Marston)
+
 ### 2.99.0.beta1 / 2013-11-07
 [full changelog](http://github.com/rspec/rspec-expectations/compare/v2.14.4...v2.99.0.beta1)
 
-Deprecations
+Deprecations:
 
 * Deprecate `have`, `have_at_least` and `have_at_most`. You can continue using those
 	matchers through https://github.com/rspec/rspec-collection_matchers, or

--- a/spec/rspec/matchers/change_spec.rb
+++ b/spec/rspec/matchers/change_spec.rb
@@ -247,6 +247,80 @@ describe "expect { ... }.not_to change { block }" do
   end
 end
 
+describe "expect { ... }.not_to change { }.from" do
+  context 'when the value starts at the from value' do
+    it 'passes when the value does not change' do
+      k = 5
+      expect { }.not_to change { k }.from(5)
+    end
+
+    it 'fails when the value does change' do
+      expect {
+        k = 5
+        expect { k += 1 }.not_to change { k }.from(5)
+      }.to fail_with(/but did change from 5 to 6/)
+    end
+
+    it 'does not issue a deprecation warning' do
+      expect(RSpec.configuration.reporter).not_to receive(:deprecation)
+      k = 5
+      expect { }.not_to change { k }.from(5)
+    end
+  end
+
+  context 'when the value starts at a different value' do
+    before { allow_deprecation }
+
+    it 'passes when the value does not change' do
+      k = 6
+      expect { }.not_to change { k }.from(5)
+    end
+
+    it 'passes when the value does change' do
+      k = 6
+      expect { k += 1 }.not_to change { k }.from(5)
+    end
+
+    it 'issues a deprecation warning' do
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 2, /#{Regexp.escape("expect { }.not_to change { }.from()")}/)
+      k = 6
+      expect { }.not_to change { k }.from(5)
+    end
+  end
+end
+
+describe "expect { ... }.not_to change { }.to" do
+  it 'issues a deprecation warning' do
+    expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /#{Regexp.escape("expect { }.not_to change { }.to()")}/)
+    expect {
+    }.not_to change { }.to(3)
+  end
+end
+
+describe "expect { ... }.not_to change { }.by" do
+  it 'issues a deprecation warning' do
+    expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /#{Regexp.escape("expect { }.not_to change { }.by()")}/)
+    expect {
+    }.not_to change { }.by(3)
+  end
+end
+
+describe "expect { ... }.not_to change { }.by_at_least" do
+  it 'issues a deprecation warning' do
+    expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /#{Regexp.escape("expect { }.not_to change { }.by_at_least()")}/)
+    expect {
+    }.not_to change { }.by_at_least(3)
+  end
+end
+
+describe "expect { ... }.not_to change { }.by_at_most" do
+  it 'issues a deprecation warning' do
+    expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /#{Regexp.escape("expect { }.not_to change { }.by_at_most()")}/)
+    expect {
+    }.not_to change { }.by_at_most(3)
+  end
+end
+
 describe "expect { ... }.to change(actual, message).by(expected)" do
   before(:each) do
     @instance = SomethingExpected.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,10 +5,12 @@ module DeprecationHelpers
     allow(RSpec.configuration.reporter).to receive(:deprecation)
   end
 
-  def expect_deprecation_with_call_site(file, line)
+  def expect_deprecation_with_call_site(file, line, snippet = //)
     expect(RSpec.configuration.reporter).to receive(:deprecation) do |options|
       matcher = include([file, line].join(':'))
-      unless matcher.matches?(options[:call_site])
+      call_site = options[:call_site] || options[:message]
+
+      unless matcher.matches?(call_site)
         # RSpec::Expectations::ExpectationNotMetError is rescued in the `match` block
         # of a custom matcher and returned as `false` from `matches?`. This would
         # prevent an expectation failure here from surfacing in the test suite if
@@ -16,6 +18,9 @@ module DeprecationHelpers
         # a different error class instead.
         raise matcher.failure_message_for_should
       end
+
+      deprecated = options[:deprecated] || options[:message]
+      expect(deprecated).to match(snippet)
     end
   end
 end


### PR DESCRIPTION
This is the follow up to #376, adding deprecation warnings to 2.99 for breaking changes in 3.0 added by that PR.

/cc @soulcutter 
