### PR TITLE
Add shorthand `chain` syntax for custom matchers

### DIFF
--- a/features/custom_matchers/define_matcher_with_fluent_interface.feature
+++ b/features/custom_matchers/define_matcher_with_fluent_interface.feature
@@ -23,6 +23,25 @@ Feature: define matcher with fluent interface
     Then the output should contain "1 example, 0 failures"
     And  the output should contain "should be bigger than 4"
 
+  Scenario: chained setter
+    Given a file named "between_spec.rb" with:
+      """ruby
+      RSpec::Matchers.define :be_bigger_than do |first|
+        match do |actual|
+          (actual > first) && (actual < second)
+        end
+
+        chain :and_smaller_than, :second
+      end
+
+      RSpec.describe 5 do
+        it { is_expected.to be_bigger_than(4).and_smaller_than(6) }
+      end
+      """
+    When I run `rspec between_spec.rb --format documentation`
+    Then the output should contain "1 example, 0 failures"
+    And  the output should contain "should be bigger than 4"
+
     Scenario: include_chain_clauses_in_custom_matcher_descriptions configured to true, and chained method with argument
       Given a file named "between_spec.rb" with:
         """ruby

--- a/spec/rspec/matchers/dsl_spec.rb
+++ b/spec/rspec/matchers/dsl_spec.rb
@@ -984,6 +984,45 @@ module RSpec::Matchers::DSL
       expect(matcher.expecting('value').matches?('other value')).to be_falsey
     end
 
+    it "can define chainable setters" do
+      matcher = new_matcher(:name) do
+        chain(:expecting, :expected_value)
+        match { |actual| actual == expected_value }
+      end
+
+      expect(matcher.expecting('value').matches?('value')).to be_truthy
+      expect(matcher.expecting('value').matches?('other value')).to be_falsey
+    end
+
+    it "can define chainable setters for several attributes" do
+      matcher = new_matcher(:name) do
+        chain(:expecting, :expected_value, :min_value, :max_value)
+        match { |actual| actual == expected_value && actual >= min_value && actual <= max_value }
+      end
+
+      expect(matcher.expecting('value', 'apple', 'zebra').matches?('value')).to be_truthy
+      expect(matcher.expecting('value', 'apple', 'zebra').matches?('other value')).to be_falsey
+      expect(matcher.expecting('other value', 'parrot', 'zebra').matches?('other value')).to be_falsey
+    end
+
+    it "raises when neither a `chain` block nor attribute name is provided" do
+      expect do
+        new_matcher(:name) do
+          chain(:expecting)
+        end
+      end.to raise_error(ArgumentError)
+    end
+
+    it "raises when both a `chain` block and attribute name are provided" do
+      expect do
+        new_matcher(:name) do
+          chain(:expecting, :expected_value) do |expected_value|
+            @expected_value = expected_value
+          end
+        end
+      end.to raise_error(ArgumentError)
+    end
+
     it 'can use an early return from a `chain` block' do
       matcher = new_matcher(:name) do
         chain(:expecting) do |expected_value|


### PR DESCRIPTION
The `chain` block in fluent matchers almost always just assigns its argument to an instance variable:

``` ruby
RSpec::Matchers.define :be_bigger_than do |first|
  match do |actual|
    (actual > first) && (actual < @second)
  end

  chain :and_smaller_than do |second|
    @second = second
  end
end
```

Requiring a block is kind of overkill in this common case, and I get tired of reimplementing the exact same thing in every fluent matcher I define.

This pull request allows you to instead write:

``` ruby
RSpec::Matchers.define :be_bigger_than do |first|
  match do |actual|
    (actual > first) && (actual < second)
  end

  chain :and_smaller_than, :second
end
```

Namely:
- you can just say `:second` instead of `do |second| @second = second end`; and
- as a bonus, since the DSL now knows a meaningful name for that remembered value, you can refer to it (e.g. in `match`) by saying `second` instead of `@second`.

I think this is an improvement. WDYT?
