### PR TITLE
Add support for key word argument matching with `respond_to`

### DIFF
--- a/lib/rspec/matchers/built_in/respond_to.rb
+++ b/lib/rspec/matchers/built_in/respond_to.rb
@@ -19,8 +19,6 @@ module RSpec
         # @example
         #   expect(obj).to respond_to(:message).with(1).argument
         #   expect(obj).to respond_to(:message).with(3).arguments
-        #   expect(obj).to respond_to(:message).with(:x).keyword_argument
-        #   expect(obj).to respond_to(:message).with(:x, :y).keyword_arguments
         def with(n)
           @expected_args = Array.new(n)
           @expected_arity = n

--- a/spec/rspec/matchers/built_in/respond_to_spec.rb
+++ b/spec/rspec/matchers/built_in/respond_to_spec.rb
@@ -288,3 +288,42 @@ describe "expect(...).not_to respond_to(:sym).with(2).arguments" do
   end
 end
 
+describe "support for keyword arguments", :if => RSpec::Support::RubyFeatures.kw_args_supported? do
+  describe "expect(...).to respond_to(:sym).with_keyword_argument(:x)" do
+    it "passes if target responds to :sym with :x keyword arg" do
+      obj = Object.new
+      eval("def obj.foo(x: nil); end")
+      puts obj.method(:foo).parameters
+      expect(obj).to respond_to(:foo).with_keyword_argument(:x => nil)
+    end
+
+    it "passes if target responds to one or more arguments" do
+      obj = Object.new
+      eval("def obj.foo(x: nil, y: nil); end")
+      expect(obj).to respond_to(:foo).with_keyword_argument(:x => nil)
+    end
+
+    it "fails if target does not respond to :sym" do
+      obj = Object.new
+      expect {
+        expect(obj).to respond_to(:foo).with_keyword_argument(:x => nil)
+      }.to fail_with(/expected .* to respond to :foo/)
+    end
+
+    it "fails if :sym expects 0 args" do
+      obj = Object.new
+      def obj.foo; end
+      expect {
+        expect(obj).to respond_to(:foo).with_keyword_argument(:x => nil)
+      }.to fail_with(/expected #<Object.*> to respond to :foo with argument x: nil/)
+    end
+
+    it "fails if :sym expects diffrent keyword args" do
+      obj = Object.new
+      eval("def obj.foo(y: nil, z: nil); end")
+      expect {
+        expect(obj).to respond_to(:foo).with_keyword_argument(:x => nil)
+      }.to fail_with(/expected #<Object.*> to respond to :foo with argument x: nil/)
+    end
+  end
+end


### PR DESCRIPTION
First pass at the final part of #471, probably needs more specs but WDYT in general?

(Fixes #471 so it'll autoclose)