### PR TITLE
Update to aruba 0.6.2.

### DIFF
--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -1,6 +1,6 @@
 # Useful for when the output is slightly different on different versions of ruby
 Then /^the output should contain "([^"]*)" or "([^"]*)"$/ do |string1, string2|
-  unless [string1, string2].any? { |s| all_output =~ regexp(s) }
+  unless [string1, string2].any? { |s| all_output.include?(s) }
     fail %Q{Neither "#{string1}" or "#{string2}" were found in:\n#{all_output}}
   end
 end

--- a/rspec-expectations.gemspec
+++ b/rspec-expectations.gemspec
@@ -41,9 +41,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake',     '~> 10.0.0'
   s.add_development_dependency 'cucumber', '~> 1.3'
-  # Aruba 0.6.2 removed an API we rely on. For now we are excluding
-  # that version until we find out if they will restore it. See:
-  # https://github.com/cucumber/aruba/commit/5b2c7b445bc80083e577b793e4411887ef295660#commitcomment-9284628
-  s.add_development_dependency "aruba",    "~> 0.5", "!= 0.6.2"
+  s.add_development_dependency "aruba",    "~> 0.6"
   s.add_development_dependency 'minitest', '~> 5.2'
 end


### PR DESCRIPTION
0.6.2 removes regexp so we need to stop using it.