### PR TITLE
add chained expectation descriptions to the default descriptions of custom matchers with fluent interfaces

### DIFF
--- a/features/custom_matchers/define_matcher_with_fluent_interface.feature
+++ b/features/custom_matchers/define_matcher_with_fluent_interface.feature
@@ -10,15 +10,42 @@ Feature: define matcher with fluent interface
           (actual > first) && (actual < @second)
         end
 
-        chain :but_smaller_than do |second|
+        chain :and_smaller_than do |second|
           @second = second
         end
       end
 
       RSpec.describe 5 do
-        it { is_expected.to be_bigger_than(4).but_smaller_than(6) }
+        it { is_expected.to be_bigger_than(4).and_smaller_than(6) }
       end
       """
     When I run `rspec between_spec.rb --format documentation`
     Then the output should contain "1 example, 0 failures"
     And  the output should contain "should be bigger than 4"
+
+    Scenario: include_chain_clauses_in_custom_matcher_descriptions configured to true, and chained method with argument
+      Given a file named "between_spec.rb" with:
+        """ruby
+        RSpec.configure do |config|
+          config.expect_with :rspec do |c|
+            c.include_chain_clauses_in_custom_matcher_descriptions = true
+          end
+        end
+
+        RSpec::Matchers.define :be_bigger_than do |first|
+          match do |actual|
+            (actual > first) && (actual < @second)
+          end
+
+          chain :and_smaller_than do |second|
+            @second = second
+          end
+        end
+
+        RSpec.describe 5 do
+          it { is_expected.to be_bigger_than(4).and_smaller_than(6) }
+        end
+        """
+      When I run `rspec between_spec.rb --format documentation`
+      Then the output should contain "1 example, 0 failures"
+      And  the output should contain "should be bigger than 4 and smaller than 6"

--- a/lib/rspec/expectations/configuration.rb
+++ b/lib/rspec/expectations/configuration.rb
@@ -107,6 +107,17 @@ module RSpec
                                  end
       end
 
+      # Sets if custom matcher descriptions and failure messages
+      # should include clauses from methods defined using `chain`.
+      attr_writer :include_chain_clauses_in_custom_matcher_descriptions
+
+      # Indicates whether or not custom matcher descriptions and failure messages
+      # should include clauses from methods defined using `chain`. It is
+      # false by default for backwards compatibility.
+      def include_chain_clauses_in_custom_matcher_descriptions?
+        @include_chain_clauses_in_custom_matcher_descriptions ||= false
+      end
+
       # @private
       def reset_syntaxes_to_default
         self.syntax = [:should, :expect]

--- a/spec/rspec/expectations/configuration_spec.rb
+++ b/spec/rspec/expectations/configuration_spec.rb
@@ -64,6 +64,27 @@ module RSpec
         end
       end
 
+      describe "#include_chain_clauses_in_custom_matcher_descriptions?" do
+        after do
+          RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions = nil
+        end
+
+        it "is false by default" do
+          expect(RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions?).to be false
+        end
+
+        it "can be set to true" do
+          RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions = true
+          expect(RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions?).to be true
+        end
+
+        it "can be set back to false" do
+          RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions = true
+          RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions = false
+          expect(RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions?).to be false
+        end
+      end
+
       shared_examples "configuring the expectation syntax" do
         before do
           @orig_syntax = RSpec::Matchers.configuration.syntax
@@ -207,4 +228,3 @@ module RSpec
     end
   end
 end
-

--- a/spec/rspec/matchers/built_in/raise_error_spec.rb
+++ b/spec/rspec/matchers/built_in/raise_error_spec.rb
@@ -394,6 +394,13 @@ RSpec.describe "Composing matchers with `raise_error`" do
   end
 
   describe "expect { }.to raise_error(matcher)" do
+    before do
+      RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions = true
+    end
+    after do
+      RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions = nil
+    end
+
     it 'passes when the matcher matches the raised error' do
       expect { raise FooError }.to raise_error(an_error_with_attribute(:foo).equal_to(:bar))
     end

--- a/spec/rspec/matchers/dsl_spec.rb
+++ b/spec/rspec/matchers/dsl_spec.rb
@@ -232,64 +232,101 @@ module RSpec::Matchers::DSL
       end
 
       it "provides a default positive expectation failure message" do
-        matcher.matches?(8)
-        expect(matcher.failure_message).to eq "expected 8 to be a multiple of 3"
+        expect { expect(8).to matcher }.to fail_with 'expected 8 to be a multiple of 3'
       end
 
       it "provides a default negative expectation failure message" do
-        matcher.matches?(9)
-        expect(matcher.failure_message_when_negated).to eq "expected 9 not to be a multiple of 3"
+        expect { expect(9).to_not matcher }.to fail_with 'expected 9 not to be a multiple of 3'
       end
     end
 
-    context 'without overrides with chained matchers' do
+    context "without overrides with chained matchers" do
       let(:matcher) do
-        new_matcher(:be_bigger_than, 5) do |first|
-          match do |actual|
-            (actual > first) &&
-            (!defined? @ceiling || actual < @second) &&
-            (!defined? @divisor || @divisor % actual == 0)
+        new_matcher(:be_bigger_than, 5) do |five|
+          match do |to_match|
+            (to_match > five) && smaller_than_ceiling?(to_match) && divisible_by_divisor?(to_match)
           end
 
-         chain :but_smaller_than do |ceiling|
+          match_when_negated do |to_match|
+            (to_match <= five) || greater_than_ceiling(to_match) && not_divisible_by_divisor?(to_match)
+          end
+
+          chain :and_smaller_than do |ceiling|
             @ceiling = ceiling
           end
 
-          chain :but_divisible_by do |divisor|
+          chain :and_divisible_by do |divisor|
             @divisor = divisor
+          end
+
+          private
+
+          def smaller_than_ceiling?(to_match)
+            to_match < @ceiling
+          end
+
+          def greater_than_ceiling(to_match)
+            to_match >= @ceiling
+          end
+
+          def divisible_by_divisor?(to_match)
+            @divisor % to_match == 0
+          end
+
+          def not_divisible_by_divisor?(to_match)
+            @divisor % to_match != 0
           end
         end
       end
 
       context "when the matchers are chained" do
-        it "provides a default description that includes the chained matchers' descriptions" do
-          expect(matcher.but_smaller_than(10).but_divisible_by(3).description).to eq "be bigger than 5 but smaller than 10 but divisible by 3"
+        context "without include_chain_clauses_in_custom_matcher_descriptions configured (by default)" do
+          let(:match) { matcher.and_smaller_than(10).and_divisible_by(3) }
+
+          it "provides a default description that does not include any of the chained matchers' descriptions" do
+            expect(match.description).to eq 'be bigger than 5'
+          end
+
+          it "provides a default positive expectation failure message that does not include any of the chained matchers' descriptions" do
+            expect { expect(8).to match }.to fail_with 'expected 8 to be bigger than 5'
+          end
+
+          it "provides a default negative expectation failure message that does not include the any of the chained matchers's descriptions" do
+            expect { expect(9).to_not match }.to fail_with 'expected 9 not to be bigger than 5'
+          end
         end
 
-        it "provides a default positive expectation failure message that includes the chained matchers' failures" do
-          matcher.but_smaller_than(10).but_divisible_by(3).matches?(8)
-          expect(matcher.failure_message).to eq "expected 8 to be bigger than 5 but smaller than 10 but divisible by 3"
+        context "with include_chain_clauses_in_custom_matcher_descriptions configured to be true" do
+          before do
+            RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions = true
+          end
+          after do
+            RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions = nil
+          end
+
+          it "provides a default description that includes the chained matchers' descriptions in they were used" do
+            expect(matcher.and_divisible_by(3).and_smaller_than(29).and_smaller_than(20).and_divisible_by(5).description).to \
+              eq 'be bigger than 5 and divisible by 3 and smaller than 29 and smaller than 20 and divisible by 5'
+          end
+
+          it "provides a default positive expectation failure message that includes the chained matchers' failures" do
+            expect { expect(30).to matcher.and_smaller_than(29).and_divisible_by(3) }.to \
+              fail_with 'expected 30 to be bigger than 5 and smaller than 29 and divisible by 3'
+          end
+
+          it "provides a default negative expectation failure message that includes the chained matchers' failures" do
+            expect { expect(21).to_not matcher.and_smaller_than(29).and_divisible_by(3) }.to \
+              fail_with 'expected 21 not to be bigger than 5 and smaller than 29 and divisible by 3'
+          end
         end
 
-        it "provides a default negative expectation failure message that includes the chained matchers' failures" do
-          matcher.but_smaller_than(10).but_divisible_by(3).matches?(9)
-          expect(matcher.failure_message_when_negated).to eq "expected 9 not to be bigger than 5 but smaller than 10 but divisible by 3"
-        end
-      end
+        it 'only decides if to include the chained clauses at the time description is invoked' do
+          matcher.and_divisible_by(3)
+          RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions = true
 
-      context "when none of the matchers are chained" do
-        it "provides a default description that does not include any of the chained matchers' descriptions" do
-          expect(matcher.description).to eq "be bigger than 5"
-        end
-
-        it "provides a default positive expectation failure message that does not include any of the chained matchers' descriptions" do
-          matcher.matches?(2)
-          expect(matcher.failure_message).to eq "expected 2 to be bigger than 5"
-        end
-
-        it "provides a default negative expectation failure message that does not include the any of the chained matchers's descriptions" do
-          matcher.matches?(10)
-          expect(matcher.failure_message_when_negated).to eq "expected 10 not to be bigger than 5"
+          expect(matcher.description).to eq 'be bigger than 5 and divisible by 3'
+          # cleanup
+          RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions = nil
         end
       end
     end
@@ -625,6 +662,46 @@ module RSpec::Matchers::DSL
         end
 
         expect(matcher.failure_message_when_negated).to eq("msg")
+      end
+    end
+
+    context "with description override and chained matcher" do
+      context "by default" do
+
+        let(:matcher) do
+          new_matcher(:be_even) do
+            match do |to_match|
+              (to_match % 2 == 0) && (to_match % @divisible_by == 0)
+            end
+
+            chain :and_divisible_by do |divisible_by|
+              @divisible_by = divisible_by
+            end
+
+            description { super() + " and divisible by #{@divisible_by}" }
+          end
+        end
+
+        context "without include_chain_clauses_in_custom_matcher_descriptions configured (by default)" do
+          it "provides a default description that does not include any of the chained matchers' descriptions" do
+            expect(matcher.and_divisible_by(10).description).to eq 'be even and divisible by 10'
+          end
+        end
+
+        context "with include_chain_clauses_in_custom_matcher_descriptions configured to true" do
+          before do
+            RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions = true
+          end
+
+          after do
+            RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions = nil
+          end
+
+          it "provides a default description that does includes the chained matchers' descriptions" do
+
+            expect(matcher.and_divisible_by(10).description).to eq 'be even and divisible by 10 and divisible by 10'
+          end
+        end
       end
     end
 


### PR DESCRIPTION
this fixes #532
