### PR TITLE
Add `be_a_subclass_of` matcher.

### DIFF
--- a/features/built_in_matchers/class.feature
+++ b/features/built_in_matchers/class.feature
@@ -1,0 +1,56 @@
+Feature: Class matchers
+
+  rspec-expectations a matcher to specify the nature of classes:
+
+    * `expect(Klass).to be_subclass_of(Klazz)`: calls `Klass.ancestors.include?(Klazz)`, which returns true if
+        Klazz is in Klass's class hierarchy or is a module and is included in a class in Klass's
+        class hierarchy. This matcher is aliased as `be_a_subclass_of` and `a_subclass_of`.
+
+
+  Scenario: be_(a_)subclass_of matcher
+    Given a file named "be_subclass_of_matcher_spec.rb" with:
+      """ruby
+      module Qux
+
+      end
+
+      class Foo
+
+      end
+      
+      class Bar < Foo
+
+      end
+
+      class Baz < Bar
+        include Qux
+      end
+
+      RSpec.describe Baz do
+        subject { Baz }
+
+        # the superclass
+        specify { expect(subject).to be_subclass_of(Bar) }
+
+        # the super-superclass
+        specify { expect(subject).to be_subclass_of(Foo) }
+
+        # Ruby internals
+        specify { expect(subject).to be_subclass_of(Object) }
+
+        # an included module
+        specify { expect(subject).to be_subclass_of(Qux) }
+
+        # negative passing case
+        it { is_expected.not_to be_subclass_of(String) }
+
+        # deliberate failures
+        specify { expect(subject).not_to be_subclass_of(Foo) }
+        specify { expect(subject).to be_subclass_of(Fixnum) }
+      end
+      """
+    When I run `rspec be_subclass_of_matcher_spec.rb`
+    Then the output should contain all of these:
+      | 7 examples, 2 failures                   |
+      | expected Baz not to be a subclass of Foo |
+      | expected Baz to be a subclass of Fixnum  |

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -352,6 +352,19 @@ module RSpec
     alias_method :be_kind_of, :be_a_kind_of
     alias_matcher :a_kind_of,  :be_a_kind_of
 
+    # Passes if actual.ancestors.include?(expected)
+    #
+    # @example
+    #
+    #   expect(Integer).to    be_a_kind_of(Fixnum)
+    #   expect(String).to     be_a_kind_of(Object)
+    #   expect(String).not_to be_a_kind_of(Integer)
+    def be_a_subclass_of(expected)
+      BuiltIn::BeASubclassOf.new(expected)
+    end
+    alias_method :be_subclass_of, :be_a_subclass_of
+    alias_matcher :a_subclass_of,  :be_a_subclass_of
+
     # Passes if actual.between?(min, max). Works with any Comparable object,
     # including String, Symbol, Time, or Numeric (Fixnum, Bignum, Integer,
     # Float, Complex, and Rational).

--- a/lib/rspec/matchers/built_in.rb
+++ b/lib/rspec/matchers/built_in.rb
@@ -12,6 +12,7 @@ module RSpec
     module BuiltIn
       autoload :BeAKindOf,               'rspec/matchers/built_in/be_kind_of'
       autoload :BeAnInstanceOf,          'rspec/matchers/built_in/be_instance_of'
+      autoload :BeASubclassOf,           'rspec/matchers/built_in/be_subclass_of'
       autoload :BeBetween,               'rspec/matchers/built_in/be_between'
       autoload :Be,                      'rspec/matchers/built_in/be'
       autoload :BeComparedTo,            'rspec/matchers/built_in/be'

--- a/lib/rspec/matchers/built_in/be_subclass_of.rb
+++ b/lib/rspec/matchers/built_in/be_subclass_of.rb
@@ -1,0 +1,16 @@
+module RSpec
+  module Matchers
+    module BuiltIn
+      # @api private
+      # Provides the implementation for `be_a_subclass_of`.
+      # Not intended to be instantiated directly.
+      class BeASubclassOf < BaseMatcher
+      private
+
+        def match(expected, actual)
+          actual.ancestors.include? expected
+        end
+      end
+    end
+  end
+end

--- a/spec/rspec/matchers/built_in/be_a_subclass_of_spec.rb
+++ b/spec/rspec/matchers/built_in/be_a_subclass_of_spec.rb
@@ -1,0 +1,45 @@
+SuperKlass = Class.new
+SubKlass = Class.new(SuperKlass)
+SubSubKlass = Class.new(SubKlass)
+OtherKlass = Class.new
+
+module RSpec
+  module Matcher
+    [:be_a_subclass_of, :be_subclass_of].each do |method|
+      RSpec.describe "expect(actual).to #{method}(expected)" do
+
+        it_behaves_like "an RSpec matcher", :valid_value => SubKlass, :invalid_value => OtherKlass do
+          let(:matcher) { send(method, SuperKlass) }
+        end
+
+        it "passes if actual is subclass of expected class" do
+          expect(SubKlass).to send(method, SuperKlass)
+        end
+
+        it "passes if actual is subklass of subclass of expected class" do
+          expect(SubSubKlass).to send(method, SuperKlass)
+        end
+
+        it "fails with failure message for should unless actual is subclass of expected class" do
+          expect {
+            expect(OtherKlass).to send(method, SuperKlass)
+          }.to fail_with(%Q{expected OtherKlass to be a subclass of SuperKlass})
+        end
+
+        it "provides a description" do
+          matcher = send(method, SuperKlass)
+          matcher.matches?(OtherKlass)
+          expect(matcher.description).to eq "be a subclass of SuperKlass"
+        end
+      end
+
+      RSpec.describe "expect(actual).not_to #{method}(expected)" do
+        it "fails with failure message for should_not if actual is subclass of expected class" do
+          expect {
+            expect(SubKlass).not_to send(method, SuperKlass)
+          }.to fail_with(%Q{expected SubKlass not to be a subclass of SuperKlass})
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I've added a `be_subclass_of` matcher to the builtins.

I realise that it is possible to use the `be` matcher for this, like so `expect(String).to be < Object`. This however, feels rather cryptic. I feel that `expect(String).to be_subclass_of Object` is clearer.

I've included a specification, as well as a cucumber feature based off of the `be_kind_of` feature.

Let me know if there's anything I can do to make this easier to merge.