### PR TITLE
Make `yield_control` default to `at_least(:once)`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,10 @@ Bug Fixes:
   method. This avoids a possible error that can occur if the object
   raises errors from `private_methods` (which can happen with celluloid
   objects). (@chapmajs, #670)
+* Make `yield_control` (with no modifier) default to
+  `at_least(:once)` rather than raising a confusing error
+  when multiple yields are encountered.
+  (Myron Marston, #675)
 
 ### 3.1.2 / 2014-09-26
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.1.1...v3.1.2)

--- a/lib/rspec/matchers/built_in/yield.rb
+++ b/lib/rspec/matchers/built_in/yield.rb
@@ -94,8 +94,7 @@ module RSpec
       # Not intended to be instantiated directly.
       class YieldControl < BaseMatcher
         def initialize
-          @expectation_type = nil
-          @expected_yields_count = nil
+          at_least(:once)
         end
 
         # @api public
@@ -151,11 +150,7 @@ module RSpec
           @probe = YieldProbe.probe(block)
           return false unless @probe.has_block?
 
-          if @expectation_type
-            @probe.num_yields.__send__(@expectation_type, @expected_yields_count)
-          else
-            @probe.yielded_once?(:yield_control)
-          end
+          @probe.num_yields.__send__(@expectation_type, @expected_yields_count)
         end
 
         # @private

--- a/spec/rspec/matchers/built_in/yield_spec.rb
+++ b/spec/rspec/matchers/built_in/yield_spec.rb
@@ -45,9 +45,10 @@ RSpec.describe "yield_control matcher" do
   end
 
   describe "expect {...}.to yield_control" do
-    it 'passes if the block yields, regardless of the number of yielded arguments' do
+    it 'passes if the block yields, regardless of the number of yielded arguments or the number of yields' do
       expect { |b| _yield_with_no_args(&b) }.to yield_control
       expect { |b| _yield_with_args(1, 2, &b) }.to yield_control
+      expect { |b| 1.upto(10, &b) }.to yield_control
     end
 
     it 'passes if the block yields using instance_exec' do


### PR DESCRIPTION
Previously, it raised a confusing error when multiple
yields occurred:

> The yield_control matcher is not designed to be used with a
> method that yields multiple times. Use the yield_successive_args
> matcher for that case.

This was confusing because yield_control has supported multiple
yields for awhile.  This also simplifies the implementation!
