### PR TITLE
Give a hint on how the set the :should syntax

### DIFF
--- a/lib/rspec/expectations/syntax.rb
+++ b/lib/rspec/expectations/syntax.rb
@@ -27,7 +27,7 @@ module RSpec
 
         RSpec.deprecate(
           "Using `#{method_name}` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax",
-          :replacement => "the new `:expect` syntax or explicitly enable `:should`"
+          :replacement => "the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }`"
         )
 
         @warn_about_should = false

--- a/spec/rspec/expectations/configuration_spec.rb
+++ b/spec/rspec/expectations/configuration_spec.rb
@@ -130,7 +130,7 @@ module RSpec
           it "warns when the should syntax is called by default" do
             expected_arguments = [
               /Using.*without explicitly enabling/,
-              {:replacement=>"the new `:expect` syntax or explicitly enable `:should`"}
+              {:replacement=>"the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }`"}
             ]
 
             expect(RSpec).to receive(:deprecate).with(*expected_arguments)


### PR DESCRIPTION
In the spirit of better usability. I struggled a bit to find how to explicitly set the `:should` syntax.

The alternative I see is to add a commented line in the generated spec_helper.
