### PR TITLE
Fix all matcher exception when actual not enumerable

### DIFF
--- a/lib/rspec/matchers/built_in/all.rb
+++ b/lib/rspec/matchers/built_in/all.rb
@@ -21,6 +21,10 @@ module RSpec
         # @api private
         # @return [String]
         def failure_message
+          unless enumerable?
+            return "#{improve_hash_formatting(super)}, #{not_enumerable_clause}"
+          end
+
           all_messages = [improve_hash_formatting(super)]
           failed_objects.each do |index, matcher_failure_message|
             all_messages << failure_message_for_item(index, matcher_failure_message)
@@ -37,6 +41,8 @@ module RSpec
       private
 
         def match(_expected, _actual)
+          return false unless enumerable?
+
           index_failed_objects
           failed_objects.empty?
         end
@@ -54,6 +60,10 @@ module RSpec
           indent_multiline_message("object at index #{index} failed to match:#{failure_message}")
         end
 
+        def not_enumerable_clause
+          'but was not enumerable'
+        end
+
         def add_new_line_if_needed(message)
           message.start_with?("\n") ? message : "\n#{message}"
         end
@@ -68,6 +78,10 @@ module RSpec
         def initialize_copy(other)
           @matcher = @matcher.clone
           super
+        end
+
+        def enumerable?
+          Enumerable === @actual
         end
       end
     end

--- a/spec/rspec/matchers/built_in/all_spec.rb
+++ b/spec/rspec/matchers/built_in/all_spec.rb
@@ -180,5 +180,15 @@ module RSpec::Matchers::BuiltIn
       end
     end
 
+    context 'when the actual data is not enumerable' do
+      let(:actual) { 5 }
+
+      it 'returns a failure message' do
+        expect {
+          expect(actual).to all(be_a(String))
+        }.to fail_with("expected #{actual.inspect} to all be a kind of String, but was not enumerable")
+      end
+    end
+
   end
 end


### PR DESCRIPTION
When the action value of passed to the `all` matcher is not enumerable,
rather than failing to match and returning an error it raises an
exception. This commit ensures that `actual` is enumerable before
proceeding with matching.
