### PR TITLE
Display nanosecond precision for Time and DateTime

### DIFF
--- a/lib/rspec/matchers/built_in/eq.rb
+++ b/lib/rspec/matchers/built_in/eq.rb
@@ -33,12 +33,18 @@ module RSpec
         end
 
         TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
-        # Append microseconds to the default format string
-        def format_time(time)
-          time.strftime("#{TIME_FORMAT}.#{"%06d" % time.usec} %z")
+
+        if Time.method_defined?(:nsec)
+          def format_time(time)
+            time.strftime("#{TIME_FORMAT}.#{"%09d" % time.nsec} %z")
+          end
+        else # for 1.8.7
+          def format_time(time)
+            time.strftime("#{TIME_FORMAT}.#{"%06d" % time.usec} %z")
+          end
         end
 
-        DATE_TIME_FORMAT = "%a, %d %b %Y %H:%M:%S.%6N %z"
+        DATE_TIME_FORMAT = "%a, %d %b %Y %H:%M:%S.%N %z"
         # ActiveSupport sometimes overrides inspect. If `ActiveSupport` is
         # defined use a custom format string that includes more time precision.
         def format_date_time(date_time)


### PR DESCRIPTION
This is a follow up to #331 and #416.

Linux creates Time objects with nanosecond precision so only displaying microseconds can hide the differences between two objects.
