### PR TITLE
Switch readme badges to svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RSpec Expectations [![Build Status](https://secure.travis-ci.org/rspec/rspec-expectations.png?branch=master)](http://travis-ci.org/rspec/rspec-expectations) [![Code Climate](https://codeclimate.com/github/rspec/rspec-expectations.png)](https://codeclimate.com/github/rspec/rspec-expectations)
+# RSpec Expectations [![Build Status](https://secure.travis-ci.org/rspec/rspec-expectations.svg?branch=master)](http://travis-ci.org/rspec/rspec-expectations) [![Code Climate](https://codeclimate.com/github/rspec/rspec-expectations.svg)](https://codeclimate.com/github/rspec/rspec-expectations)
 
 RSpec::Expectations lets you express expected outcomes on an object in an
 example.


### PR DESCRIPTION
SVG readme badges are crisper :)

Before:
![screen shot 2014-11-25 at 14 33 43](https://cloud.githubusercontent.com/assets/162976/5177616/54833ca4-74b0-11e4-9ea0-4fdcff724695.png)

After:
![screen shot 2014-11-25 at 14 35 05](https://cloud.githubusercontent.com/assets/162976/5177617/5a8c138c-74b0-11e4-989d-59cbe03aa9ca.png)
