### PR TITLE
Properly sub-class Exception so YARD can detect ExpectationNotMetError.

### DIFF
--- a/lib/rspec/expectations.rb
+++ b/lib/rspec/expectations.rb
@@ -63,6 +63,7 @@ module RSpec
     # the user sets an expectation, it can't be caught in their
     # code by a bare `rescue`.
     # @api public
-    ExpectationNotMetError = Class.new(::Exception)
+    class ExpectationNotMetError < ::Exception
+    end
   end
 end


### PR DESCRIPTION
[rubydoc.org](http://www.rubydoc.info/gems/rspec-expectations/RSpec/Expectations) does not list `ExpectationNotMetError` as a class, but instead a plain constant.
