### PR TITLE
Add all matcher [DONE]

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -41,6 +41,10 @@ Enhancements:
 * Improve the failure message for `be_xyz` predicate matchers so
   that it includes the `inspect` output of the receiver.
   (Erik Michaels-Ober, Sam Phippen)
+* Add support for `all` matcher, to allow you to match matcher on a collection.
+  * `expect(stoplight.color).to ~eq("blue")`
+  * `expect([1, 3, 5]).to all( be_odd.and be_an(Integer) )`
+  (Adam Farhi)
 
 ### 3.0.0.beta2 / 2014-02-17
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.0.0.beta1...v3.0.0.beta2)

--- a/features/built_in_matchers/all.feature
+++ b/features/built_in_matchers/all.feature
@@ -1,0 +1,70 @@
+Feature: all matcher
+
+  Use the `all` matcher to specify that a collection's objects all pass an expected matcher.
+  This works on any object that responds to #all? (array and any Enumerable object):
+
+    ```ruby
+    expect([1, 3, 5]).to all( be_odd )
+    expect([1, 3, 5]).to all( be_an(Integer) )
+    expect([1, 3, 5]).to all( be < 10 )
+    expect([1, 3, 4]).to all( be_odd ) # fails
+    ```
+
+  The matcher also supports compound matchers:
+
+    ```ruby
+    expect([1, 3, 5]).to all( be_odd.and be < 10 )
+    expect([1, 4, 21]).to all( be_odd.or be < 10 )
+    ```
+
+  Scenario: array usage
+    Given a file named "array_all_matcher_spec.rb" with:
+      """ruby
+      RSpec.describe [1, 3, 5] do
+        it { is_expected.to all( be_odd ) }
+        it { is_expected.to all( be_an(Integer) ) }
+        it { is_expected.to all( be < 10 ) }
+
+        # deliberate failures
+        it { is_expected.to all( be_even ) }
+        it { is_expected.to all( be_a(String) ) }
+        it { is_expected.to all( be < 0 ) }
+        it { is_expected.to all( eq(8) ) }
+
+        #  should fail since not all objects are greater then 2
+        it { is_expected.to all( be > 2 ) }
+
+        # should fail since not all objects are 3
+        it { is_expected.to all( eq(3) ) }
+      end
+      """
+    When I run `rspec array_all_matcher_spec.rb`
+    Then the output should contain all of these:
+      | 9 examples, 6 failures                        |
+      | expected [1, 3, 5] to all be even             |
+      | expected [1, 3, 5] to all be a kind of String |
+      | expected [1, 3, 5] to all be < 0              |
+      | expected [1, 3, 5] to all eq 8                |
+      | expected [1, 3, 5] to all be > 2              |
+      | expected [1, 3, 5] to all eq 3                |
+
+  Scenario: compound matcher usage
+    Given a file named "compound_all_matcher_spec.rb" with:
+      """ruby
+      RSpec.describe ['anything', 'everything', 'something'] do
+        it { is_expected.to all( be_a(String).and include("thing") ) }
+        it { is_expected.to all( be_a(String).and ending_with("g") ) }
+        it { is_expected.to all( starting_with("s").or include("y") ) }
+
+        # deliberate failures
+        it { is_expected.to all( include("foo").and include("bar") ) }
+        it { is_expected.to all( be_a(String).and starting_with("a") ) }
+        it { is_expected.to all( starting_with("a").or include("z") ) }
+      end
+      """
+    When I run `rspec compound_all_matcher_spec.rb`
+    Then the output should contain all of these:
+      | 6 examples, 3 failures                                                                              |
+      | expected ["anything", "everything", "something"] to all include "foo" and include "bar"             |
+      | expected ["anything", "everything", "something"] to all be a kind of String and starting with "a"   |
+      | expected ["anything", "everything", "something"] to all starting with "a" or include "z"            |

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -580,6 +580,24 @@ module RSpec
     alias_matcher :a_hash_including,       :include
     alias_matcher :including,              :include
 
+    # Passes if actual all expected objects pass. This works for
+    # collections and Strings.
+    #
+    # @example
+    #
+    #   expect([1, 3, 5]).to      all be_odd
+    #   expect([1, 3, 6]).to      all be_odd # fails
+    #   expect([1, 3, 5]).not_to  all be_even
+    #
+    # You can also use this with compound matchers
+    #
+    # @example
+    #
+    #   expect([1, 3, 5]).to all( be_odd.and be_an(Integer) )
+    def all(expected)
+      BuiltIn::All.new(expected)
+    end
+
     # Given a `Regexp` or `String`, passes if `actual.match(pattern)`
     # Given an arbitrary nested data structure (e.g. arrays and hashes),
     # matches if `expected === actual` || `actual == expected` for each

--- a/lib/rspec/matchers/built_in.rb
+++ b/lib/rspec/matchers/built_in.rb
@@ -31,6 +31,7 @@ module RSpec
       autoload :Exist,                   'rspec/matchers/built_in/exist'
       autoload :Has,                     'rspec/matchers/built_in/has'
       autoload :Include,                 'rspec/matchers/built_in/include'
+      autoload :All,                     'rspec/matchers/built_in/all'
       autoload :Match,                   'rspec/matchers/built_in/match'
       autoload :NegativeOperatorMatcher, 'rspec/matchers/built_in/operators'
       autoload :OperatorMatcher,         'rspec/matchers/built_in/operators'

--- a/lib/rspec/matchers/built_in/all.rb
+++ b/lib/rspec/matchers/built_in/all.rb
@@ -1,0 +1,78 @@
+module RSpec
+  module Matchers
+    module BuiltIn
+      # @api private
+      # Provides the implementation for `all`.
+      # Not intended to be instantiated directly.
+      class All < BaseMatcher
+
+        # @private
+        attr_reader :matcher, :failed_objects
+
+        def initialize(matcher)
+          @matcher = matcher
+          @failed_objects = {}
+        end
+
+        # @private
+        def does_not_match?(actual)
+          raise NotImplementedError, '`expect().not_to all( matcher )` is not supported.'
+        end
+
+        # @api private
+        # @return [String]
+        def failure_message
+          all_messages = [improve_hash_formatting(super)]
+          failed_objects.each do |index, matcher_failure_message|
+            all_messages << failure_message_for_item(index, matcher_failure_message)
+          end
+          all_messages.join("\n\n")
+        end
+
+        # @api private
+        # @return [String]
+        def description
+          described_items = surface_descriptions_in(matcher)
+          improve_hash_formatting "all#{to_sentence(described_items)}"
+        end
+
+      private
+
+        def match(_, actual)
+          index_failed_objects
+          failed_objects.empty?
+        end
+
+        def index_failed_objects
+          actual.each_with_index do |actual_item, index|
+            cloned_matcher = matcher.clone
+            matches = cloned_matcher.matches?(actual_item)
+            failed_objects[index] = cloned_matcher.failure_message unless matches
+          end
+        end
+
+        def failure_message_for_item(index, failure_message)
+          failure_message = indent_multiline_message( add_new_line_if_needed(failure_message) )
+          indent_multiline_message("object at index #{index} failed to match:#{failure_message}")
+        end
+
+        def add_new_line_if_needed(message)
+          message.start_with?("\n") ? message : "\n#{message}"
+        end
+
+        def indent_multiline_message(message)
+          message = message.sub(/\n+\z/, '')
+          message.lines.map do |line|
+            line =~ /\S/ ? '   ' + line : line
+          end.join
+        end
+
+        def initialize_copy(other)
+          @matcher = @matcher.clone
+          super
+        end
+
+      end
+    end
+  end
+end

--- a/spec/rspec/matchers/built_in/all_spec.rb
+++ b/spec/rspec/matchers/built_in/all_spec.rb
@@ -1,0 +1,184 @@
+module RSpec::Matchers::BuiltIn
+  describe All do
+
+    it_behaves_like 'an RSpec matcher', :valid_value => ['A', 'A', 'A'], :invalid_value => ['A', 'A', 'B'] do
+      let(:matcher) { all( eq('A') ) }
+    end
+
+    describe 'description' do
+      it 'provides a description' do
+        matcher = all( eq('A') )
+        expect(matcher.description).to eq 'all eq "A"'
+      end
+    end
+
+    context 'when single matcher is given' do
+
+      describe 'expect(...).to all(expected)' do
+
+        it 'can pass' do
+          expect(['A', 'A', 'A']).to all( eq('A') )
+        end
+
+        describe 'failure message' do
+
+          context 'when the matcher has single-line failure message' do
+            it 'returns the index of the failed object' do
+              expect {
+                expect(['A', 'A', 'A', 5, 'A']).to all( be_a(String) )
+              }.to fail_with(dedent <<-EOS)
+              |expected ["A", "A", "A", 5, "A"] to all be a kind of String
+              |
+              |   object at index 3 failed to match:
+              |      expected 5 to be a kind of String
+              EOS
+            end
+
+            it 'returns the indexes of all failed objects, not just the first one' do
+              expect {
+                expect(['A', 'A', 'A', 5, 6]).to all( be_a(String) )
+              }.to fail_with(dedent <<-EOS)
+              |expected ["A", "A", "A", 5, 6] to all be a kind of String
+              |
+              |   object at index 3 failed to match:
+              |      expected 5 to be a kind of String
+              |
+              |   object at index 4 failed to match:
+              |      expected 6 to be a kind of String
+              EOS
+            end
+          end
+
+
+          context 'when the matcher has multi-line failure message' do
+            it 'returns the index of the failed object' do
+              expect {
+                expect(['A', 'A', 'A', 'C', 'A']).to all( eq('A') )
+              }.to fail_with(dedent <<-EOS)
+              |expected ["A", "A", "A", "C", "A"] to all eq "A"
+              |
+              |   object at index 3 failed to match:
+              |      expected: "A"
+              |           got: "C"
+              |
+              |      (compared using ==)
+              EOS
+            end
+
+            it 'returns the indexes of all failed objects, not just the first one' do
+              expect {
+                expect(['A', 'B', 'A', 'C', 'A']).to all( eq('A') )
+              }.to fail_with(dedent <<-EOS)
+              |expected ["A", "B", "A", "C", "A"] to all eq "A"
+              |
+              |   object at index 1 failed to match:
+              |      expected: "A"
+              |           got: "B"
+              |
+              |      (compared using ==)
+              |
+              |   object at index 3 failed to match:
+              |      expected: "A"
+              |           got: "C"
+              |
+              |      (compared using ==)
+              EOS
+            end
+          end
+
+        end
+      end
+    end
+
+    context 'when composed matcher is given' do
+
+      describe 'expect(...).to all(expected)' do
+        it 'can pass' do
+          expect([3, 4, 7, 8]).to all( be_between(2, 5).or be_between(6, 9) )
+        end
+      end
+
+      describe 'failure message' do
+
+        context 'when a single object fails' do
+          it 'returns the index of the failed object for the composed matcher' do
+            expect {
+              expect([3, 4, 7, 28]).to all( be_between(2, 5).or be_between(6, 9) )
+            }.to fail_with(dedent <<-EOS)
+              |expected [3, 4, 7, 28] to all be between 2 and 5 (inclusive) or be between 6 and 9 (inclusive)
+              |
+              |   object at index 3 failed to match:
+              |      expected 28 to be between 2 and 5 (inclusive) or expected 28 to be between 6 and 9 (inclusive)
+            EOS
+          end
+        end
+
+        context 'when a multiple objects fails' do
+          it 'returns the indexes of the failed objects for the composed matcher, not just the first one' do
+            expect {
+              expect([3, 4, 27, 22]).to all( be_between(2, 5).or be_between(6, 9) )
+            }.to fail_with(dedent <<-EOS)
+              |expected [3, 4, 27, 22] to all be between 2 and 5 (inclusive) or be between 6 and 9 (inclusive)
+              |
+              |   object at index 2 failed to match:
+              |      expected 27 to be between 2 and 5 (inclusive) or expected 27 to be between 6 and 9 (inclusive)
+              |
+              |   object at index 3 failed to match:
+              |      expected 22 to be between 2 and 5 (inclusive) or expected 22 to be between 6 and 9 (inclusive)
+            EOS
+          end
+        end
+      end
+    end
+
+    shared_examples "making a copy" do |copy_method|
+      context "when making a copy via `#{copy_method}`" do
+
+        let(:base_matcher) { eq(3) }
+        let(:all_matcher) { all( base_matcher ) }
+        let(:copied_matcher) { all_matcher.__send__(copy_method) }
+
+        it "uses a copy of the base matcher" do
+          expect(copied_matcher).not_to equal(all_matcher)
+          expect(copied_matcher.matcher).not_to equal(base_matcher)
+          expect(copied_matcher.matcher).to be_a(base_matcher.class)
+          expect(copied_matcher.matcher.expected).to eq(3)
+        end
+
+        context 'when using a custom matcher' do
+
+          let(:base_matcher) { custom_include(3) }
+
+          it 'copies custom matchers properly so they can work even though they have singleton behavior' do
+            expect(copied_matcher).not_to equal(all_matcher)
+            expect(copied_matcher.matcher).not_to equal(base_matcher)
+            expect([[3]]).to copied_matcher
+            expect { expect([[4]]).to copied_matcher }.to fail_matching("expected [4]")
+          end
+
+        end
+
+      end
+    end
+
+    include_examples 'making a copy', :clone
+    include_examples 'making a copy', :dup
+
+    context "when using a matcher instance that memoizes state multiple times in a composed expression" do
+      it "works properly in spite of the memoization" do
+        expect {
+          expect(["foo", "bar", "a"]).to all( have_string_length(3) )
+        }.to fail
+      end
+
+      context "when passing a compound expression" do
+        it "works properly in spite of the memoization" do
+          expect {
+            expect(["foo", "bar", "a"]).to all( have_string_length(2).or have_string_length(3) )
+          }.to fail
+        end
+      end
+    end
+
+  end
+end

--- a/spec/rspec/matchers/built_in/compound_spec.rb
+++ b/spec/rspec/matchers/built_in/compound_spec.rb
@@ -1,8 +1,5 @@
 module RSpec::Matchers::BuiltIn
   describe Compound do
-    RSpec::Matchers.define :custom_include do |*args|
-      match { |actual| expect(actual).to include(*args) }
-    end
 
     shared_examples "making a copy" do |compound_method, copy_method|
       context "when making a copy via `#{copy_method}`" do

--- a/spec/rspec/matchers/composable_spec.rb
+++ b/spec/rspec/matchers/composable_spec.rb
@@ -19,17 +19,6 @@ module RSpec
         end
       end
 
-      RSpec::Matchers.define :have_string_length do |expected|
-        match do |actual|
-          @actual = actual
-          string_length == expected
-        end
-
-        def string_length
-          @string_length ||= @actual.length
-        end
-      end
-
       context "when using a matcher instance that memoizes state multiple times in a composed expression" do
         it "works properly in spite of the memoization" do
           expect(["foo", "bar", "a"]).to all_but_one(have_string_length(3))
@@ -46,19 +35,6 @@ module RSpec
 
       describe "cloning data structures containing matchers" do
         include Composable
-
-        RSpec::Matchers.define :be_a_clone_of do |expected|
-          match do |actual|
-            !actual.equal?(expected) &&
-             actual.class.equal?(expected.class) &&
-             state_of(actual) == state_of(expected)
-          end
-
-          def state_of(object)
-            ivar_names = object.instance_variables
-            Hash[ ivar_names.map { |n| [n, object.instance_variable_get(n)] } ]
-          end
-        end
 
         it "clones only the contained matchers" do
           matcher_1   = eq(1)

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -4,6 +4,34 @@ RSpec::Matchers.define :include_method do |expected|
   end
 end
 
+RSpec::Matchers.define :custom_include do |*args|
+  match { |actual| expect(actual).to include(*args) }
+end
+
+RSpec::Matchers.define :be_a_clone_of do |expected|
+  match do |actual|
+    !actual.equal?(expected) &&
+        actual.class.equal?(expected.class) &&
+        state_of(actual) == state_of(expected)
+  end
+
+  def state_of(object)
+    ivar_names = object.instance_variables
+    Hash[ ivar_names.map { |n| [n, object.instance_variable_get(n)] } ]
+  end
+end
+
+RSpec::Matchers.define :have_string_length do |expected|
+  match do |actual|
+    @actual = actual
+    string_length == expected
+  end
+
+  def string_length
+    @string_length ||= @actual.length
+  end
+end
+
 module RSpec
   module Matchers
     def fail


### PR DESCRIPTION
https://github.com/rspec/rspec-expectations/issues/483
- [x] add cuke
- [x] disallow the negative form for now (potentially reenable it after there's been a community discussion)
- [x] update changelog
- [x] define initialize_copy: (https://github.com/rspec/rspec-expectations/pull/518/files#diff-afbc871db3c3948bc68aca8db1cb90dbR29)
- [ ] Ensure the negation PR is ready to merge (an error message here mentions it)

**Changelog**
- Add support for `all` matcher, to allow you to match matcher on a collection.
  - `expect(stoplight.color).to ~eq("blue")`
  - `expect([1, 3, 5]).to all( be_odd.and be_an(Integer) )`
    (Adam Farhi)

as @myronmarston mentioned;
waiting for 3.1 release
