### PR TITLE
Update `errors_on` deprecation message

### DIFF
--- a/lib/rspec/matchers/built_in/have.rb
+++ b/lib/rspec/matchers/built_in/have.rb
@@ -142,7 +142,15 @@ EOF
         def print_deprecation_message(query_method)
           deprecation_message = "the rspec-collection_matchers gem "
           deprecation_message << "or replace your expectation with something like "
-          deprecation_message << "`expect(#{cardinality_expression(query_method)}).#{expectation_format_method} #{suggested_matcher_expression}`"
+          if defined?(RSpec::Rails) && /\.errors_on/ =~ original_matcher_expression
+            deprecation_message << "\n\n"
+            deprecation_message << "    #{target_expression}.valid?"
+            deprecation_message << "\n"
+            deprecation_message << "    expect(#{cardinality_expression(query_method)}).#{expectation_format_method} #{suggested_matcher_expression}"
+            deprecation_message << "\n\n"
+          else
+            deprecation_message << "`expect(#{cardinality_expression(query_method)}).#{expectation_format_method} #{suggested_matcher_expression}`"
+          end
 
           RSpec.deprecate("`#{expectation_expression(query_method)}`",
             :replacement => deprecation_message,

--- a/spec/rspec/matchers/have_spec.rb
+++ b/spec/rspec/matchers/have_spec.rb
@@ -532,6 +532,58 @@ EOF
       end
     end
 
+    context "when the target is a Rails record" do
+      class TheModel
+        attr_reader :errors
+
+        def initialize(errors)
+          @errors = {}
+          @errors[:attr] = Array(errors)
+        end
+
+        def errors_on(attr, _ignore_opts = {})
+          Array(@errors[attr]).flatten.compact
+        end
+      end
+
+      it "prints a specific message for the positive expectation format" do
+        stub_const "RSpec::Rails", Module.new
+
+        expectation_expression = "expect(collection_owner).to have(2).errors_on"
+
+        message = "the rspec-collection_matchers gem " +
+                  "or replace your expectation with something like " +
+                  "\n\n" +
+                  "    collection_owner.valid?\n" +
+                  "    expect(collection_owner.errors_on.size).to eq(2)" +
+                  "\n\n"
+
+        expect_have_deprecation(expectation_expression, message)
+
+        target = TheModel.new(%w(foo bar))
+        expect(target).to have(2).errors_on(:attr)
+      end
+
+      it "prints a specific message for the negative expectation format" do
+        stub_const "RSpec::Rails", Module.new
+
+        expectation_expression = "expect(collection_owner).not_to have(2).errors_on"
+
+        message = "the rspec-collection_matchers gem " +
+                  "or replace your expectation with something like " +
+                  "\n\n" +
+                  "    collection_owner.valid?\n" +
+                  "    expect(collection_owner.errors_on.size).to_not eq(2)" +
+                  "\n\n"
+
+
+        expect_have_deprecation(expectation_expression, message)
+
+        target = TheModel.new('foo')
+        expect(target).not_to have(2).errors_on(:attr)
+      end
+    end
+
     context "when the target is an enumerator" do
       it "prints a specific message for the positive expectation format" do
         target = %w[a b c].to_enum(:each)


### PR DESCRIPTION
Special case handling for deprecation message when used with `errors_on`.
- The `errors_on` method is now provided by `rspec-collection_matchers` gem (previously from `rspec-rails`)
- Conversion from previous matcher to new methods is not straight forward if gem is not used
- Fixes rspec/rspec-rails#1026.
