### PR TITLE
Deprecate constant.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,8 @@ Deprecations:
   value starts at `y` and it does not change. (Myron Marston)
 * Deprecate `matcher == value` as an alias for `matcher.matches?(value)`,
   in favor of `matcher === value`. (Myron Marston)
+* Deprecate `RSpec::Matchers::OperatorMatcher` in favor of
+  `RSpec::Matchers::BuiltIn::OperatorMatcher`. (Myron Marston)
 
 ### 2.99.0.beta1 / 2013-11-07
 [full changelog](http://github.com/rspec/rspec-expectations/compare/v2.14.4...v2.99.0.beta1)

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -708,6 +708,14 @@ module RSpec
       BuiltIn::MatchArray.new(array)
     end
 
-    OperatorMatcher.register(Enumerable, '=~', BuiltIn::MatchArray)
+    BuiltIn::OperatorMatcher.register(Enumerable, '=~', BuiltIn::MatchArray)
+
+    def self.const_missing(name)
+      return super unless name == :OperatorMatcher
+
+      RSpec.deprecate("RSpec::Matchers::OperatorMatcher",
+                      :replacement => "RSpec::Matchers::BuiltIn::OperatorMatcher")
+      BuiltIn::OperatorMatcher
+    end
   end
 end

--- a/lib/rspec/matchers/operator_matcher.rb
+++ b/lib/rspec/matchers/operator_matcher.rb
@@ -1,95 +1,95 @@
 module RSpec
   module Matchers
-    class OperatorMatcher
-      class << self
-        def registry
-          @registry ||= {}
-        end
-
-        def register(klass, operator, matcher)
-          registry[klass] ||= {}
-          registry[klass][operator] = matcher
-        end
-
-        def unregister(klass, operator)
-          registry[klass] && registry[klass].delete(operator)
-        end
-
-        def get(klass, operator)
-          klass.ancestors.each { |ancestor|
-            matcher = registry[ancestor] && registry[ancestor][operator]
-            return matcher if matcher
-          }
-
-          nil
-        end
-      end
-
-      def initialize(actual)
-        @actual = actual
-      end
-
-      def self.use_custom_matcher_or_delegate(operator)
-        define_method(operator) do |expected|
-          if uses_generic_implementation_of?(operator) && matcher = OperatorMatcher.get(@actual.class, operator)
-            @actual.__send__(::RSpec::Matchers.last_should, matcher.new(expected))
-          else
-            eval_match(@actual, operator, expected)
-          end
-        end
-
-        negative_operator = operator.sub(/^=/, '!')
-        if negative_operator != operator && respond_to?(negative_operator)
-          define_method(negative_operator) do |expected|
-            opposite_should = ::RSpec::Matchers.last_should == :should ? :should_not : :should
-            raise "RSpec does not support `#{::RSpec::Matchers.last_should} #{negative_operator} expected`.  " +
-              "Use `#{opposite_should} #{operator} expected` instead."
-          end
-        end
-      end
-
-      ['==', '===', '=~', '>', '>=', '<', '<='].each do |operator|
-        use_custom_matcher_or_delegate operator
-      end
-
-      def fail_with_message(message)
-        RSpec::Expectations.fail_with(message, @expected, @actual)
-      end
-
-      def description
-        "#{@operator} #{@expected.inspect}"
-      end
-
-    private
-
-      if Method.method_defined?(:owner) # 1.8.6 lacks Method#owner :-(
-        def uses_generic_implementation_of?(op)
-          Expectations.method_handle_for(@actual, op).owner == ::Kernel
-        rescue NameError
-          false
-        end
-      else
-        def uses_generic_implementation_of?(op)
-          # This is a bit of a hack, but:
-          #
-          # {}.method(:=~).to_s # => "#<Method: Hash(Kernel)#=~>"
-          #
-          # In the absence of Method#owner, this is the best we
-          # can do to see if the method comes from Kernel.
-          Expectations.method_handle_for(@actual, op).to_s.include?('(Kernel)')
-        rescue NameError
-          false
-        end
-      end
-
-      def eval_match(actual, operator, expected)
-        ::RSpec::Matchers.last_matcher = self
-        @operator, @expected = operator, expected
-        __delegate_operator(actual, operator, expected)
-      end
-    end
-
     module BuiltIn
+      class OperatorMatcher
+        class << self
+          def registry
+            @registry ||= {}
+          end
+
+          def register(klass, operator, matcher)
+            registry[klass] ||= {}
+            registry[klass][operator] = matcher
+          end
+
+          def unregister(klass, operator)
+            registry[klass] && registry[klass].delete(operator)
+          end
+
+          def get(klass, operator)
+            klass.ancestors.each { |ancestor|
+              matcher = registry[ancestor] && registry[ancestor][operator]
+              return matcher if matcher
+            }
+
+            nil
+          end
+        end
+
+        def initialize(actual)
+          @actual = actual
+        end
+
+        def self.use_custom_matcher_or_delegate(operator)
+          define_method(operator) do |expected|
+            if uses_generic_implementation_of?(operator) && matcher = OperatorMatcher.get(@actual.class, operator)
+              @actual.__send__(::RSpec::Matchers.last_should, matcher.new(expected))
+            else
+              eval_match(@actual, operator, expected)
+            end
+          end
+
+          negative_operator = operator.sub(/^=/, '!')
+          if negative_operator != operator && respond_to?(negative_operator)
+            define_method(negative_operator) do |expected|
+              opposite_should = ::RSpec::Matchers.last_should == :should ? :should_not : :should
+              raise "RSpec does not support `#{::RSpec::Matchers.last_should} #{negative_operator} expected`.  " +
+                "Use `#{opposite_should} #{operator} expected` instead."
+            end
+          end
+        end
+
+        ['==', '===', '=~', '>', '>=', '<', '<='].each do |operator|
+          use_custom_matcher_or_delegate operator
+        end
+
+        def fail_with_message(message)
+          RSpec::Expectations.fail_with(message, @expected, @actual)
+        end
+
+        def description
+          "#{@operator} #{@expected.inspect}"
+        end
+
+      private
+
+        if Method.method_defined?(:owner) # 1.8.6 lacks Method#owner :-(
+          def uses_generic_implementation_of?(op)
+            Expectations.method_handle_for(@actual, op).owner == ::Kernel
+          rescue NameError
+            false
+          end
+        else
+          def uses_generic_implementation_of?(op)
+            # This is a bit of a hack, but:
+            #
+            # {}.method(:=~).to_s # => "#<Method: Hash(Kernel)#=~>"
+            #
+            # In the absence of Method#owner, this is the best we
+            # can do to see if the method comes from Kernel.
+            Expectations.method_handle_for(@actual, op).to_s.include?('(Kernel)')
+          rescue NameError
+            false
+          end
+        end
+
+        def eval_match(actual, operator, expected)
+          ::RSpec::Matchers.last_matcher = self
+          @operator, @expected = operator, expected
+          __delegate_operator(actual, operator, expected)
+        end
+      end
+
       class PositiveOperatorMatcher < OperatorMatcher
         def __delegate_operator(actual, operator, expected)
           if actual.__send__(operator, expected)

--- a/spec/rspec/matchers/operator_matcher_spec.rb
+++ b/spec/rspec/matchers/operator_matcher_spec.rb
@@ -211,21 +211,40 @@ describe "operator matchers", :uses_should do
     let(:custom_subklass) { Class.new(custom_klass) }
 
     after {
-      RSpec::Matchers::OperatorMatcher.unregister(custom_klass, "=~")
+      RSpec::Matchers::BuiltIn::OperatorMatcher.unregister(custom_klass, "=~")
     }
 
     it "allows operator matchers to be registered for types" do
-      RSpec::Matchers::OperatorMatcher.register(custom_klass, "=~", RSpec::Matchers::BuiltIn::Match)
-      expect(RSpec::Matchers::OperatorMatcher.get(custom_klass, "=~")).to eq(RSpec::Matchers::BuiltIn::Match)
+      RSpec::Matchers::BuiltIn::OperatorMatcher.register(custom_klass, "=~", RSpec::Matchers::BuiltIn::Match)
+      expect(RSpec::Matchers::BuiltIn::OperatorMatcher.get(custom_klass, "=~")).to eq(RSpec::Matchers::BuiltIn::Match)
     end
 
     it "considers ancestors when finding an operator matcher" do
-      RSpec::Matchers::OperatorMatcher.register(custom_klass, "=~", RSpec::Matchers::BuiltIn::Match)
-      expect(RSpec::Matchers::OperatorMatcher.get(custom_subklass, "=~")).to eq(RSpec::Matchers::BuiltIn::Match)
+      RSpec::Matchers::BuiltIn::OperatorMatcher.register(custom_klass, "=~", RSpec::Matchers::BuiltIn::Match)
+      expect(RSpec::Matchers::BuiltIn::OperatorMatcher.get(custom_subklass, "=~")).to eq(RSpec::Matchers::BuiltIn::Match)
     end
 
     it "returns nil if there is no matcher registered for a type" do
-      expect(RSpec::Matchers::OperatorMatcher.get(custom_klass, "=~")).to be_nil
+      expect(RSpec::Matchers::BuiltIn::OperatorMatcher.get(custom_klass, "=~")).to be_nil
+    end
+
+    context "when accessing it using the old 2.x const name" do
+      it 'returns the new constant scoped by `BuiltIn`' do
+        allow_deprecation
+        expect(RSpec::Matchers::OperatorMatcher).to be(RSpec::Matchers::BuiltIn::OperatorMatcher)
+      end
+
+      it 'issues a deprecation warning' do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /OperatorMatcher/)
+        RSpec::Matchers::OperatorMatcher
+      end
+
+      it 'allows other undefined constant to raise errors like normal' do
+        expect_no_deprecation
+        expect {
+          RSpec::Matchers::FooBarBazz
+        }.to raise_error(NameError, /RSpec::Matchers::FooBarBazz/)
+      end
     end
   end
 


### PR DESCRIPTION
It's moved under `BuiltIn` in RSpec 3.

This is a followup to #389 for 2.99.
