### PR TITLE
Exclude aruba 0.6.2 for now.

### DIFF
--- a/rspec-expectations.gemspec
+++ b/rspec-expectations.gemspec
@@ -41,6 +41,9 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake',     '~> 10.0.0'
   s.add_development_dependency 'cucumber', '~> 1.3'
-  s.add_development_dependency 'aruba',    '~> 0.5'
+  # Aruba 0.6.2 removed an API we rely on. For now we are excluding
+  # that version until we find out if they will restore it. See:
+  # https://github.com/cucumber/aruba/commit/5b2c7b445bc80083e577b793e4411887ef295660#commitcomment-9284628
+  s.add_development_dependency "aruba",    "~> 0.5", "!= 0.6.2"
   s.add_development_dependency 'minitest', '~> 5.2'
 end


### PR DESCRIPTION
This should fix the build.

See https://github.com/cucumber/aruba/commit/5b2c7b445bc80083e577b793e4411887ef295660#commitcomment-9284628 for background.