### PR TITLE
Add more helpful error message for `change`.

### DIFF
--- a/lib/rspec/matchers/built_in/change.rb
+++ b/lib/rspec/matchers/built_in/change.rb
@@ -298,6 +298,14 @@ module RSpec
         attr_reader :message, :actual_before, :actual_after
 
         def initialize(receiver=nil, message=nil, &block)
+          if receiver && !message
+            raise(
+              ArgumentError,
+              "`change` requires either an object and message " \
+              "(`change(obj, :msg)`) or a block (`change { }`). " \
+              "You passed an object but no message."
+            )
+          end
           @message    = message ? "##{message}" : "result"
           @value_proc = block || lambda { receiver.__send__(message) }
         end

--- a/spec/rspec/matchers/built_in/change_spec.rb
+++ b/spec/rspec/matchers/built_in/change_spec.rb
@@ -175,7 +175,14 @@ RSpec.describe "expect { ... }.to change(actual, message)" do
         expect {}.to change(@instance, :some_value)
       end.to fail_with(/^expected #some_value to have changed, but is still/)
     end
+  end
 
+  context "with a missing message" do
+    it "fails with an ArgumentError" do
+      expect do
+        expect {}.to change(:receiver)
+      end.to raise_error(ArgumentError, /^`change` requires either an object and message/)
+    end
   end
 end
 


### PR DESCRIPTION
When change was called with a single argument and no block, the
message to be sent to the receiver defaulted to nil, causing an
unclear failure message.

Fixes #584.
