### PR TITLE
Use more display precision for Time and DateTime

### DIFF
--- a/lib/rspec/matchers/built_in/eq.rb
+++ b/lib/rspec/matchers/built_in/eq.rb
@@ -7,11 +7,11 @@ module RSpec
         end
 
         def failure_message
-          "\nexpected: #{expected.inspect}\n     got: #{actual.inspect}\n\n(compared using ==)\n"
+          "\nexpected: #{format_object(expected)}\n     got: #{format_object(actual)}\n\n(compared using ==)\n"
         end
 
         def failure_message_when_negated
-          "\nexpected: value != #{expected.inspect}\n     got: #{actual.inspect}\n\n(compared using ==)\n"
+          "\nexpected: value != #{format_object(expected)}\n     got: #{format_object(actual)}\n\n(compared using ==)\n"
         end
 
         def description
@@ -19,6 +19,35 @@ module RSpec
         end
 
         def diffable?; true; end
+
+      private
+
+        def format_object(object)
+          if Time === object
+            format_time(object)
+          elsif defined?(DateTime) && DateTime === object
+            format_date_time(object)
+          else
+            object.inspect
+          end
+        end
+
+        TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+        # Append microseconds to the default format string
+        def format_time(time)
+          time.strftime("#{TIME_FORMAT}.#{"%06d" % time.usec} %z")
+        end
+
+        DATE_TIME_FORMAT = "%a, %d %b %Y %H:%M:%S.%6N %z"
+        # ActiveSupport sometimes overrides inspect. If `ActiveSupport` is
+        # defined use a custom format string that includes more time precision.
+        def format_date_time(date_time)
+          if defined?(ActiveSupport)
+            date_time.strftime(DATE_TIME_FORMAT)
+          else
+            date_time.inspect
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Use more display precision for Time and DateTime

The `eq` matcher often results in confusing output when comparing `Time`
and `DateTime` objects.

`Time#inspect` returns a value that is not full precision. This often
leads to a confusing failure message when two time objects differ by
fractional seconds. The matcher returns a failure but the diff shows
identical values. Microseconds have been added to the diff output for
`Time`.

By default `DateTime#inspect` outputs enough precision to prevent this
problem. `ActiveSupport` monkey patches `#inspect` to print a more human
readable but ambiguous representation. If `ActiveSupport` is defined a
custom format string is used for `DateTime` that has enough precision
to differentiate the two objects.

Fixes rspec/rspec-expectations#331
