### PR TITLE
Deprecation warning on predicate matcher

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,8 @@ Deprecations:
 * Deprecate `RSpec::Matchers::Pretty#expected_to_sentence`. (Myron Marston)
 * Deprecate `RSpec::Matchers::Configuration` in favor of
   `RSpec::Expectations::Configuration`. (Myron Marston)
+* Deprecate `be_xyz` predicate matcher on an object that doesn't respond to
+  `xyz?` or `xyzs?`. (Daniel Fone)
 
 ### 2.99.0.beta2 / 2014-02-17
 [full changelog](http://github.com/rspec/rspec-expectations/compare/v2.99.0.beta1...v2.99.0.beta2)

--- a/lib/rspec/matchers/built_in/be.rb
+++ b/lib/rspec/matchers/built_in/be.rb
@@ -149,13 +149,17 @@ it is a bit confusing.
           end
 
           begin
-            return @result = actual.__send__(predicate, *@args, &@block)
+            @result = actual.__send__(predicate, *@args, &@block)
+            check_respond_to(predicate)
+            return @result
           rescue NameError => predicate_missing_error
             "this needs to be here or rcov will not count this branch even though it's executed in a code example"
           end
 
           begin
-            return @result = actual.__send__(present_tense_predicate, *@args, &@block)
+            @result = actual.__send__(present_tense_predicate, *@args, &@block)
+            check_respond_to(present_tense_predicate)
+            return @result
           rescue NameError
             raise predicate_missing_error
           end
@@ -208,6 +212,13 @@ it is a bit confusing.
 
         def prefix_to_sentence
           split_words(@prefix)
+        end
+
+        def check_respond_to(method)
+          RSpec.deprecate(
+            "Matching with #{@prefix}#{@expected} on an object that doesn't respond to `#{method}`",
+            :replacement => "`respond_to_missing?` or `respond_to?` on your object"
+          ) unless actual.respond_to?(method)
         end
       end
     end

--- a/spec/rspec/matchers/be_spec.rb
+++ b/spec/rspec/matchers/be_spec.rb
@@ -38,6 +38,7 @@ describe "expect(...).to be_predicate" do
           true
         end
     end
+    allow(RSpec).to receive(:deprecate)
     expect(RSpec).to receive(:deprecate).with(
       "matching with be_happy on private method happy?",
       :replacement => "`expect(object.send(:happy?)).to be_true` or change the method's visibility to public",
@@ -66,6 +67,26 @@ describe "expect(...).to be_predicate" do
     matcher = be_happy
     value = double(:happy? => false)
     expect(matcher == value).to be false
+  end
+
+  it 'warns of deprecation when actual does not respond to :predicate?' do
+    oddly_happy_class = Class.new do
+      def method_missing(method)
+        return true if method == :happy?
+      end
+    end
+    expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /Matching with be_happy on an object that doesn't respond to `happy\?`/)
+    expect(oddly_happy_class.new).to be_happy
+  end
+
+  it 'does not warn of deprecation when actual responds to present tense predicate' do
+    present_happy_class = Class.new do
+      def exists?
+        true
+      end
+    end
+    expect_no_deprecation
+    expect(present_happy_class.new).to be_exist
   end
 end
 


### PR DESCRIPTION
When `actual` is a poorly behaved object and does not respond to
:predicate? In light of #513
