### PR TITLE
Feature: Add a 'deeply_include' matcher

### DIFF
--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -573,12 +573,16 @@ module RSpec
     #   expect("spread").to     include("read")
     #   expect("spread").not_to include("red")
     def include(*expected)
-      BuiltIn::Include.new(*expected)
+      BuiltIn::Include.new(false, *expected)
     end
     alias_matcher :a_collection_including, :include
     alias_matcher :a_string_including,     :include
     alias_matcher :a_hash_including,       :include
     alias_matcher :including,              :include
+
+    def deeply_include(*expected)
+      BuiltIn::Include.new(true, *expected)
+    end
 
     # Passes if actual all expected objects pass. This works for
     # any enumerable object.

--- a/spec/rspec/matchers/built_in/include_spec.rb
+++ b/spec/rspec/matchers/built_in/include_spec.rb
@@ -77,6 +77,151 @@ RSpec.describe "#include matcher" do
         }.to fail_matching(%Q|expected {} to include {:something => nil}|)
       end
 
+      context 'when deeply compared' do
+        it 'passes for a Hash with a partial subhash' do
+          @actual_hash = {
+            foo: 'bar',
+            baz: {
+              'hello'   => 1,
+              'goodbye' => 2,
+            }
+          }
+
+          expect(@actual_hash).to deeply_include(
+            foo: 'bar',
+            baz: {
+              'hello' => 1,
+            }
+          )
+        end
+
+        it 'passes for a Hash with a very deeply nested partial subhash' do
+          @actual_hash = {
+            foo:      'bar',
+            baz:      {
+              'hello'   => {
+                '1'       => {
+                  '2'       => 'yes',
+                  '3'       => 'no',
+                  '4'       => [
+                    1,
+                    2,
+                  ]
+                }
+              },
+            }
+          }
+
+          expect(@actual_hash).to deeply_include(
+            foo:      'bar',
+            baz:      {
+              'hello'   => {
+                '1'       => {
+                  '2'       => 'yes',
+                  '3'       => 'no',
+                  '4'       => [
+                    1,
+                    2,
+                  ]
+                }
+              },
+            }
+          )
+        end
+
+        it 'passes for a Hash with a very deeply nested partial Array' do
+          @actual_hash = {
+            foo:      'bar',
+            baz:      {
+              'hello'   => {
+                '1'       => {
+                  '2'       => 'yes',
+                  '3'       => 'no',
+                  '4'       => [
+                    1,
+                    2,
+                  ]
+                }
+              },
+            }
+          }
+
+          expect(@actual_hash).to deeply_include(
+            foo: 'bar',
+            baz: {
+              'hello'   => {
+                '1'       => {
+                  '2'       => 'yes',
+                  '3'       => 'no',
+                  '4'       => [
+                    2,
+                  ]
+                }
+              },
+            }
+          )
+        end
+
+        it 'fails for a Hash with an incorrect partial subhash' do
+          @actual_hash = {
+            foo: 'bar',
+            baz: {
+              'hello'   => 1,
+              'goodbye' => 2,
+            }
+          }
+
+          @expected_hash = {
+            foo: 'bar',
+            baz: {
+              'hello' => 2,
+            }
+          }
+
+          expect {
+            expect(@actual_hash).not_to deeply_include(@expected_hash)
+          }.to fail_matching(%r|expected #{hash_inspect @actual_hash} not to include #{hash_inspect @expected_hash}|)
+        end
+
+        it 'fails for a Hash with an incorrect partial subhash' do
+          @actual_hash = {
+            foo: 'bar',
+            baz: {
+              'hello'   => {
+                '1'       => {
+                  '2'       => 'yes',
+                  '3'       => 'no',
+                  '4'       => [
+                    1,
+                    2,
+                  ]
+                }
+              },
+            }
+          }
+
+          @expected_hash = {
+            foo: 'bar',
+            baz: {
+              'hello'   => {
+                '1'       => {
+                  '2'       => 'yes',
+                  '3'       => 'no',
+                  '4'       => [
+                    5,
+                    2,
+                  ]
+                }
+              },
+            }
+          }
+
+          expect {
+            expect(@actual_hash).not_to deeply_include(@expected_hash)
+          }.to fail_matching(%r|expected {:foo => "bar", :baz => {"hello" => {"1" => {"2" => "yes", "3" => "no", "4" => \[1, 2\]}}}} not to include {:foo => "bar", :baz => {"hello" => {"1" => {"2" => "yes", "3" => "no", "4" => \[5, 2\]}}}}|)
+        end
+      end
+
       it 'works even when an entry in the hash overrides #send' do
         hash = { :key => 'value' }
         def hash.send; :sent; end


### PR DESCRIPTION
We've had many cases in the past where, when comparing a Hash against another
Hash, we want the 'include' comparison to continue onto any subhashes in the
original Hash.

For example, with the current implementation:

``` ruby
it 'knows when one hash is included in another' do
  @actual_hash = {
    foo: 'bar',
    baz: {
      'hello'   => 1,
      'goodbye' => 2,
    }
  }

  expect(@actual_hash).to include(
    foo: 'bar',
    baz: {
      'hello' => 1,
      'goodbye' => 2,
    }
  )
end
```

This passes correctly, but for us, there are often times when the Hash that is
returned contains keys that we don't necessarily care about, and sometimes those
keys are nested a level or two deep.

For example, if we are testing that we receive the proper data from a response
Hash from an API, there may be a `request_id` in there which is unique and that
we don't actually care about, but there are other items which we want to match
against.

Using the current implementation we'd have to do something like this:

``` ruby
it 'knows when one hash is included in another' do
  @response_hash = {
    products: [
      {
        guid:       'bbd7fa10f15bb771c33b32545ca95e16',
        name:       'Rubber Duckies',
        category:   'Toys',
        materials:  [
          'Yellow Lead-Free Paint',
          'Rubber',
          'Duckies'
        ]
      }
    ]
  }

  first_product = @response_hash['products'][0]

  expect(first_product).to include(
    name:     'Rubber Duckies',
    category: 'Toys',
  )

  expect(first_product['materials']).to include([
    'Rubber',
    'Duckies'
  ])
end
```

With the changes in this commit, we've added a `deeply_include` matcher which
would allow the above example to be written thusly:

``` ruby
it 'knows when one hash is included in another' do
  @response_hash = {
    products: [
      {
        guid:       'bbd7fa10f15bb771c33b32545ca95e16',
        name:       'Rubber Duckies',
        category:   'Toys',
        materials:  [
          'Yellow Lead-Free Paint',
          'Rubber',
          'Duckies'
        ]
      }
    ]
  }

  expect(@response_hash).to deeply_include(
    products: [{
      name:       'Rubber Duckies',
      category:   'Toys',
      materials:  [
        'Rubber',
        'Duckies'
      ]
    }]
  )
end
```

Obviously this implementation is... very poor, but I wanted to get the
conversation started and I'll make any necessary changes to get it in line with
what you all would like.

Our initial thoughts are that we may just create a subclass of the `Include`
matcher for the `deep` implementation.

Additionally the matcher will need to be refactored so that we can implement
a better recursive strategy than instantiating new instances on every recursive
loop.
