### PR TITLE
Stop using RSpec::Core::BacktraceFormatter directly.

### DIFF
--- a/lib/rspec/expectations/configuration.rb
+++ b/lib/rspec/expectations/configuration.rb
@@ -102,8 +102,8 @@ module RSpec
       # @!attribute [rw] backtrace_formatter
       attr_writer :backtrace_formatter
       def backtrace_formatter
-        @backtrace_formatter ||= if defined?(::RSpec::Core::BacktraceFormatter)
-          ::RSpec::Core::BacktraceFormatter
+        @backtrace_formatter ||= if defined?(::RSpec.configuration.backtrace_formatter)
+         ::RSpec.configuration.backtrace_formatter
         else
           NullBacktraceFormatter
         end

--- a/spec/rspec/expectations/configuration_spec.rb
+++ b/spec/rspec/expectations/configuration_spec.rb
@@ -26,13 +26,18 @@ module RSpec
         end
 
         it "defaults to rspec-core's backtrace formatter when rspec-core is loaded" do
-          expect(config.backtrace_formatter).to be(RSpec::Core::BacktraceFormatter)
+          expect(config.backtrace_formatter).to be(RSpec.configuration.backtrace_formatter)
           expect(formatted_backtrace).to eq(cleaned_backtrace)
         end
 
         it "defaults to a null formatter when rspec-core is not loaded" do
-          hide_const("RSpec::Core::BacktraceFormatter")
-          expect(formatted_backtrace).to eq(original_backtrace)
+          RSpec::Mocks.with_temporary_scope do
+            rspec_dup = ::RSpec.dup
+            class << rspec_dup; undef configuration; end
+            stub_const("RSpec", rspec_dup)
+
+            expect(formatted_backtrace).to eq(original_backtrace)
+          end
         end
 
         it "can be set to another backtrace formatter" do


### PR DESCRIPTION
We want to use the instance of it returned by
RSpec.configuration.backtrace_formatter instead.

See:

https://github.com/rspec/rspec-core/blob/c8afb7c25ee684cdd9de747b46f0cfa0ff18e1e2/lib/rspec/core/backtrace_formatter.rb#L7-L12
