### PR TITLE
Pass original message to custom failure message

### DIFF
--- a/lib/rspec/expectations/handler.rb
+++ b/lib/rspec/expectations/handler.rb
@@ -29,7 +29,7 @@ module RSpec
       end
 
       def self.handle_failure(matcher, message, failure_message_method)
-        message = message.call if message.respond_to?(:call)
+        message = message.call(matcher.__send__(failure_message_method)) if message.respond_to?(:call)
         message ||= matcher.__send__(failure_message_method)
 
         if matcher.respond_to?(:diffable?) && matcher.diffable?

--- a/spec/rspec/expectations/handler_spec.rb
+++ b/spec/rspec/expectations/handler_spec.rb
@@ -113,6 +113,18 @@ module RSpec
 
           RSpec::Expectations::PositiveExpectationHandler.handle_matcher(actual, matcher, failure_message)
         end
+
+        it "passes the original message to the custom failure message when one is provided as a callable object" do
+          matcher = double("matcher", :failure_message => "message", :matches? => false)
+          actual = Object.new
+
+          failure_message = double("failure message")
+          allow(failure_message).to receive(:call) { |arg1| "custom #{arg1}" }
+
+          expect(::RSpec::Expectations).to receive(:fail_with).with("custom message")
+
+          RSpec::Expectations::PositiveExpectationHandler.handle_matcher(actual, matcher, failure_message)
+        end
       end
     end
 
@@ -174,6 +186,18 @@ module RSpec
           expect(::RSpec::Expectations).to receive(:fail_with).with("custom")
 
           RSpec::Expectations::NegativeExpectationHandler.handle_matcher(actual, matcher, failure_message)
+        end
+
+        it "passes the original message to the custom failure message when one is provided as a callable object" do
+          matcher = double("matcher", :failure_message => "message", :matches? => false)
+          actual = Object.new
+
+          failure_message = double("failure message")
+          allow(failure_message).to receive(:call) { |arg1| "custom #{arg1}" }
+
+          expect(::RSpec::Expectations).to receive(:fail_with).with("custom message")
+
+          RSpec::Expectations::PositiveExpectationHandler.handle_matcher(actual, matcher, failure_message)
         end
       end
     end


### PR DESCRIPTION
When you set the custom failure message of a matcher to a Proc, the
original/default failure message is now passed to the Proc as
block argument.

The impetus for this was wanting to add more detail to a failed test's output
without completely ditching the nicely formatted default failure message.
