### PR TITLE
Fix all matcher to work with any object that responds to each_with_index...

### DIFF
--- a/lib/rspec/matchers/built_in/all.rb
+++ b/lib/rspec/matchers/built_in/all.rb
@@ -21,8 +21,8 @@ module RSpec
         # @api private
         # @return [String]
         def failure_message
-          unless enumerable?
-            return "#{improve_hash_formatting(super)}, but was not enumerable"
+          unless iterable?
+            return "#{improve_hash_formatting(super)}, but was not iterable"
           end
 
           all_messages = [improve_hash_formatting(super)]
@@ -41,7 +41,7 @@ module RSpec
       private
 
         def match(_expected, _actual)
-          return false unless enumerable?
+          return false unless iterable?
 
           index_failed_objects
           failed_objects.empty?
@@ -76,7 +76,7 @@ module RSpec
           super
         end
 
-        def enumerable?
+        def iterable?
           @actual.respond_to?(:each_with_index)
         end
       end

--- a/spec/rspec/matchers/built_in/all_spec.rb
+++ b/spec/rspec/matchers/built_in/all_spec.rb
@@ -186,15 +186,25 @@ module RSpec::Matchers::BuiltIn
       it 'returns a failure message' do
         expect {
           expect(actual).to all(be_a(String))
-        }.to fail_with("expected #{actual.inspect} to all be a kind of String, but was not enumerable")
+        }.to fail_with("expected #{actual.inspect} to all be a kind of String, but was not iterable")
       end
     end
 
     context 'when the actual data does not include enumerable but defines #each_with_index' do
-      it 'can pass' do
+      let(:actual) do
         obj = Object.new
         def obj.each_with_index(&block); [5].each_with_index { |o,i| yield(o,i) }; end
-        expect(obj).to all(be_a(Integer))
+        obj
+      end
+
+      it 'passes properly' do
+        expect(actual).to all(be_a(Integer))
+      end
+
+      it 'fails properly' do
+        expect {
+          expect(actual).to all(be_even)
+        }.to fail_with(/to all be even/)
       end
     end
 


### PR DESCRIPTION
rspec/rspec-rails#1170

Commit 5b4dc0ca6ad2ed11a7e5100854c7b4022010382c introduced explicit
checking to ensure that the all matcher is run only on Enumerable
objects. This broke the matcher for objects that behave like Enumerable,
but don't include the Enumerable module (e.g. Rails
ActiveRecord::Relations).
