### PR TITLE
Fix regression in `contain_exactly`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,14 @@ Bug Fixes:
 * Rename private `LegacyMacherAdapter` constant to `LegacyMatcherAdapter`
   to fix typo. (Abdelkader Boudih, #563)
 
+### 3.0.2 Development
+[Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.0.1...3-0-maintenance)
+
+Bug Fixes:
+
+* Fix regression in `contain_exactly` (AKA `match_array`) that caused it
+  to wrongly pass when the expected array was empty. (Myron Marston, #581)
+
 ### 3.0.1 / 2014-06-12
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.0.0...v3.0.1)
 

--- a/lib/rspec/matchers/built_in/contain_exactly.rb
+++ b/lib/rspec/matchers/built_in/contain_exactly.rb
@@ -79,15 +79,11 @@ module RSpec
 
         def pairings_maximizer
           @pairings_maximizer ||= begin
-            expected_matches = {}
-            actual_matches   = {}
+            expected_matches = Hash[Array.new(expected.size) { |i| [i, []] }]
+            actual_matches   = Hash[Array.new(actual.size)   { |i| [i, []] }]
 
             expected.each_with_index do |e, ei|
-              expected_matches[ei] ||= []
-
               actual.each_with_index do |a, ai|
-                actual_matches[ai] ||= []
-
                 # Normally we'd call `values_match?(e, a)` here but that contains
                 # some extra checks we don't need (e.g. to support nested data
                 # structures), and given that it's called N*M times here, it helps

--- a/spec/rspec/matchers/built_in/contain_exactly_spec.rb
+++ b/spec/rspec/matchers/built_in/contain_exactly_spec.rb
@@ -98,6 +98,26 @@ RSpec.describe "expect(array).to contain_exactly(*other_array)" do
     expect([1,3,2]).to contain_exactly(1,2,3)
   end
 
+  it 'fails if the expected array is empty and the actual array is non-empty' do
+    expect {
+      expect([1]).to contain_exactly()
+    }.to fail_with(<<-MESSAGE)
+expected collection contained:  []
+actual collection contained:    [1]
+the extra elements were:        [1]
+MESSAGE
+  end
+
+  it 'fails if the actual array is empty and the expected array is non-empty' do
+    expect {
+      expect([]).to contain_exactly(1)
+    }.to fail_with(<<-MESSAGE)
+expected collection contained:  [1]
+actual collection contained:    []
+the missing elements were:      [1]
+MESSAGE
+  end
+
   def timeout_if_not_debugging(time)
     return yield if defined?(::Debugger)
     Timeout.timeout(time) { yield }


### PR DESCRIPTION
The new implementation in 3.0.0 allowed this to pass:

expect([1]).to contain_exactly()

The problem was that the `actual_matches` hash was lazily
initialized in an `expected.each_with_index` loop. This
meant that if `expected` was empty, `actual_matches` would
be made empty as well, causing the match logic to pass.

Fixes #581.
