### PR TITLE
Add missing require.

### DIFF
--- a/lib/rspec/matchers/built_in/respond_to.rb
+++ b/lib/rspec/matchers/built_in/respond_to.rb
@@ -1,3 +1,5 @@
+RSpec::Support.require_rspec_support "method_signature_verifier"
+
 module RSpec
   module Matchers
     module BuiltIn


### PR DESCRIPTION
This file uses rspec-support’s MethodSignatureVerifier
but does not load it. It was working because rspec-mocks
loads it so it was loaded in the same process. It would
fail for users using rspec-expectations but not rspec-mocks,
though.
