### PR TITLE
Fix `should =~ list` when `list` has no `=~` method.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@ Bug Fixes:
 * Fix regression in `Expectations#method_handle_for` where proxy objects
   with method delegated would wrongly not return a method handle.
   (Jon Rowe, #594)
+* Fix issue with detection of generic operator matchers so they work
+  correctly when undefined. (Myron Marston, #597)
 
 ### 2.99.1 / 2014-06-19
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v2.99.0...v2.99.1)

--- a/spec/rspec/matchers/match_array_spec.rb
+++ b/spec/rspec/matchers/match_array_spec.rb
@@ -47,6 +47,19 @@ describe "should =~ array", :uses_should do
       array.should =~ array
     end
   end
+
+  context "when the array undefines `=~`" do
+    it 'still works' do
+      array_klass = Class.new(Array) { undef =~ }
+      array = array_klass.new([1, 2])
+
+      array.should =~ [1, 2]
+
+      expect {
+        array.should =~ [0, 1, 2]
+      }.to fail_with(/expected collection contained/)
+    end
+  end
 end
 
 describe "should_not =~ [:with, :multiple, :args]", :uses_should do


### PR DESCRIPTION
This is a backport of #597 to 2.99.  I would have cherry-picked but it wouldn't cherry pick cleanly.  Will merge when green.
