### PR TITLE
Fix do end blocks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Bug Fixes:
 
 * Fix `NoMethodError` triggered by beta2 when `YARD` was loaded in
   the test environment. (Myron Marston)
+* Fix `be_xyz` matcher to accept a `do...end` block. (Myron Marston)
 
 ### 3.0.0.beta2 / 2014-02-17
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.0.0.beta1...v3.0.0.beta2)

--- a/lib/rspec/matchers/built_in/be.rb
+++ b/lib/rspec/matchers/built_in/be.rb
@@ -135,8 +135,9 @@ module RSpec
           @block = block
         end
 
-        def matches?(actual)
-          @actual = actual
+        def matches?(actual, &block)
+          @actual  = actual
+          @block ||= block
 
           if is_private_on?( @actual )
             raise Expectations::ExpectationNotMetError.new("expectation set on private method `#{predicate}`")

--- a/spec/rspec/matchers/built_in/be_spec.rb
+++ b/spec/rspec/matchers/built_in/be_spec.rb
@@ -192,6 +192,52 @@ describe "expect(...).to be_predicate(&block)" do
     expect(mouth).to be_frown { true }
     expect(mouth).not_to be_frown { false }
   end
+
+  it 'works with a do..end block for either predicate form' do
+    mouth1 = Object.new
+    def mouth1.frown?; yield; end
+    mouth2 = Object.new
+    def mouth2.frowns?; yield; end
+
+    expect(mouth1).to be_frown do
+      true
+    end
+
+    expect(mouth1).not_to be_frown do
+      false
+    end
+
+    expect(mouth2).to be_frown do
+      true
+    end
+
+    expect(mouth2).not_to be_frown do
+      false
+    end
+  end
+
+  it 'prefers a { ... } block to a do/end block because it binds more tightly' do
+    mouth1 = Object.new
+    def mouth1.frown?; yield; end
+    mouth2 = Object.new
+    def mouth2.frowns?; yield; end
+
+    expect(mouth1).to be_frown { true } do
+      false
+    end
+
+    expect(mouth1).not_to be_frown { false } do
+      true
+    end
+
+    expect(mouth2).to be_frown { true } do
+      false
+    end
+
+    expect(mouth2).not_to be_frown { false } do
+      true
+    end
+  end
 end
 
 describe "expect(...).not_to be_predicate(&block)" do


### PR DESCRIPTION
This fixes #137.

As discussed in that issue, `be_xyz` predicate matchers didn't support `do...end` blocks properly.  This fixes.

I had also commented there that `change` needs a fix here as well, but after looking into it some more, I've concluded that it's OK as is.  For `change` we raise an error if `do ... end` is used to provide the block, because we can't support the chainable `by`, `to`, `from`, etc, expressions off of a `do...end` block.  That's because in an expression like:

``` ruby
expect do
  do_something
end.to change do
  foo
end.by(3)
```

...ruby sends the `by` message to the return value of `expect().to(matcher)`, at which point it is too late for it to apply to the matcher.  Given that, I think it's best if we don't support the `do...end` form for `change` at all.  The other change matcher classes don't prevent the do...end block but you can only get instances of those classes by using the chainable methods like `by`, so we already know that no `do...end` block has been passed by the time we get there.  So, nothing to do for `change` :).

/cc @xaviershay 
