### PR TITLE
Change failure message for BeComparedTo#failure_message_when_negated

### DIFF
--- a/lib/rspec/matchers/built_in/be.rb
+++ b/lib/rspec/matchers/built_in/be.rb
@@ -113,14 +113,12 @@ module RSpec
         end
 
         def failure_message_when_negated
-          message = <<-MESSAGE
-`expect(actual).not_to be #{@operator} #{@expected}` not only FAILED,
-it is a bit confusing.
-          MESSAGE
-
-          raise message << ([:===,:==].include?(@operator) ?
-                            "It might be more clearly expressed without the \"be\"?" :
-                            "It might be more clearly expressed in the positive?")
+          message = "`expect(#{@actual}).not_to be #{@operator} #{@expected}`"
+          if [:<, :>, :<=, :>=].include?(@operator)
+            raise message << " not only FAILED,\nit is a bit confusing."
+          else
+            raise message
+          end
         end
 
         def description

--- a/spec/rspec/matchers/built_in/be_spec.rb
+++ b/spec/rspec/matchers/built_in/be_spec.rb
@@ -449,11 +449,35 @@ describe "expect(...).to be ===" do
   end
 end
 
-describe "expect(...).not_to with operators" do
-  it "coaches user to stop using operators with expect().not_to" do
+describe "expect(...).not_to with comparison operators" do
+  it "coaches user to stop using operators with expect().not_to with numerical comparison operators" do
     expect {
       expect(5).not_to be < 6
-    }.to raise_error(/`expect\(actual\).not_to be < 6` not only FAILED,\nit is a bit confusing./m)
+    }.to raise_error("`expect(5).not_to be < 6` not only FAILED,\nit is a bit confusing.")
+
+    expect {
+      expect(5).not_to be <= 6
+    }.to raise_error("`expect(5).not_to be <= 6` not only FAILED,\nit is a bit confusing.")
+
+    expect {
+      expect(6).not_to be > 5
+    }.to raise_error("`expect(6).not_to be > 5` not only FAILED,\nit is a bit confusing.")
+
+    expect {
+      expect(6).not_to be >= 5
+    }.to raise_error("`expect(6).not_to be >= 5` not only FAILED,\nit is a bit confusing.")
+  end
+end
+
+describe "expect(...).not_to with equality operators" do
+  it "raises normal error with expect().not_to with equality operators" do
+    expect {
+      expect(6).not_to be == 6
+    }.to raise_error("`expect(6).not_to be == 6`")
+
+    expect {
+      expect(String).not_to be === "Hello"
+    }.to raise_error("`expect(String).not_to be === Hello`")
   end
 end
 


### PR DESCRIPTION
- Normal error message will be given for all operator except comparison
  operators
- For comparison operators such as gt/lt/gte/lte, with normal message a
  warning saying that the usage is confusing is given.
- "It might be more clearly expressed without the" is dropped completely
  as it doesn't sound correct with except
- Fixes #386
