### PR TITLE
Stop supporting `require ‘rspec-expectations’`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,8 @@ Breaking Changes for 3.0.0:
   (Adrian Gonzalez)
 * Block matchers must now implement `supports_block_expectations?`.
   (Myron Marston)
+* Stop supporting `require 'rspec-expectations'`.
+  Use `require 'rspec/expectations'` instead. (Myron Marston)
 
 Bug Fixes:
 

--- a/lib/rspec-expectations.rb
+++ b/lib/rspec-expectations.rb
@@ -1,1 +1,0 @@
-require "rspec/expectations"


### PR DESCRIPTION
Use `require ‘rspec/expectations’` instead.

We don't have `rspec-mocks.rb` or `rspec-core.rb` files for those libs.  We don't need it for this lib, and its presence has made us do some one-off work arounds:

https://github.com/rspec/rspec-support/blob/17bd12c37c4ae608490afd2db75d7b04b3cc7171/spec/rspec/support/caller_filter_spec.rb#L27

https://github.com/rspec/rspec-expectations/blob/2ef8bc86e7523616cb3719004fe08a6bfe55f741/.rubocop.yml#L34
