### PR TITLE
Improve negated failure message of `output` matcher.

### DIFF
--- a/features/built_in_matchers/output.feature
+++ b/features/built_in_matchers/output.feature
@@ -36,7 +36,7 @@ Feature: output matcher
     Then the output should contain all of these:
       | 11 examples, 5 failures                                      |
       | expected block to output to stdout, but did not              |
-      | expected block to not output to stdout, but did              |
+      | expected block to not output to stdout, but output "foo"     |
       | expected block to output "bar" to stdout, but output "foo"   |
       | expected block to output "foo" to stdout, but output nothing |
       | expected block to output /bar/ to stdout, but output "foo"   |
@@ -64,7 +64,7 @@ Feature: output matcher
     Then the output should contain all of these:
       | 11 examples, 5 failures                                      |
       | expected block to output to stderr, but did not              |
-      | expected block to not output to stderr, but did              |
+      | expected block to not output to stderr, but output "foo      |
       | expected block to output "bar" to stderr, but output "foo\n" |
       | expected block to output "foo" to stderr, but output nothing |
       | expected block to output /bar/ to stderr, but output "foo\n" |

--- a/lib/rspec/matchers/built_in/output.rb
+++ b/lib/rspec/matchers/built_in/output.rb
@@ -80,13 +80,18 @@ module RSpec
 
         def positive_failure_reason
           return "was not a block" unless Proc === @block
-          return "output #{captured? ? @actual.inspect : 'nothing'}" if @expected
+          return "output #{actual_output_description}" if @expected
           "did not"
         end
 
         def negative_failure_reason
           return "was not a block" unless Proc === @block
-          "did"
+          "output #{actual_output_description}"
+        end
+
+        def actual_output_description
+          return "nothing" unless captured?
+          @actual.inspect
         end
       end
 

--- a/spec/rspec/matchers/built_in/output_spec.rb
+++ b/spec/rspec/matchers/built_in/output_spec.rb
@@ -29,7 +29,7 @@ shared_examples "output_to_stream" do |stream_name|
     it "fails if the block outputs to #{stream_name}" do
       expect {
         expect { stream.print 'foo' }.not_to matcher
-      }.to fail_with("expected block to not output to #{stream_name}, but did")
+      }.to fail_with("expected block to not output to #{stream_name}, but output \"foo\"")
     end
   end
 
@@ -63,7 +63,7 @@ shared_examples "output_to_stream" do |stream_name|
     it "fails if the block outputs the same string to #{stream_name}" do
       expect {
         expect { stream.print 'foo' }.to_not matcher('foo')
-      }.to fail_with("expected block to not output \"foo\" to #{stream_name}, but did")
+      }.to fail_with("expected block to not output \"foo\" to #{stream_name}, but output \"foo\"")
     end
   end
 
@@ -97,7 +97,7 @@ shared_examples "output_to_stream" do |stream_name|
     it "fails if the block outputs a string to #{stream_name} that matches the regex" do
       expect {
         expect { stream.print 'foo' }.to_not matcher(/foo/)
-      }.to fail_matching("expected block to not output /foo/ to #{stream_name}, but did\nDiff")
+      }.to fail_matching("expected block to not output /foo/ to #{stream_name}, but output \"foo\"\nDiff")
     end
   end
 
@@ -121,7 +121,7 @@ shared_examples "output_to_stream" do |stream_name|
     it "fails if the block outputs a string to #{stream_name} that passes the given matcher" do
       expect {
         expect { stream.print 'foo' }.to_not matcher(a_string_starting_with("f"))
-      }.to fail_matching("expected block to not output a string starting with \"f\" to #{stream_name}, but did\nDiff")
+      }.to fail_matching("expected block to not output a string starting with \"f\" to #{stream_name}, but output \"foo\"\nDiff")
     end
   end
 end


### PR DESCRIPTION
"expected block to not output to stderr, but did" is
not super helpful -- you'll want to know what was output.
