### PR TITLE
Deprecate RSpec::Matchers::Configuration.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ Deprecations:
   custom matchers. (Myron Marston)
 * Deprecate `RSpec::Matchers::Pretty#_pretty_print`. (Myron Marston)
 * Deprecate `RSpec::Matchers::Pretty#expected_to_sentence`. (Myron Marston)
+* Deprecate `RSpec::Matchers::Configuration` in favor of
+  `RSpec::Expectations::Configuration`. (Myron Marston)
 
 ### 2.99.0.beta2 / 2014-02-17
 [full changelog](http://github.com/rspec/rspec-expectations/compare/v2.99.0.beta1...v2.99.0.beta2)

--- a/lib/rspec/expectations.rb
+++ b/lib/rspec/expectations.rb
@@ -1,7 +1,7 @@
 require 'rspec/expectations/extensions'
 require 'rspec/matchers'
 require 'rspec/expectations/expectation_target'
-require 'rspec/matchers/configuration'
+require 'rspec/expectations/configuration'
 require 'rspec/expectations/fail_with'
 require 'rspec/expectations/errors'
 require 'rspec/expectations/deprecation'

--- a/lib/rspec/expectations/configuration.rb
+++ b/lib/rspec/expectations/configuration.rb
@@ -1,7 +1,7 @@
 require 'rspec/expectations/syntax'
 
 module RSpec
-  module Matchers
+  module Expectations
     # Provides configuration options for rspec-expectations.
     class Configuration
       # Configures the supported syntax.
@@ -94,11 +94,13 @@ module RSpec
         end
       end
     end
+  end
 
+  module Matchers
     # The configuration object
-    # @return [RSpec::Matchers::Configuration] the configuration object
+    # @return [RSpec::Expectations::Configuration] the configuration object
     def self.configuration
-      @configuration ||= Configuration.new
+      @configuration ||= Expectations::Configuration.new
     end
 
     # set default syntax

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -711,11 +711,17 @@ module RSpec
     BuiltIn::OperatorMatcher.register(Enumerable, '=~', BuiltIn::MatchArray)
 
     def self.const_missing(name)
-      return super unless name == :OperatorMatcher
-
-      RSpec.deprecate("RSpec::Matchers::OperatorMatcher",
-                      :replacement => "RSpec::Matchers::BuiltIn::OperatorMatcher")
-      BuiltIn::OperatorMatcher
+      case name
+        when :OperatorMatcher
+          RSpec.deprecate("`RSpec::Matchers::OperatorMatcher`",
+                          :replacement => "`RSpec::Matchers::BuiltIn::OperatorMatcher`")
+          BuiltIn::OperatorMatcher
+        when :Configuration
+          RSpec.deprecate("`RSpec::Matchers::Configuration`",
+                          :replacement => "`RSpec::Expectations::Configuration`")
+          Expectations::Configuration
+        else super
+      end
     end
   end
 end

--- a/spec/rspec/expectations/configuration_spec.rb
+++ b/spec/rspec/expectations/configuration_spec.rb
@@ -2,16 +2,35 @@ require 'spec_helper'
 require 'delegate'
 
 module RSpec
-  module Matchers
+  module Expectations
     describe "RSpec::Matchers.configuration" do
       it 'returns a memoized configuration instance' do
-        expect(RSpec::Matchers.configuration).to be_a(RSpec::Matchers::Configuration)
+        expect(RSpec::Matchers.configuration).to be_a(RSpec::Expectations::Configuration)
         expect(RSpec::Matchers.configuration).to be(RSpec::Matchers.configuration)
       end
     end
 
     describe Configuration do
       let(:config) { Configuration.new }
+
+      context "when accessing it using the old 2.x const name" do
+        it 'returns the new constant' do
+          allow_deprecation
+          expect(RSpec::Matchers::Configuration).to be(RSpec::Expectations::Configuration)
+        end
+
+        it 'issues a deprecation warning' do
+          expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /RSpec::Matchers::Configuration/)
+          RSpec::Matchers::Configuration
+        end
+
+        it 'allows other undefined constant to raise errors like normal' do
+          expect_no_deprecation
+          expect {
+            RSpec::Matchers::FooBarBazz
+          }.to raise_error(NameError, /RSpec::Matchers::FooBarBazz/)
+        end
+      end
 
       describe "#backtrace_formatter" do
         let(:original_backtrace) { %w[ clean-me/a.rb other/file.rb clean-me/b.rb ] }


### PR DESCRIPTION
This is a 2.99 deprecation PR that pairs with #488.
