### PR TITLE
Rename type to class internally

### DIFF
--- a/features/built_in_matchers/raise_error.feature
+++ b/features/built_in_matchers/raise_error.feature
@@ -91,7 +91,7 @@ Feature: `raise_error` matcher
     When I run `rspec example_spec.rb`
     Then the example should pass
 
-  Scenario: match type + message with string
+  Scenario: match class + message with string
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.describe "matching error message with string" do
@@ -104,7 +104,7 @@ Feature: `raise_error` matcher
     When I run `rspec example_spec.rb`
     Then the example should pass
 
-  Scenario: match type + message with regexp
+  Scenario: match class + message with regexp
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.describe "matching error message with regex" do

--- a/lib/rspec/matchers/built_in/include.rb
+++ b/lib/rspec/matchers/built_in/include.rb
@@ -33,13 +33,13 @@ module RSpec
         # @api private
         # @return [String]
         def failure_message
-          improve_hash_formatting(super) + invalid_type_message
+          improve_hash_formatting(super) + invalid_object_message
         end
 
         # @api private
         # @return [String]
         def failure_message_when_negated
-          improve_hash_formatting(super) + invalid_type_message
+          improve_hash_formatting(super) + invalid_object_message
         end
 
         # @api private
@@ -50,7 +50,7 @@ module RSpec
 
       private
 
-        def invalid_type_message
+        def invalid_object_message
           return '' if actual.respond_to?(:include?)
           ", but it does not respond to `include?`"
         end

--- a/spec/rspec/matchers/built_in/contain_exactly_spec.rb
+++ b/spec/rspec/matchers/built_in/contain_exactly_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe "matching against things that aren't arrays" do
     }.to fail_with(/expected a collection/)
   end
 
-  it 'works with other collection types' do
+  it 'works with other collection objects' do
     expect(Set.new([3, 2, 1])).to contain_exactly(1, 2, 3)
     expect {
       expect(Set.new([3, 2, 1])).to contain_exactly(1, 2)

--- a/spec/rspec/matchers/built_in/operators_spec.rb
+++ b/spec/rspec/matchers/built_in/operators_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe "operator matchers", :uses_should do
       RSpec::Matchers::BuiltIn::OperatorMatcher.unregister(custom_klass, "=~")
     }
 
-    it "allows operator matchers to be registered for types" do
+    it "allows operator matchers to be registered for classes" do
       RSpec::Matchers::BuiltIn::OperatorMatcher.register(custom_klass, "=~", RSpec::Matchers::BuiltIn::Match)
       expect(RSpec::Matchers::BuiltIn::OperatorMatcher.get(custom_klass, "=~")).to eq(RSpec::Matchers::BuiltIn::Match)
     end
@@ -222,7 +222,7 @@ RSpec.describe "operator matchers", :uses_should do
       expect(RSpec::Matchers::BuiltIn::OperatorMatcher.get(custom_subklass, "=~")).to eq(RSpec::Matchers::BuiltIn::Match)
     end
 
-    it "returns nil if there is no matcher registered for a type" do
+    it "returns nil if there is no matcher registered for a class" do
       expect(RSpec::Matchers::BuiltIn::OperatorMatcher.get(custom_klass, "=~")).to be_nil
     end
   end

--- a/spec/rspec/matchers/built_in/yield_spec.rb
+++ b/spec/rspec/matchers/built_in/yield_spec.rb
@@ -481,15 +481,15 @@ RSpec.describe "yield_with_args matcher" do
   end
 
   describe "expect {...}.to yield_with_args(String, Fixnum)" do
-    it "passes if the block yields objects of the given types" do
+    it "passes if the block yields objects of the given classes" do
       expect { |b| _yield_with_args("string", 15, &b) }.to yield_with_args(String, Fixnum)
     end
 
-    it "passes if the block yields the given types" do
+    it "passes if the block yields the given classes" do
       expect { |b| _yield_with_args(String, Fixnum, &b) }.to yield_with_args(String, Fixnum)
     end
 
-    it "fails if the block yields objects of different types" do
+    it "fails if the block yields objects of different classes" do
       expect {
         expect { |b| _yield_with_args(15, "string", &b) }.to yield_with_args(String, Fixnum)
       }.to fail_with(/expected given block to yield with arguments, but yielded with unexpected arguments/)
@@ -630,15 +630,15 @@ RSpec.describe "yield_successive_args matcher" do
   end
 
   describe "expect {...}.to yield_successive_args(String, Fixnum)" do
-    it "passes if the block successively yields objects of the given types" do
+    it "passes if the block successively yields objects of the given classes" do
       expect { |b| ["string", 15].each(&b) }.to yield_successive_args(String, Fixnum)
     end
 
-    it "passes if the block yields the given types" do
+    it "passes if the block yields the given classes" do
       expect { |b| [String, Fixnum].each(&b) }.to yield_successive_args(String, Fixnum)
     end
 
-    it "fails if the block yields objects of different types" do
+    it "fails if the block yields objects of different classes" do
       expect {
         expect { |b| [15, "string"].each(&b) }.to yield_successive_args(String, Fixnum)
       }.to fail_with(/expected given block to yield successively with arguments/)

--- a/spec/rspec/matchers/description_generation_spec.rb
+++ b/spec/rspec/matchers/description_generation_spec.rb
@@ -140,12 +140,12 @@ RSpec.describe "Matchers should be able to generate their own descriptions" do
     expect(RSpec::Matchers.generated_description).to eq "should raise Exception"
   end
 
-  example "expect(...).to raise_error with type" do
+  example "expect(...).to raise_error with class" do
     expect { raise }.to raise_error(RuntimeError)
     expect(RSpec::Matchers.generated_description).to eq "should raise RuntimeError"
   end
 
-  example "expect(...).to raise_error with type and message" do
+  example "expect(...).to raise_error with class and message" do
     expect { raise "there was an error" }.to raise_error(RuntimeError, "there was an error")
     expect(RSpec::Matchers.generated_description).to eq "should raise RuntimeError with \"there was an error\""
   end


### PR DESCRIPTION
There has been some discussion about us conflating types and classes:

<blockquote class="twitter-tweet" lang="en"><p><a href="https://twitter.com/myronmarston">@myronmarston</a> <a href="https://twitter.com/JonRowe">@JonRowe</a> [1/?] I noticed RSpec seems to conflate Ruby&#39;s classes with types, in both the docs (<a href="http://t.co/rkyTrIIOSh">http://t.co/rkyTrIIOSh</a>) and the</p>&mdash; friendly catduck™ (@duckinator) <a href="https://twitter.com/duckinator/status/542148488365371392">December 9, 2014</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

<blockquote class="twitter-tweet" lang="en"><p><a href="https://twitter.com/myronmarston">@myronmarston</a> <a href="https://twitter.com/JonRowe">@JonRowe</a> [2/?] various codebases (<a href="https://t.co/jamOJhnIpp">https://t.co/jamOJhnIpp</a>). I&#39;d be willing to fix that if you all are interested; but, if you</p>&mdash; friendly catduck™ (@duckinator) <a href="https://twitter.com/duckinator/status/542148638399807488">December 9, 2014</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

<blockquote class="twitter-tweet" lang="en"><p><a href="https://twitter.com/myronmarston">@myronmarston</a> <a href="https://twitter.com/JonRowe">@JonRowe</a> [3/3] are, how would you want me to approach the code side of it? Are their exposed APIs that this would break?</p>&mdash; friendly catduck™ (@duckinator) <a href="https://twitter.com/duckinator/status/542148817219756032">December 9, 2014</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Now I disagree that the matcher is incorrectly named (as it's a documentation heading only) but these changes are distinctly classes (and not sample data referring to type either) so I saw no harm in making them.

/cc @duckinator
