### PR TITLE
Prefer __send__ to send.

### DIFF
--- a/lib/rspec/matchers/built_in/yield.rb
+++ b/lib/rspec/matchers/built_in/yield.rb
@@ -124,7 +124,7 @@ module RSpec
           probe = YieldProbe.probe(block)
 
           if @expectation_type
-            probe.num_yields.send(@expectation_type, @expected_yields_count)
+            probe.num_yields.__send__(@expectation_type, @expected_yields_count)
           else
             probe.yielded_once?(:yield_control)
           end


### PR DESCRIPTION
It works more consistently (as user objects may have
a custom definition of `send` but redefining `__send__`
issues a warning).
