### PR TITLE
Updated truthiness docunmetation for built_in_matchers

### DIFF
--- a/features/built_in_matchers/README.md
+++ b/features/built_in_matchers/README.md
@@ -46,10 +46,11 @@ e.g.
 
 ## Truthiness and existentialism
 
-    expect(actual).to be_true  # passes if actual is truthy (not nil or false)
-    expect(actual).to be_false # passes if actual is falsy (nil or false)
-    expect(actual).to be_nil   # passes if actual is nil
-    expect(actual).to be       # passes if actual is truthy (not nil or false)
+    expect(actual).to be_truthy # passes if actual is truthy (not nil or false)
+    expect(actual).to be true   # passes if actual == true
+    expect(actual).to be_falsy  # passes if actual is falsy (nil or false)
+    expect(actual).to be false  # passes if actual == false
+    expect(actual).to be_nil    # passes if actual is nil
 
 ## Expecting errors
 


### PR DESCRIPTION
Updated the documentation for built in matchers with the new syntax. This is now matches [the examples in /README.md](https://github.com/rspec/rspec-expectations/blob/master/README.md#truthiness)
