### PR TITLE
Compound matcher diff

### DIFF
--- a/lib/rspec/expectations/fail_with.rb
+++ b/lib/rspec/expectations/fail_with.rb
@@ -24,8 +24,7 @@ module RSpec
                                "appropriate failure_message[_when_negated] method to return a string?"
         end
 
-        diff = differ.diff(actual, expected)
-        message = "#{message}\nDiff:#{diff}" unless diff.empty?
+        message = ::RSpec::Matchers::ExpectedsForMultipleDiffs.from(expected).message_with_diff(message, method(:differ), actual)
 
         raise RSpec::Expectations::ExpectationNotMetError, message
       end

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -10,6 +10,7 @@ RSpec::Support.define_optimized_require_for_rspec(:matchers) { |f| require_relat
   dsl
   matcher_delegator
   aliased_matcher
+  expecteds_for_multiple_diffs
 ].each { |file| RSpec::Support.require_rspec_matchers(file) }
 
 # RSpec's top level namespace. All of rspec-expectations is contained

--- a/lib/rspec/matchers/built_in/compound.rb
+++ b/lib/rspec/matchers/built_in/compound.rb
@@ -3,6 +3,7 @@ module RSpec
     module BuiltIn
       # @api private
       # Base class for `and` and `or` compound matchers.
+      # rubocop:disable ClassLength
       class Compound < BaseMatcher
         # @private
         attr_reader :matcher_1, :matcher_2, :evaluator

--- a/lib/rspec/matchers/built_in/compound.rb
+++ b/lib/rspec/matchers/built_in/compound.rb
@@ -5,7 +5,7 @@ module RSpec
       # Base class for `and` and `or` compound matchers.
       class Compound < BaseMatcher
         # @private
-        attr_reader :matcher_1, :matcher_2
+        attr_reader :matcher_1, :matcher_2, :evaluator
 
         def initialize(matcher_1, matcher_2)
           @matcher_1 = matcher_1
@@ -34,6 +34,28 @@ module RSpec
         def expects_call_stack_jump?
           NestedEvaluator.matcher_expects_call_stack_jump?(matcher_1) ||
           NestedEvaluator.matcher_expects_call_stack_jump?(matcher_2)
+        end
+
+        # @api private
+        # @return [Boolean]
+        def diffable?
+          matcher_is_diffable?(matcher_1) || matcher_is_diffable?(matcher_2)
+        end
+
+        # @api private
+        # @return [RSpec::Matchers::ExpectedsForMultipleDiffs]
+        def expected
+          return nil unless evaluator
+          ::RSpec::Matchers::ExpectedsForMultipleDiffs.for_many_matchers(diffable_matcher_list)
+        end
+
+      protected
+
+        def diffable_matcher_list
+          list = []
+          list.concat(diffable_matcher_list_for(matcher_1)) unless matcher_1_matches?
+          list.concat(diffable_matcher_list_for(matcher_2)) unless matcher_2_matches?
+          list
         end
 
       private
@@ -88,17 +110,29 @@ module RSpec
         end
 
         def matcher_1_matches?
-          @evaluator.matcher_matches?(matcher_1)
+          evaluator.matcher_matches?(matcher_1)
         end
 
         def matcher_2_matches?
-          @evaluator.matcher_matches?(matcher_2)
+          evaluator.matcher_matches?(matcher_2)
         end
 
         def matcher_supports_block_expectations?(matcher)
           matcher.supports_block_expectations?
         rescue NoMethodError
           false
+        end
+
+        def matcher_is_diffable?(matcher)
+          matcher.diffable?
+        rescue NoMethodError
+          false
+        end
+
+        def diffable_matcher_list_for(matcher)
+          return [] unless matcher_is_diffable?(matcher)
+          return matcher.diffable_matcher_list if Compound === matcher
+          [matcher]
         end
 
         # For value expectations, we can evaluate the matchers sequentially.

--- a/lib/rspec/matchers/expecteds_for_multiple_diffs.rb
+++ b/lib/rspec/matchers/expecteds_for_multiple_diffs.rb
@@ -1,0 +1,79 @@
+module RSpec
+  module Matchers
+    # @api private
+    # Handles list of expected values when there is a need to render
+    # multiple diffs. Also can handle one value.
+    class ExpectedsForMultipleDiffs
+      # @private
+      # Default diff label when there is only one matcher in diff
+      # output
+      DEFAULT_DIFF_LABEL = "Diff:".freeze
+
+      # @private
+      # Maximum readable matcher description length
+      DESCRIPTION_MAX_LENGTH = 65
+
+      def initialize(expected_list)
+        @expected_list = expected_list
+      end
+
+      # @api private
+      # Wraps provided expected value in instance of
+      # ExpectedForMultipleDiffs. If provided value is already an
+      # ExpectedForMultipleDiffs then it just returns it.
+      # @param [Any] expected value to be wrapped
+      # @return [RSpec::Matchers::ExpectedsForMultipleDiffs]
+      def self.from(expected)
+        return expected if self === expected
+        new([[expected, DEFAULT_DIFF_LABEL]])
+      end
+
+      # @api private
+      # Wraps provided matcher list in instance of
+      # ExpectedForMultipleDiffs.
+      # @param [Array<Any>] matchers list of matchers to wrap
+      # @return [RSpec::Matchers::ExpectedsForMultipleDiffs]
+      def self.for_many_matchers(matchers)
+        new(matchers.map { |m| [m.expected, diff_label_for(m)] })
+      end
+
+      # @api private
+      # Returns message with diff(s) appended for provided differ
+      # factory and actual value if there are any
+      # @param [String] message original failure message
+      # @param [Proc] differ_factory brand new differ factory method (or proc, block)
+      # @param [Any] actual value
+      # @return [String]
+      def message_with_diff(message, differ_factory, actual)
+        diff = diffs(differ_factory, actual)
+        message = "#{message}\n#{diff}" unless diff.empty?
+        message
+      end
+
+    private
+
+      def self.diff_label_for(matcher)
+        "Diff for (#{truncated(description_for(matcher))}):"
+      end
+
+      def self.description_for(matcher)
+        matcher.description
+      rescue NoMethodError
+        matcher.inspect
+      end
+
+      def self.truncated(description)
+        return description if description.length <= DESCRIPTION_MAX_LENGTH
+        description[0...DESCRIPTION_MAX_LENGTH - 3] << "..."
+      end
+
+      def diffs(differ_factory, actual)
+        @expected_list.map do |(expected, diff_label)|
+          diff = differ_factory.call.diff(actual, expected)
+          next if diff.empty?
+          "#{diff_label}#{diff}"
+        end.compact.join("\n")
+      end
+    end
+  end
+end

--- a/spec/rspec/matchers/expecteds_for_multiple_diffs_spec.rb
+++ b/spec/rspec/matchers/expecteds_for_multiple_diffs_spec.rb
@@ -1,0 +1,116 @@
+module RSpec
+  module Matchers
+    RSpec.describe ExpectedsForMultipleDiffs do
+
+      before do
+        stub_const("::RSpec::Matchers::ExpectedsForMultipleDiffs::DESCRIPTION_MAX_LENGTH", 30)
+      end
+
+      class FakeDiffer
+        FACTORY = Proc.new { FakeDiffer }
+
+        def self.diff(actual, expected)
+          [actual, expected].inspect
+        end
+      end
+
+      let(:differ_factory) { FakeDiffer::FACTORY }
+
+      let(:message) { "a message" }
+      let(:actual) { "actual value" }
+
+      let(:wrapped_value) { described_class.from("expected value") }
+
+      let(:matcher_1) { instance_double(BuiltIn::BaseMatcher, :description => "matcher 1 description", :expected => "expected 1") }
+      let(:matcher_2) { instance_double(BuiltIn::BaseMatcher, :description => "matcher 2 description", :expected => "expected 2") }
+      let(:matcher_3) { instance_double(BuiltIn::BaseMatcher, :description => "matcher 3 description", :expected => "expected 3") }
+
+      let(:long_description) { "a very very long description for my custom smart matcher, which can be used for everything" }
+      let(:truncated_description) { "a very very long descriptio..." }
+      let(:matcher_with_long_description) { instance_double(BuiltIn::BaseMatcher, :description => long_description, :expected => "expected value") }
+
+      let(:matcher_without_description_defined) { double("custom matcher", :expected => "expected value", :inspect => "#<CustomMatcher:0xf0c8561a55>") }
+
+      before { allow(matcher_without_description_defined).to receive(:description).and_raise(NoMethodError) }
+
+      describe ".from" do
+        it "wraps provided value in ExpectedsForMultipleDiffs" do
+          expect(wrapped_value).to be_a(described_class)
+        end
+
+        it "returns original value if it was already wrapped" do
+          expect(described_class.from(wrapped_value)).to be(wrapped_value)
+        end
+      end
+
+      describe ".for_many_matchers" do
+        let(:wrapped_value) { described_class.for_many_matchers([matcher_1, matcher_2, matcher_3]) }
+
+        it "has a diff for all matchers with their description" do
+          expect(wrapped_value.message_with_diff(
+            message, differ_factory, actual
+          )).to eq(dedent <<-EOS)
+            |a message
+            |Diff for (matcher 1 description):["actual value", "expected 1"]
+            |Diff for (matcher 2 description):["actual value", "expected 2"]
+            |Diff for (matcher 3 description):["actual value", "expected 3"]
+          EOS
+        end
+      end
+
+      describe "#message_with_diff" do
+        it "returns just provided message if diff is empty" do
+          allow(FakeDiffer).to receive(:diff) { "" }
+          expect(wrapped_value.message_with_diff(
+            message, differ_factory, actual
+          )).to eq(dedent <<-EOS)
+            |a message
+          EOS
+        end
+
+        it "returns regular message with diff when single expected" do
+          expect(wrapped_value.message_with_diff(
+            message, differ_factory, actual
+          )).to eq(dedent <<-EOS)
+            |a message
+            |Diff:["actual value", "expected value"]
+          EOS
+        end
+
+        it "returns message with diff and matcher description when single expected with matcher" do
+          wrapped_value = described_class.for_many_matchers([include("expected value")])
+
+          expect(wrapped_value.message_with_diff(
+            message, differ_factory, actual
+          )).to eq(dedent <<-EOS)
+            |a message
+            |Diff for (include "expected value"):["actual value", ["expected value"]]
+          EOS
+        end
+
+        it "returns message with diff and truncated matcher description if it is too long" do
+          wrapped_value = described_class.for_many_matchers([matcher_with_long_description])
+
+          expect(wrapped_value.message_with_diff(
+            message, differ_factory, actual
+          )).to eq(dedent <<-EOS)
+            |a message
+            |Diff for (#{truncated_description}):["actual value", "expected value"]
+          EOS
+        end
+
+        it "handles custom matchers without description defined" do
+          wrapped_value = described_class.for_many_matchers([matcher_without_description_defined])
+
+          expect(wrapped_value.message_with_diff(
+            message, differ_factory, actual
+          )).to eq(dedent <<-EOS)
+            |a message
+            |Diff for (#{matcher_without_description_defined.inspect}):["actual value", "expected value"]
+          EOS
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
related to #712 

This is work in progress but some input required.

So I tried first to approach it by using special return value from `#expected` - an instance of class `ExpectedForMultipleDiffs`, but it became a mess very fast.
Then I tried to actually return more general `Expected` value and shifted responsibility of generating diffs to it.
But then it puzzled me, all the logic about composing `failure_message`-s of matchers is hidden inside of `CompoundMatcher`'s private methods, particularly in method `#failure_message`, and since diffs need to be injected inside of this `failure_message` at multiple places, I thought about actually having a special value for `failure_message` - `FailureMessage`

So the final idea is:
- have a class `LazyFailureMessage` and shift responsibility of generating diffs to it
- `lift` (or `coerce`) all `failure_message` values to it and give it a differ factory and let it return proper `failure_message` with diffs inside
- allow some matchers (`Compound` and `All`) to make evaluation of `failure_message` lazy, allowing it to wait for differ to pass it around to child matchers

You can look at the commits, they currently non-squashed and show failed attempts to tackle it.

Basically this variant of design works surprisingly well, but still it could be hard to understand, so I need some input and/or ideas. I thought, for example, about actually shifting responsibility of generating of `failure_message` for compound matchers somewhere outside of it - it could work out well too.

If this kind of design is ok to go, then I will just clean it up a bit and put some docs strings there.

/cc @myronmarston @JonRowe 