### PR TITLE
Pass matcher to message proc

### DIFF
--- a/lib/rspec/expectations/handler.rb
+++ b/lib/rspec/expectations/handler.rb
@@ -29,7 +29,7 @@ module RSpec
       end
 
       def self.handle_failure(matcher, message, failure_message_method)
-        message = message.call if message.respond_to?(:call)
+        message = message.arity > 0 ? message.call(matcher) : message.call if message.respond_to?(:call)
         message ||= matcher.__send__(failure_message_method)
 
         if matcher.respond_to?(:diffable?) && matcher.diffable?

--- a/spec/rspec/expectations/handler_spec.rb
+++ b/spec/rspec/expectations/handler_spec.rb
@@ -103,12 +103,25 @@ module RSpec
           RSpec::Expectations::PositiveExpectationHandler.handle_matcher(actual, matcher, "custom")
         end
 
-        it "uses the custom failure message when one is provided as a callable object" do
+        it "uses the custom failure message when one is provided as a callable object with no argument" do
           matcher = double("matcher", :failure_message => "message", :matches? => false)
           actual = Object.new
 
-          failure_message = double("failure message", :call => "custom")
+          failure_message = double("failure message", :arity => 0)
 
+          expect(failure_message).to receive(:call).with(no_args).and_return("custom")
+          expect(::RSpec::Expectations).to receive(:fail_with).with("custom")
+
+          RSpec::Expectations::PositiveExpectationHandler.handle_matcher(actual, matcher, failure_message)
+        end
+
+        it "uses the custom failure message when one is provided as a callable object with an argument" do
+          matcher = double("matcher", :failure_message => "message", :matches? => false)
+          actual = Object.new
+
+          failure_message = double("failure message", :arity => 1)
+
+          expect(failure_message).to receive(:call).with(matcher).and_return("custom")
           expect(::RSpec::Expectations).to receive(:fail_with).with("custom")
 
           RSpec::Expectations::PositiveExpectationHandler.handle_matcher(actual, matcher, failure_message)
@@ -165,12 +178,25 @@ module RSpec
           RSpec::Expectations::NegativeExpectationHandler.handle_matcher(actual, matcher, "custom")
         end
 
-        it "uses the custom failure message when one is provided as a callable object" do
+        it "uses the custom failure message when one is provided as a callable object with no argument" do
+          matcher = double("matcher", :failure_message => "message", :matches? => false)
+          actual = Object.new
+
+          failure_message = double("failure message", :arity => 0)
+
+          expect(failure_message).to receive(:call).with(no_args).and_return("custom")
+          expect(::RSpec::Expectations).to receive(:fail_with).with("custom")
+
+          RSpec::Expectations::PositiveExpectationHandler.handle_matcher(actual, matcher, failure_message)
+        end
+
+        it "uses the custom failure message when one is provided as a callable object with an argument" do
           matcher = double("matcher", :failure_message_when_negated => "message", :matches? => true)
           actual = Object.new
 
-          failure_message = double("failure message", :call => "custom")
+          failure_message = double("failure message", :arity => 1)
 
+          expect(failure_message).to receive(:call).with(matcher).and_return("custom")
           expect(::RSpec::Expectations).to receive(:fail_with).with("custom")
 
           RSpec::Expectations::NegativeExpectationHandler.handle_matcher(actual, matcher, failure_message)


### PR DESCRIPTION
Hi,

I wanted to do like this.

``` rb
expect(something).to eq('other thing'), lambda { |matcher| "\n[step 1]\n#{matcher.failure_message}" }
```

However, the failure message caller object doesn't pass the matcher so I can't use it in the proc. Could you consider to merge this feature?
