### PR TITLE
Removing explicit checking of object's private methods

### DIFF
--- a/lib/rspec/matchers/built_in/be.rb
+++ b/lib/rspec/matchers/built_in/be.rb
@@ -215,7 +215,7 @@ module RSpec
       private
 
         def predicate_accessible?
-          !private_predicate? && predicate_exists?
+          actual.respond_to?(predicate) || actual.respond_to?(present_tense_predicate)
         end
 
         # support 1.8.7, evaluate once at load time for performance
@@ -227,10 +227,6 @@ module RSpec
           def private_predicate?
             @actual.private_methods.include? predicate
           end
-        end
-
-        def predicate_exists?
-          actual.respond_to?(predicate) || actual.respond_to?(present_tense_predicate)
         end
 
         def predicate_matches?
@@ -265,11 +261,11 @@ module RSpec
         end
 
         def validity_message
-          if private_predicate?
-            "expected #{@actual} to respond to `#{predicate}` but `#{predicate}` is a private method"
-          elsif !predicate_exists?
-            "expected #{@actual} to respond to `#{predicate}`"
-          end
+          return nil if predicate_accessible?
+
+          msg = "expected #{@actual} to respond to `#{predicate}`"
+          msg << " but `#{predicate}` is a private method" if private_predicate?
+          msg
         end
       end
     end

--- a/spec/rspec/matchers/built_in/be_spec.rb
+++ b/spec/rspec/matchers/built_in/be_spec.rb
@@ -86,6 +86,13 @@ RSpec.describe "expect(...).to be_predicate" do
     expect { expect(privately_happy.new).to be_happy }.to fail_with(/private/)
   end
 
+  it 'does not call :private_methods when the object publicly responds to the message' do
+    publicly_happy = double('happy')
+    expect(publicly_happy).to receive(:happy?) { true }
+    expect(publicly_happy).not_to receive(:private_methods)
+    expect(publicly_happy).to be_happy
+  end
+
   it "fails on error other than NameError" do
     actual = double("actual")
     expect(actual).to receive(:foo?).and_raise("aaaah")


### PR DESCRIPTION
This PR changes predicate matcher behavior to no longer inspect an object's private methods using a call to `private_methods`. Calling `respond_to?(:method, false)` should exclude private methods from searching. This does reduce verbosity when reporting on expectation failures; however, this will correct an issue by which RSpec causes side-effect errors when trying to call a predicate.
