### PR TITLE
More helpful error messages for be_true and be_false

### DIFF
--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -245,6 +245,10 @@ module RSpec
     end
     alias_matcher :a_truthy_value, :be_truthy
 
+    def be_true
+      raise NoMethodError, '`be_true` has been removed in favor of `be true` and `be_truthy`.'
+    end
+
     # Passes if actual is falsey (false or nil)
     def be_falsey
       BuiltIn::BeFalsey.new
@@ -252,6 +256,10 @@ module RSpec
     alias_matcher :be_falsy,       :be_falsey
     alias_matcher :a_falsey_value, :be_falsey
     alias_matcher :a_falsy_value,  :be_falsey
+
+    def be_false
+      raise NoMethodError, '`be_false` has been removed in favor of `be false` and `be_falsey`.'
+    end
 
     # Passes if actual is nil
     def be_nil

--- a/spec/rspec/matchers/built_in/be_spec.rb
+++ b/spec/rspec/matchers/built_in/be_spec.rb
@@ -274,6 +274,14 @@ describe "expect(...).to be_truthy" do
   end
 end
 
+describe "expect(...).to be_true" do
+  it "fails with a helpful message" do
+    expect {
+      expect(true).to be_true
+    }.to raise_error(NoMethodError, '`be_true` has been removed in favor of `be true` and `be_truthy`.')
+  end
+end
+
 describe "expect(...).to be_falsey" do
   it "passes when actual equal?(false)" do
     expect(false).to be_falsey
@@ -303,6 +311,14 @@ describe "expect(...).to be_falsy" do
     expect {
       expect(true).to be_falsy
     }.to fail_with("expected: falsey value\n     got: true")
+  end
+end
+
+describe "expect(...).to be_false" do
+  it "fails with a helpful message" do
+    expect {
+      expect(false).to be_false
+    }.to raise_error(NoMethodError, '`be_false` has been removed in favor of `be false` and `be_falsey`.')
   end
 end
 


### PR DESCRIPTION
These are a couple of helpful error messages when you try to use `be_true` and `be_false`. This would have been helpful for me when I started a new project using 3.0 and was surprised to find that `be_true` raised `NoMethodError` with the message `undefined method `true?' for true:TrueClass`, which lead me to believe something was broken in my environment. This will hopefully save some time for other people in the same situation. 
