### PR TITLE
Fix typo: `s/expet/expect/g`

### DIFF
--- a/lib/rspec/expectations.rb
+++ b/lib/rspec/expectations.rb
@@ -38,7 +38,7 @@ module RSpec
   #
   # Given the expression:
   #
-  #     expet(order.entries).not_to include(entry)
+  #     expect(order.entries).not_to include(entry)
   #
   # ...the `not_to` method (also available as `to_not`) invokes the equivalent of
   # `include.matches?(order.entries)`, but it interprets `false` as success, and


### PR DESCRIPTION
Sorry if this is too trivial for a pull request. I noticed a typo while poring over the documentation, so I thought to send a patch. Thanks for all your hard work on RSpec!
