### PR TITLE
Make `define_negated_matcher` produce an appropriate failure message.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,8 @@ Bug Fixes:
 * Fix `define_negated_matcher` so that matchers that support fluent
   interfaces continue to be negated after you use the chained method.
   (Myron Marston, #656)
+* Fix `define_negated_matcher` so that the matchers fail with an
+  appropriate failure message. (Myron Marston, #659)
 
 ### 3.1.1 / 2014-09-15
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.1.0...v3.1.1)

--- a/lib/rspec/matchers/built_in/base_matcher.rb
+++ b/lib/rspec/matchers/built_in/base_matcher.rb
@@ -53,26 +53,6 @@ module RSpec
         end
 
         # @api private
-        # Provides a good generic failure message. Based on `description`.
-        # When subclassing, if you are not satisfied with this failure message
-        # you often only need to override `description`.
-        # @return [String]
-        def failure_message
-          assert_ivars :@actual
-          "expected #{@actual.inspect} to #{description}"
-        end
-
-        # @api private
-        # Provides a good generic negative failure message. Based on `description`.
-        # When subclassing, if you are not satisfied with this failure message
-        # you often only need to override `description`.
-        # @return [String]
-        def failure_message_when_negated
-          assert_ivars :@actual
-          "expected #{@actual.inspect} not to #{description}"
-        end
-
-        # @api private
         # Generates a "pretty" description using the logic in {Pretty}.
         # @return [String]
         def description
@@ -114,6 +94,38 @@ module RSpec
         else
           alias present_ivars instance_variables
         end
+
+        # @api private
+        # Provides default implementations of failure messages, based on the `description`.
+        module DefaultFailureMessages
+          # @api private
+          # Provides a good generic failure message. Based on `description`.
+          # When subclassing, if you are not satisfied with this failure message
+          # you often only need to override `description`.
+          # @return [String]
+          def failure_message
+            "expected #{actual.inspect} to #{description}"
+          end
+
+          # @api private
+          # Provides a good generic negative failure message. Based on `description`.
+          # When subclassing, if you are not satisfied with this failure message
+          # you often only need to override `description`.
+          # @return [String]
+          def failure_message_when_negated
+            "expected #{actual.inspect} not to #{description}"
+          end
+
+          # @private
+          def self.has_default_failure_messages?(matcher)
+            matcher.method(:failure_message).owner == self &&
+            matcher.method(:failure_message_when_negated).owner == self
+          rescue NameError
+            false
+          end
+        end
+
+        include DefaultFailureMessages
       end
     end
   end

--- a/lib/rspec/matchers/dsl.rb
+++ b/lib/rspec/matchers/dsl.rb
@@ -263,6 +263,8 @@ module RSpec
       # override any of these using the {RSpec::Matchers::DSL::Macros Macros} methods
       # from within an `RSpec::Matchers.define` block.
       module DefaultImplementations
+        include BuiltIn::BaseMatcher::DefaultFailureMessages
+
         # @api private
         # Used internally by objects returns by `should` and `should_not`.
         def diffable?
@@ -272,16 +274,6 @@ module RSpec
         # The default description.
         def description
           "#{name_to_sentence}#{to_sentence expected}#{chained_method_clause_sentences}"
-        end
-
-        # The default failure message for positive expectations.
-        def failure_message
-          "expected #{actual.inspect} to #{description}"
-        end
-
-        # The default failure message for negative expectations.
-        def failure_message_when_negated
-          "expected #{actual.inspect} not to #{description}"
         end
 
         # Matchers do not support block expectations by default. You

--- a/spec/rspec/matchers/aliased_matcher_spec.rb
+++ b/spec/rspec/matchers/aliased_matcher_spec.rb
@@ -86,7 +86,7 @@ module RSpec
 
         expect {
           expect { $stdout.puts "a" }.to avoid_outputting.to_stdout
-        }.to fail_with(/expected block to avoid outputting to stdout, but did not/)
+        }.to fail
       end
 
       context "when negating a matcher that does not define `description` (which is an optional part of the matcher protocol)" do


### PR DESCRIPTION
Fixes #657.

/cc @JonRowe 
