### PR TITLE
Improve `change` failure messages.

### DIFF
--- a/lib/rspec/matchers/built_in/change.rb
+++ b/lib/rspec/matchers/built_in/change.rb
@@ -119,12 +119,14 @@ module RSpec
           @change_details.changed? && matches_before? && matches_after?
         end
 
+        def description
+          "change #{@change_details.message} #{change_description}"
+        end
+
         def failure_message
-          if !matches_before?
-            "expected #{@change_details.message} to have initially been #{description_of @expected_before}, but was #{description_of @change_details.actual_before}"
-          else
-            "expected #{@change_details.message} to have changed to #{description_of @expected_after}, but is now #{description_of @change_details.actual_after}"
-          end
+          return before_value_failure   unless matches_before?
+          return did_not_change_failure unless @change_details.changed?
+          after_value_failure
         end
 
       private
@@ -135,6 +137,22 @@ module RSpec
 
         def matches_after?
           values_match?(@expected_after, @change_details.actual_after)
+        end
+
+        def before_value_failure
+          "expected #{@change_details.message} to have initially been #{description_of @expected_before}, but was #{description_of @change_details.actual_before}"
+        end
+
+        def after_value_failure
+          "expected #{@change_details.message} to have changed to #{description_of @expected_after}, but is now #{description_of @change_details.actual_after}"
+        end
+
+        def did_not_change_failure
+          "expected #{@change_details.message} to have changed #{change_description}, but did not change"
+        end
+
+        def did_change_failure
+          "expected #{@change_details.message} not to have changed, but did change from #{description_of @change_details.actual_before} to #{description_of @change_details.actual_after}"
         end
       end
 
@@ -163,15 +181,14 @@ module RSpec
         end
 
         def failure_message_when_negated
-          if !matches_before?
-            "expected #{@change_details.message} to have initially been #{description_of @expected_before}, but was #{description_of @change_details.actual_before}"
-          else
-            "expected #{@change_details.message} not to have changed, but did change from #{description_of @change_details.actual_before} to #{description_of @change_details.actual_after}"
-          end
+          return before_value_failure unless matches_before?
+          did_change_failure
         end
 
-        def description
-          "change #{@change_details.message} from #{description_of @expected_before}#{@description_suffix}"
+      private
+
+        def change_description
+          "from #{description_of @expected_before}#{@description_suffix}"
         end
       end
 
@@ -194,8 +211,10 @@ module RSpec
           raise NotImplementedError, "`expect { }.not_to change { }.to()` is not supported"
         end
 
-        def description
-          "change #{@change_details.message} to #{description_of @expected_after}#{@description_suffix}"
+      private
+
+        def change_description
+          "to #{description_of @expected_after}#{@description_suffix}"
         end
       end
 

--- a/spec/rspec/matchers/built_in/change_spec.rb
+++ b/spec/rspec/matchers/built_in/change_spec.rb
@@ -527,6 +527,12 @@ describe "expect { ... }.to change { block }.from(old)" do
     end.to fail_with("expected result to have initially been \"cat\", but was \"string\"")
   end
 
+  it "fails when attribute does not change" do
+    expect do
+      expect { }.to change { @instance.some_value }.from("string")
+    end.to fail_with('expected result to have changed from "string", but did not change')
+  end
+
   it "provides a #description" do
     expect(change { }.from(3).description).to eq "change result from 3"
   end
@@ -564,6 +570,12 @@ describe "expect { ... }.to change(actual, message).to(new)" do
       expect do
         expect { @instance.some_value = "cat" }.to change(@instance, :some_value).from("string").to("dog")
       end.to fail_with("expected #some_value to have changed to \"dog\", but is now \"cat\"")
+    end
+
+    it "fails with a clear message when it ends with the right value but did not change" do
+      expect {
+        expect { }.to change(@instance, :some_value).to("string")
+      }.to fail_with('expected #some_value to have changed to "string", but did not change')
     end
   end
 end


### PR DESCRIPTION
There were a couple of cases that produced puzzling failure messages:

k = "foo"
expect { }.to change { k }.to("foo")

..used to fail with:

  expected #some_value to have changed to "foo", but is now "foo"

..and now fails with:

  expected #some_value to have changed to "foo", but did not change

k = "foo"
expect { }.to change { k }.from("foo")

..used to fail with:

  expected result to have changed to BasicObject, but is now "foo"

..and now fails with:

  expected result to have changed from "foo", but did not change
