### PR TITLE
Don't raise errors in exists matcher

### DIFF
--- a/lib/rspec/matchers/built_in/exist.rb
+++ b/lib/rspec/matchers/built_in/exist.rb
@@ -11,15 +11,51 @@ module RSpec
 
         def matches?(actual)
           @actual = actual
-          predicates = [:exist?, :exists?].select { |p| @actual.respond_to?(p) }
-          existence_values = predicates.map { |p| @actual.__send__(p, *@expected) }
-          uniq_truthy_values = existence_values.map { |v| !!v }.uniq
+          valid_test? && actual_exists?
+        end
 
+        def does_not_match?(actual)
+          @actual = actual
+          valid_test? && !actual_exists?
+        end
+
+        def failure_message
+          "expected #{@actual.inspect} to exist#{validity_message}"
+        end
+
+        def failure_message_when_negated
+          "expected #{@actual.inspect} not to exist#{validity_message}"
+        end
+
+      private
+
+        def valid_test?
+          uniq_truthy_values.size == 1
+        end
+
+        def actual_exists?
+          existence_values.first
+        end
+
+        def uniq_truthy_values
+          @uniq_truthy_values ||= existence_values.map { |v| !!v }.uniq
+        end
+
+        def existence_values
+          @existence_values ||= predicates.map { |p| @actual.__send__(p, *@expected) }
+        end
+
+        def predicates
+          @predicates ||= [:exist?, :exists?].select { |p| @actual.respond_to?(p) }
+        end
+
+        def validity_message
           case uniq_truthy_values.size
-          when 0; raise NoMethodError.new("#{@actual.inspect} does not respond to either #exist? or #exists?")
-          when 1; existence_values.first
-          else raise "#exist? and #exists? returned different values:\n\n" +
-            " exist?: #{existence_values.first}\n" +
+          when 0
+            " but it responds to neither #exist? nor #exists?"
+          when 2
+            " but #exist? and #exists? returned different values:\n\n"\
+            " exist?: #{existence_values.first}\n"\
             "exists?: #{existence_values.last}"
           end
         end

--- a/spec/rspec/matchers/built_in/exist_spec.rb
+++ b/spec/rspec/matchers/built_in/exist_spec.rb
@@ -11,10 +11,10 @@ describe "exist matcher" do
 
     [:to, :not_to].each do |expect_method|
       describe "expect(...).#{expect_method} exist" do
-        it "raises an error" do
+        it "fails" do
           expect {
             expect(subject).send(expect_method, exist)
-          }.to raise_error(NoMethodError)
+          }.to fail_with(/it responds to neither #exist\? nor #exists\?/)
         end
       end
     end
@@ -104,10 +104,10 @@ describe "exist matcher" do
 
       [:to, :not_to].each do |expect_method|
         describe "expect(...).#{expect_method} exist" do
-          it "raises an error" do
+          it "fails" do
             expect {
               expect(subject).send(expect_method, exist)
-            }.to raise_error(/#exist\? and #exists\? returned different values/)
+            }.to fail_with(/#exist\? and #exists\? returned different values/)
           end
         end
       end


### PR DESCRIPTION
Fail gracefully instead.

Implements #470
