### PR TITLE
raise exceptions on `expect(..) == ..` syntax

### DIFF
--- a/lib/rspec/expectations/expectation_target.rb
+++ b/lib/rspec/expectations/expectation_target.rb
@@ -68,6 +68,10 @@ module RSpec
       end
       alias to_not not_to
 
+      def ==(*args)
+        raise ArgumentError, 'The expect syntax does not support ==, use `.to eq()`'
+      end
+
     private
 
       def prevent_operator_matchers(verb)

--- a/spec/rspec/expectations/expectation_target_spec.rb
+++ b/spec/rspec/expectations/expectation_target_spec.rb
@@ -79,6 +79,12 @@ module RSpec
             expect(3).not_to == 4
           }.to raise_error(ArgumentError)
         end
+
+        it 'does not support #==' do
+          expect {
+            expect(3) == 3
+          }.to raise_error(ArgumentError)
+        end
       end
 
       context "when passed a block" do
@@ -144,4 +150,3 @@ module RSpec
     end
   end
 end
-


### PR DESCRIPTION
I caught myself replacing old `x.should == y` syntax with `expect(x) == y`. As you might imagine, that does absolutely nothing. Half of my specs were not testing code, some were broken.

I fear that this might happen to others. This raises an exception to a common `==` matcher.
