### PR TITLE
Restore formatting for `all` failure messages.

### DIFF
--- a/features/built_in_matchers/all.feature
+++ b/features/built_in_matchers/all.feature
@@ -33,10 +33,10 @@ Feature: `all` matcher
       """
     When I run `rspec array_all_matcher_spec.rb`
     Then the output should contain all of these:
-      | 6 examples, 3 failures                          |
-      | expected [1, 3, 5] to all (be even)             |
-      | expected [1, 3, 5] to all (be a kind of String) |
-      | expected [1, 3, 5] to all (be > 2)              |
+      | 6 examples, 3 failures                        |
+      | expected [1, 3, 5] to all be even             |
+      | expected [1, 3, 5] to all be a kind of String |
+      | expected [1, 3, 5] to all be > 2              |
 
   Scenario: compound matcher usage
     Given a file named "compound_all_matcher_spec.rb" with:
@@ -54,7 +54,7 @@ Feature: `all` matcher
       """
     When I run `rspec compound_all_matcher_spec.rb`
     Then the output should contain all of these:
-      | 6 examples, 3 failures                                                                           |
-      | expected ["anything", "everything", "something"] to all (include "foo" and include "bar")        |
-      | expected ["anything", "everything", "something"] to all (be a kind of String and start with "a") |
-      | expected ["anything", "everything", "something"] to all (start with "a" or include "z")          |
+      | 6 examples, 3 failures                                                                         |
+      | expected ["anything", "everything", "something"] to all include "foo" and include "bar"        |
+      | expected ["anything", "everything", "something"] to all be a kind of String and start with "a" |
+      | expected ["anything", "everything", "something"] to all start with "a" or include "z"          |

--- a/lib/rspec/matchers/built_in/all.rb
+++ b/lib/rspec/matchers/built_in/all.rb
@@ -31,8 +31,7 @@ module RSpec
         # @api private
         # @return [String]
         def description
-          described_items = surface_descriptions_in(matcher)
-          improve_hash_formatting "all#{to_sentence(described_items)}"
+          improve_hash_formatting "all #{description_of matcher}"
         end
 
       private

--- a/spec/rspec/matchers/built_in/all_spec.rb
+++ b/spec/rspec/matchers/built_in/all_spec.rb
@@ -8,7 +8,7 @@ module RSpec::Matchers::BuiltIn
     describe 'description' do
       it 'provides a description' do
         matcher = all( eq('A') )
-        expect(matcher.description).to eq 'all (eq "A")'
+        expect(matcher.description).to eq 'all eq "A"'
       end
     end
 
@@ -27,7 +27,7 @@ module RSpec::Matchers::BuiltIn
               expect {
                 expect(['A', 'A', 'A', 5, 'A']).to all( be_a(String) )
               }.to fail_with(dedent <<-EOS)
-              |expected ["A", "A", "A", 5, "A"] to all (be a kind of String)
+              |expected ["A", "A", "A", 5, "A"] to all be a kind of String
               |
               |   object at index 3 failed to match:
               |      expected 5 to be a kind of String
@@ -38,7 +38,7 @@ module RSpec::Matchers::BuiltIn
               expect {
                 expect(['A', 'A', 'A', 5, 6]).to all( be_a(String) )
               }.to fail_with(dedent <<-EOS)
-              |expected ["A", "A", "A", 5, 6] to all (be a kind of String)
+              |expected ["A", "A", "A", 5, 6] to all be a kind of String
               |
               |   object at index 3 failed to match:
               |      expected 5 to be a kind of String
@@ -55,7 +55,7 @@ module RSpec::Matchers::BuiltIn
               expect {
                 expect(['A', 'A', 'A', 'C', 'A']).to all( eq('A') )
               }.to fail_with(dedent <<-EOS)
-              |expected ["A", "A", "A", "C", "A"] to all (eq "A")
+              |expected ["A", "A", "A", "C", "A"] to all eq "A"
               |
               |   object at index 3 failed to match:
               |      expected: "A"
@@ -69,7 +69,7 @@ module RSpec::Matchers::BuiltIn
               expect {
                 expect(['A', 'B', 'A', 'C', 'A']).to all( eq('A') )
               }.to fail_with(dedent <<-EOS)
-              |expected ["A", "B", "A", "C", "A"] to all (eq "A")
+              |expected ["A", "B", "A", "C", "A"] to all eq "A"
               |
               |   object at index 1 failed to match:
               |      expected: "A"
@@ -105,7 +105,7 @@ module RSpec::Matchers::BuiltIn
             expect {
               expect([3, 4, 7, 28]).to all( be_between(2, 5).or be_between(6, 9) )
             }.to fail_with(dedent <<-EOS)
-              |expected [3, 4, 7, 28] to all (be between 2 and 5 (inclusive) or be between 6 and 9 (inclusive))
+              |expected [3, 4, 7, 28] to all be between 2 and 5 (inclusive) or be between 6 and 9 (inclusive)
               |
               |   object at index 3 failed to match:
               |      expected 28 to be between 2 and 5 (inclusive) or expected 28 to be between 6 and 9 (inclusive)
@@ -118,7 +118,7 @@ module RSpec::Matchers::BuiltIn
             expect {
               expect([3, 4, 27, 22]).to all( be_between(2, 5).or be_between(6, 9) )
             }.to fail_with(dedent <<-EOS)
-              |expected [3, 4, 27, 22] to all (be between 2 and 5 (inclusive) or be between 6 and 9 (inclusive))
+              |expected [3, 4, 27, 22] to all be between 2 and 5 (inclusive) or be between 6 and 9 (inclusive)
               |
               |   object at index 2 failed to match:
               |      expected 27 to be between 2 and 5 (inclusive) or expected 27 to be between 6 and 9 (inclusive)


### PR DESCRIPTION
This changed in c03cdc734b729481cffcb2d30cbf5670b7cfc2e6.
It was a consequence of fixing `Pretty#to_sentence`, but
as it turns out, we don’t even need to use that. It reads
better without the parens, so this restores the old formatting.

/cc @cupakromer 
