### PR TITLE
Allow `RSpec::Matchers` to be mixed into `main`.

### DIFF
--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -840,11 +840,14 @@ module RSpec
 
   private
 
+    BE_PREDICATE_REGEX = /^(be_(?:an?_)?)(.*)/
+    HAS_REGEX = /^(?:have_)(.*)/
+
     def method_missing(method, *args, &block)
       case method.to_s
-        when BuiltIn::BePredicate::REGEX
+        when BE_PREDICATE_REGEX
           BuiltIn::BePredicate.new(method, *args, &block)
-        when BuiltIn::Has::REGEX
+        when HAS_REGEX
           BuiltIn::Has.new(method, *args, &block)
         else
           super

--- a/lib/rspec/matchers/built_in/be.rb
+++ b/lib/rspec/matchers/built_in/be.rb
@@ -192,10 +192,8 @@ module RSpec
           expected
         end
 
-        REGEX = /^(be_(?:an?_)?)(.*)/
-
         def prefix_and_expected(symbol)
-          REGEX.match(symbol.to_s).captures.compact
+          Matchers::BE_PREDICATE_REGEX.match(symbol.to_s).captures.compact
         end
 
         def prefix_to_sentence

--- a/lib/rspec/matchers/built_in/has.rb
+++ b/lib/rspec/matchers/built_in/has.rb
@@ -26,10 +26,8 @@ module RSpec
 
       private
 
-        REGEX = /^(?:have_)(.*)/
-
         def predicate
-          @predicate ||= :"has_#{@method_name.to_s.match(REGEX).captures.first}?"
+          @predicate ||= :"has_#{@method_name.to_s.match(Matchers::HAS_REGEX).captures.first}?"
         end
 
         def method_description

--- a/spec/rspec/matchers_spec.rb
+++ b/spec/rspec/matchers_spec.rb
@@ -1,5 +1,24 @@
 require 'spec_helper'
 
+main = self
+describe RSpec::Matchers do
+  include ::RSpec::Support::InSubProcess
+
+  it 'can be mixed into `main`' do
+    in_sub_process do
+      main.instance_eval do
+        include RSpec::Matchers
+        expect(3).to eq(3)
+        expect(3).to be_odd
+
+        expect {
+          expect(4).to be_zero
+        }.to fail_with("expected zero? to return true, got false")
+      end
+    end
+  end
+end
+
 module RSpec
   module Matchers
     describe "built in matchers" do


### PR DESCRIPTION
I don't understand why the references to the other
constant was breaking this, but it was :(.

Fixes #427.
