### PR TITLE
Fix generated descriptions with nested matchers

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -33,6 +33,8 @@ Bug Fixes:
   rspec-expectations outside of an rspec-core context. (Myron Marston, #689)
 * Fix `start_with` and `end_with` to work properly when checking a
   string against an array of strings. (Myron Marston, #690)
+* Don't use internally delegated matchers when generating descriptions
+  for examples without doc strings. (Myron Marston, #692)
 
 ### 3.1.2 / 2014-09-26
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.1.1...v3.1.2)

--- a/spec/rspec/matchers/description_generation_spec.rb
+++ b/spec/rspec/matchers/description_generation_spec.rb
@@ -165,6 +165,21 @@ RSpec.describe "Matchers should be able to generate their own descriptions" do
     expect(RSpec::Matchers.generated_description).to eq "should throw :what_a_mess"
   end
 
+  example "expect(...).to matcher_that_delegates_to_an_internal_expectation" do
+    expect(1).to matcher_that_delegates_to_an_internal_expectation
+    expect(RSpec::Matchers.generated_description).to eq "should matcher that delegates to an internal expectation"
+  end
+
+  example "expect(...).not_to matcher_that_delegates_to_an_internal_expectation" do
+    expect(1).not_to matcher_that_delegates_to_an_internal_expectation
+    expect(RSpec::Matchers.generated_description).to eq "should not matcher that delegates to an internal expectation"
+  end
+
+  RSpec::Matchers.define :matcher_that_delegates_to_an_internal_expectation do
+    match { expect(1).to eq(1) }
+    match_when_negated { expect(1).to eq(1) }
+  end
+
   def team
     Class.new do
       def players


### PR DESCRIPTION
This fixes an issue exposed by rspec/rspec-mocks#826.

/cc @JonRowe @e2
