### PR TITLE
Alias corrected constant name to old misspelling.

### DIFF
--- a/lib/rspec/expectations/handler.rb
+++ b/lib/rspec/expectations/handler.rb
@@ -157,5 +157,11 @@ module RSpec
         end
       end
     end
+
+    # RSpec 3.0 was released with the class name misspelled. For SemVer compatibility,
+    # we will provide this misspelled alias until 4.0.
+    # @deprecated Use LegacyMatcherAdapter instead.
+    # @private
+    LegacyMacherAdapter = LegacyMatcherAdapter
   end
 end

--- a/spec/rspec/matchers/legacy_spec.rb
+++ b/spec/rspec/matchers/legacy_spec.rb
@@ -1,6 +1,11 @@
 module RSpec
   module Matchers
     RSpec.describe "Legacy matchers" do
+      it 'still provides a `LegacyMacherAdapter` constant because 3.0 was released with ' +
+         'it and it would be a SemVer violation to remove it before 4.0' do
+        expect(Expectations::LegacyMacherAdapter).to be(Expectations::LegacyMatcherAdapter)
+      end
+
       shared_examples "a matcher written against a legacy protocol" do |matcher_class|
         matcher = matcher_class.new
         before { allow_deprecation }


### PR DESCRIPTION
The misspelled version was released in 3.0. Removing
it in 3.x releases would be a SemVer violation, so we’ll
provide an alias.

This is a follow up to #563.
