### PR TITLE
Tweak `change` chained interface docs

### DIFF
--- a/features/built_in_matchers/change.feature
+++ b/features/built_in_matchers/change.feature
@@ -6,8 +6,8 @@ Feature: `change` matcher
   * `expect { do_something }.to change(object, :attribute)`
   * `expect { do_something }.to change { object.attribute }`
 
-  You can further qualify the change by chaining `by`, `by_at_most`, `by_at_least`, `from`
-  and/or `to`.
+  You can further qualify the change by chaining `from` and/or `to` or one of `by`, `by_at_most`,
+  `by_at_least`.
 
   Background:
     Given a file named "lib/counter.rb" with:

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -397,11 +397,14 @@ module RSpec
     # You can chain any of the following off of the end to specify details
     # about the change:
     #
+    # * `from`
+    # * `to`
+    #
+    # or any one of:
+    #
     # * `by`
     # * `by_at_least`
     # * `by_at_most`
-    # * `from`
-    # * `to`
     #
     # @example
     #


### PR DESCRIPTION
Follow up to #629, an attempt to clarify the docs regarding chaining modifiers onto the `change` matcher.
