### PR TITLE
Add `a_hash_including` alias.

### DIFF
--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -557,6 +557,7 @@ module RSpec
     end
     alias_matcher :a_collection_including, :include
     alias_matcher :a_string_including,     :include
+    alias_matcher :a_hash_including,       :include
     alias_matcher :including,              :include
 
     # Given a `Regexp` or `String`, passes if `actual.match(pattern)`

--- a/spec/rspec/matchers/aliases_spec.rb
+++ b/spec/rspec/matchers/aliases_spec.rb
@@ -232,6 +232,14 @@ module RSpec
 
     specify do
       expect(
+        a_hash_including(:a => 5)
+      ).to be_aliased_to(
+        include(:a => 5)
+      ).with_description('a hash including {:a => 5}')
+    end
+
+    specify do
+      expect(
         including(3)
       ).to be_aliased_to(
         include(3)


### PR DESCRIPTION
The other aliases didn't really fit for a hash but a hash
is one of the main types of objects used with the `include`
matcher.

I'm working on a blog post about composable matchers and of the examples I'm using would really benefit from this alias, and I think it's worth having in general.  The example, FWIW:

``` ruby
class BackgroundWorker
  attr_reader :queue

  def initialize
    @queue = queue
  end

  def enqueue(job_data)
    queue << job_data.merge(:enqueued_at => Time.now)
  end
end

describe BackgroundWorker do
  it 'puts enqueued jobs onto the queue' do
    worker = BackgroundWorker.new
    worker.enqueue(:klass => "SomeClass", :id => 37)

    expect(worker.queue).to match [a_hash_including(:klass => "SomeClass", :id => 37)]
  end
end
```

/cc @xaviershay 
