### PR TITLE
Proxy blocks along with arguments in has matchers

### DIFF
--- a/lib/rspec/matchers/built_in/has.rb
+++ b/lib/rspec/matchers/built_in/has.rb
@@ -4,12 +4,12 @@ module RSpec
       class Has
         include Composable
 
-        def initialize(method_name, *args)
-          @method_name, @args = method_name, args
+        def initialize(method_name, *args, &block)
+          @method_name, @args, @block = method_name, args, block
         end
 
         def matches?(actual)
-          actual.__send__(predicate, *@args)
+          actual.__send__(predicate, *@args, &@block)
         end
 
         def failure_message

--- a/spec/rspec/matchers/built_in/has_spec.rb
+++ b/spec/rspec/matchers/built_in/has_spec.rb
@@ -16,6 +16,18 @@ describe "expect(...).to have_sym(*args)" do
     }.to fail_with("expected #has_key?(:a) to return true, got false")
   end
 
+  it 'passes based on the result of a block being proxied' do
+    o = Object.new
+    def o.has_some_stuff?; yield; end
+    expect(o).to have_some_stuff { true }
+  end
+
+  it 'fails based off the result of a block being proxied' do
+    o = Object.new
+    def o.has_some_stuff?; yield; end
+    expect(o).to_not have_some_stuff { false }
+  end
+
   it 'does not include any args in the failure message if no args were given to the matcher' do
     o = Object.new
     def o.has_some_stuff?; false; end


### PR DESCRIPTION
Currently, when using the has matcher any arguments passed are sent
along to the method being proxied. However, any blocks that were provided were
being lost. This commit sends along any blocks with the arguments.

<@dgalarza | @hrs | @masonforest>
