### PR TITLE
Refactor failure matcher definitions to use a recommended technique.

### DIFF
--- a/spec/rspec/expectations_spec.rb
+++ b/spec/rspec/expectations_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe "RSpec::Expectations" do
   it 'does not allow expectation failures to be caught by a bare rescue' do
     expect {
       expect(2).to eq(3) rescue nil
-    }.to fail_matching("expected: 3")
+    }.to fail_including("expected: 3")
   end
 end

--- a/spec/rspec/matchers/built_in/all_spec.rb
+++ b/spec/rspec/matchers/built_in/all_spec.rb
@@ -153,7 +153,7 @@ module RSpec::Matchers::BuiltIn
             expect(copied_matcher).not_to equal(all_matcher)
             expect(copied_matcher.matcher).not_to equal(base_matcher)
             expect([[3]]).to copied_matcher
-            expect { expect([[4]]).to copied_matcher }.to fail_matching("expected [4]")
+            expect { expect([[4]]).to copied_matcher }.to fail_including("expected [4]")
           end
 
         end

--- a/spec/rspec/matchers/built_in/be_spec.rb
+++ b/spec/rspec/matchers/built_in/be_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "expect(...).to be_predicate" do
   it "fails when actual does not respond to :predicate?" do
     expect {
       expect(Object.new).to be_happy
-    }.to fail_matching("to respond to `happy?`")
+    }.to fail_including("to respond to `happy?`")
   end
 
   it 'falls back to a present-tense form of the predicate when needed' do
@@ -147,7 +147,7 @@ RSpec.describe "expect(...).not_to be_predicate" do
   it "fails when actual does not respond to :sym?" do
     expect {
       expect(Object.new).not_to be_happy
-    }.to fail_matching("to respond to `happy?`")
+    }.to fail_including("to respond to `happy?`")
   end
 end
 
@@ -169,7 +169,7 @@ RSpec.describe "expect(...).to be_predicate(*args)" do
   it "fails when actual does not respond to :predicate?" do
     expect {
       expect(Object.new).to be_older_than(3)
-    }.to fail_matching("to respond to `older_than?`")
+    }.to fail_including("to respond to `older_than?`")
   end
 end
 
@@ -191,7 +191,7 @@ RSpec.describe "expect(...).not_to be_predicate(*args)" do
   it "fails when actual does not respond to :predicate?" do
     expect {
       expect(Object.new).not_to be_older_than(3)
-    }.to fail_matching("to respond to `older_than?`")
+    }.to fail_including("to respond to `older_than?`")
   end
 end
 
@@ -218,7 +218,7 @@ RSpec.describe "expect(...).to be_predicate(&block)" do
     delegate = double("delegate", :check_happy => true)
     expect {
       expect(Object.new).to be_happy { delegate.check_happy }
-    }.to fail_matching("to respond to `happy?`")
+    }.to fail_including("to respond to `happy?`")
   end
 
   it 'passes the block on to the present-tense predicate form' do
@@ -299,7 +299,7 @@ RSpec.describe "expect(...).not_to be_predicate(&block)" do
     delegate = double("delegate", :check_happy => true)
     expect {
       expect(Object.new).not_to be_happy { delegate.check_happy }
-    }.to fail_matching("to respond to `happy?`")
+    }.to fail_including("to respond to `happy?`")
   end
 end
 
@@ -326,7 +326,7 @@ RSpec.describe "expect(...).to be_predicate(*args, &block)" do
     delegate = double("delegate", :check_older_than => true)
     expect {
       expect(Object.new).to be_older_than(3) { |age| delegate.check_older_than(age) }
-    }.to fail_matching("to respond to `older_than?`")
+    }.to fail_including("to respond to `older_than?`")
   end
 end
 
@@ -353,7 +353,7 @@ RSpec.describe "expect(...).not_to be_predicate(*args, &block)" do
     delegate = double("delegate", :check_older_than => true)
     expect {
       expect(Object.new).not_to be_older_than(3) { |age| delegate.check_older_than(age) }
-    }.to fail_matching("to respond to `older_than?`")
+    }.to fail_including("to respond to `older_than?`")
   end
 end
 

--- a/spec/rspec/matchers/built_in/compound_spec.rb
+++ b/spec/rspec/matchers/built_in/compound_spec.rb
@@ -38,7 +38,7 @@ module RSpec::Matchers::BuiltIn
 
           expect([3]).to copy
 
-          expect { expect([4]).to copy }.to fail_matching("expected [4]")
+          expect { expect([4]).to copy }.to fail_including("expected [4]")
         end
       end
     end
@@ -229,7 +229,7 @@ module RSpec::Matchers::BuiltIn
 
           expect {
             expect(p).to combine(be_a(Integer), eq(3))
-          }.to fail_matching("expected: 3")
+          }.to fail_including("expected: 3")
         end
       end
     end
@@ -248,7 +248,7 @@ module RSpec::Matchers::BuiltIn
             a_string_starting_with("f").and(ending_with("d")),
             a_string_starting_with("b").and(ending_with("n"))
           )
-        }.to fail_matching('expected ["foo", "bar"] to include (a string starting with "f" and ending with "d") and (a string starting with "b" and ending with "n")')
+        }.to fail_including('expected ["foo", "bar"] to include (a string starting with "f" and ending with "d") and (a string starting with "b" and ending with "n")')
       end
 
       it 'provides a description' do
@@ -405,7 +405,7 @@ module RSpec::Matchers::BuiltIn
                   |baz
                   |bar
                 EOS
-              }.to fail_matching(expected_failure)
+              }.to fail_including(expected_failure)
             end
           end
 
@@ -418,7 +418,7 @@ module RSpec::Matchers::BuiltIn
                   |baz
                   |bar
                 EOS
-              }.to fail_matching(a_string_excluding "Diff")
+              }.to fail_with(a_string_excluding "Diff")
             end
           end
 
@@ -448,7 +448,7 @@ module RSpec::Matchers::BuiltIn
                   |baz
                   |bar
                 EOS
-              }.to fail_matching(expected_failure)
+              }.to fail_including(expected_failure)
             end
           end
         end
@@ -498,7 +498,7 @@ module RSpec::Matchers::BuiltIn
                 |baz
                 |bar
               EOS
-            }.to fail_matching(expected_failure)
+            }.to fail_including(expected_failure)
           end
         end
 
@@ -530,7 +530,7 @@ module RSpec::Matchers::BuiltIn
                 |baz
                 |bug
               EOS
-            }.to fail_matching(expected_failure)
+            }.to fail_including(expected_failure)
           end
         end
 
@@ -544,7 +544,7 @@ module RSpec::Matchers::BuiltIn
           it 'fails with a message not containing any diff' do
             expect {
               expect(35).to subject
-            }.to fail_matching(a_string_excluding "Diff")
+            }.to fail_with(a_string_excluding "Diff")
           end
         end
       end
@@ -692,7 +692,7 @@ module RSpec::Matchers::BuiltIn
               |baz
               |bug
             EOS
-          }.to fail_matching(expected_failure)
+          }.to fail_including(expected_failure)
         end
       end
 
@@ -725,7 +725,7 @@ module RSpec::Matchers::BuiltIn
               |baz
               |bug
             EOS
-          }.to fail_matching(expected_failure)
+          }.to fail_including(expected_failure)
         end
       end
 
@@ -757,7 +757,7 @@ module RSpec::Matchers::BuiltIn
               |baz
               |bug
             EOS
-          }.to fail_matching(expected_failure)
+          }.to fail_including(expected_failure)
         end
       end
 
@@ -771,7 +771,7 @@ module RSpec::Matchers::BuiltIn
         it 'fails with a message containing diffs for both matcher' do
           expect {
             expect(true).to subject
-          }.to fail_matching(a_string_excluding "Diff")
+          }.to fail_with(a_string_excluding "Diff")
         end
       end
     end
@@ -812,7 +812,7 @@ module RSpec::Matchers::BuiltIn
             |bug
             |squash
           EOS
-        }.to fail_matching(expected_failure)
+        }.to fail_including(expected_failure)
       end
 
       it 'fails with a complete message' do

--- a/spec/rspec/matchers/built_in/contain_exactly_spec.rb
+++ b/spec/rspec/matchers/built_in/contain_exactly_spec.rb
@@ -177,7 +177,7 @@ MESSAGE
 
       expect {
         expect(actual).to contain_exactly(*expected)
-      }.to fail_matching("the missing elements were:      [0, 1, 4, 4]")
+      }.to fail_including("the missing elements were:      [0, 1, 4, 4]")
     end
   end
 
@@ -300,7 +300,7 @@ RSpec.describe "matching against things that aren't arrays" do
     expect(Set.new([3, 2, 1])).to contain_exactly(1, 2, 3)
     expect {
       expect(Set.new([3, 2, 1])).to contain_exactly(1, 2)
-    }.to fail_matching("expected collection contained:  [1, 2]")
+    }.to fail_including("expected collection contained:  [1, 2]")
   end
 
   it 'works with non-enumerables that implement `to_ary`' do
@@ -308,7 +308,7 @@ RSpec.describe "matching against things that aren't arrays" do
     expect(relation).to contain_exactly(2, 1, 3)
     expect {
       expect(relation).to contain_exactly(1, 2)
-    }.to fail_matching("expected collection contained:  [1, 2]")
+    }.to fail_including("expected collection contained:  [1, 2]")
   end
 end
 

--- a/spec/rspec/matchers/built_in/eq_spec.rb
+++ b/spec/rspec/matchers/built_in/eq_spec.rb
@@ -56,7 +56,7 @@ module RSpec
       it 'fails properly when the actual is an array of multiline strings' do
         expect {
           expect(["a\nb", "c\nd"]).to eq([])
-        }.to fail_matching("expected: []")
+        }.to fail_including("expected: []")
       end
 
       describe '#description' do
@@ -161,7 +161,7 @@ module RSpec
         it 'fails with a conventional representation of the decimal' do
           expect {
             expect(float).to eq(decimal)
-          }.to fail_matching "expected: 3.3 (#<BigDecimal"
+          }.to fail_including "expected: 3.3 (#<BigDecimal"
         end
 
         it 'does not not assume BigDecimal is defined since you need to require `bigdecimal` to make it available' do

--- a/spec/rspec/matchers/built_in/exist_spec.rb
+++ b/spec/rspec/matchers/built_in/exist_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "exist matcher" do
         it "fails" do
           expect {
             expect(subject).send(expect_method, exist)
-          }.to fail_matching("it does not respond to either `exist?` or `exists?`")
+          }.to fail_including("it does not respond to either `exist?` or `exists?`")
         end
       end
     end
@@ -115,7 +115,7 @@ RSpec.describe "exist matcher" do
           it "fails" do
             expect {
               expect(subject).send(expect_method, exist)
-            }.to fail_matching("`exist?` and `exists?` returned different values")
+            }.to fail_including("`exist?` and `exists?` returned different values")
           end
         end
       end

--- a/spec/rspec/matchers/built_in/has_spec.rb
+++ b/spec/rspec/matchers/built_in/has_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "expect(...).to have_sym(*args)" do
   it "fails if target does not respond to #has_sym?" do
     expect {
       expect(Object.new).to have_key(:a)
-    }.to fail_matching('to respond to `has_key?`')
+    }.to fail_including('to respond to `has_key?`')
   end
 
   it "reraises an exception thrown in #has_sym?(*args)" do
@@ -138,7 +138,7 @@ RSpec.describe "expect(...).not_to have_sym(*args)" do
   it "fails if target does not respond to #has_sym?" do
     expect {
       expect(Object.new).not_to have_key(:a)
-    }.to fail_matching('to respond to `has_key?`')
+    }.to fail_including('to respond to `has_key?`')
   end
 
   it "reraises an exception thrown in #has_sym?(*args)" do

--- a/spec/rspec/matchers/built_in/have_attributes_spec.rb
+++ b/spec/rspec/matchers/built_in/have_attributes_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "#have_attributes matcher" do
     it "fails if target does not have any of the expected attributes" do
       expect {
         expect(person).to have_attributes(:name => wrong_name)
-      }.to fail_matching(%r|expected #{object_inspect person} to have attributes #{hash_inspect :name => wrong_name} but had attributes #{hash_inspect :name => correct_name }|)
+      }.to fail_with(%r|expected #{object_inspect person} to have attributes #{hash_inspect :name => wrong_name} but had attributes #{hash_inspect :name => correct_name }|)
     end
 
     it "fails with correct message if object manipulates its data" do
@@ -45,7 +45,7 @@ RSpec.describe "#have_attributes matcher" do
       end.new
       expect {
         expect(counter).to have_attributes(:count => 1)
-      }.to fail_matching(%r|to have attributes #{hash_inspect :count => 1} but had attributes #{hash_inspect :count => 2 }|)
+      }.to fail_with(%r|to have attributes #{hash_inspect :count => 1} but had attributes #{hash_inspect :count => 2 }|)
     end
 
     it 'diffs the attributes received with those expected' do
@@ -59,13 +59,13 @@ RSpec.describe "#have_attributes matcher" do
 
       expect {
         expect(person).to have_attributes(:name => wrong_name)
-      }.to fail_matching(expected_diff)
+      }.to fail_including(expected_diff)
     end
 
     it "fails if target does not responds to any of the attributes" do
       expect {
         expect(person).to have_attributes(:color => 'red')
-      }.to fail_matching("expected #{object_inspect person} to respond to :color")
+      }.to fail_including("expected #{object_inspect person} to respond to :color")
     end
 
     it "doesn't produce a diff if the target fails the respond to check" do
@@ -77,7 +77,7 @@ RSpec.describe "#have_attributes matcher" do
     it "fails if target responds to the attribute but requires arguments" do
       expect {
         expect(person).to have_attributes(:parent => 'Billy')
-      }.to fail_matching("expected #{object_inspect person} to respond to :parent with 0 arguments")
+      }.to fail_including("expected #{object_inspect person} to respond to :parent with 0 arguments")
     end
 
     describe "expect(...).to have_attributes(key => matcher)" do
@@ -94,7 +94,7 @@ RSpec.describe "#have_attributes matcher" do
       it "fails with a clear message when the matcher does not match" do
         expect {
           expect(person).to have_attributes(:age => (a_value < 10))
-        }.to fail_matching("expected #{object_inspect person} to have attributes {:age => (a value < 10)}")
+        }.to fail_including("expected #{object_inspect person} to have attributes {:age => (a value < 10)}")
       end
     end
   end
@@ -108,7 +108,7 @@ RSpec.describe "#have_attributes matcher" do
     it "fails if target has all of the expected attributes" do
       expect {
         expect(person).to_not have_attributes(:age => correct_age)
-      }.to fail_matching(%r|expected #{object_inspect person} not to have attributes #{hash_inspect :age => correct_age}|)
+      }.to fail_with(%r|expected #{object_inspect person} not to have attributes #{hash_inspect :age => correct_age}|)
     end
 
     it "doesn't produce a diff" do
@@ -120,13 +120,13 @@ RSpec.describe "#have_attributes matcher" do
     it "fails if target does not responds to any of the attributes" do
       expect {
         expect(person).to_not have_attributes(:color => 'red')
-      }.to fail_matching("expected #{object_inspect person} to respond to :color")
+      }.to fail_including("expected #{object_inspect person} to respond to :color")
     end
 
     it "fails if target responds to the attribute but requires arguments" do
       expect {
         expect(person).to_not have_attributes(:parent => 'Billy')
-      }.to fail_matching("expected #{object_inspect person} to respond to :parent with 0 arguments")
+      }.to fail_including("expected #{object_inspect person} to respond to :parent with 0 arguments")
     end
   end
 
@@ -143,7 +143,7 @@ RSpec.describe "#have_attributes matcher" do
     it "fails if target does not have any of the expected attributes" do
       expect {
         expect(person).to have_attributes(:name => correct_name, :age => wrong_age)
-      }.to fail_matching(%r|expected #{object_inspect person} to have attributes #{hash_inspect :name => correct_name, :age => wrong_age}|)
+      }.to fail_with(%r|expected #{object_inspect person} to have attributes #{hash_inspect :name => correct_name, :age => wrong_age}|)
     end
 
     it 'diffs the attributes received with those expected' do
@@ -158,19 +158,19 @@ RSpec.describe "#have_attributes matcher" do
 
       expect {
         expect(person).to have_attributes(:name => correct_name, :age => wrong_age)
-      }.to fail_matching(expected_diff)
+      }.to fail_including(expected_diff)
     end
 
     it "fails if target does not responds to any of the attributes" do
       expect {
         expect(person).to have_attributes(:name => correct_name, :color => 'red')
-      }.to fail_matching("expected #{object_inspect person} to respond to :color")
+      }.to fail_including("expected #{object_inspect person} to respond to :color")
     end
 
     it "fails if target responds to the attribute but requires arguments" do
       expect {
         expect(person).to have_attributes(:name => correct_name, :parent => 'Billy')
-      }.to fail_matching("expected #{object_inspect person} to respond to :parent with 0 arguments")
+      }.to fail_including("expected #{object_inspect person} to respond to :parent with 0 arguments")
     end
   end
 
@@ -183,25 +183,25 @@ RSpec.describe "#have_attributes matcher" do
     it "fails if target has any of the expected attributes" do
       expect {
         expect(person).to_not have_attributes(:name => wrong_name, :age => correct_age)
-      }.to fail_matching(%r|expected #{object_inspect person} not to have attributes #{hash_inspect :name => wrong_name, :age => correct_age}|)
+      }.to fail_with(%r|expected #{object_inspect person} not to have attributes #{hash_inspect :name => wrong_name, :age => correct_age}|)
     end
 
     it "fails if target has all of the expected attributes" do
       expect {
         expect(person).to_not have_attributes(:name => correct_name, :age => correct_age)
-      }.to fail_matching(%r|expected #{object_inspect person} not to have attributes #{hash_inspect :name => correct_name, :age => correct_age}|)
+      }.to fail_with(%r|expected #{object_inspect person} not to have attributes #{hash_inspect :name => correct_name, :age => correct_age}|)
     end
 
     it "fails if target does not responds to any of the attributes" do
       expect {
         expect(person).to_not have_attributes(:name => correct_name, :color => 'red')
-      }.to fail_matching("expected #{object_inspect person} to respond to :color")
+      }.to fail_including("expected #{object_inspect person} to respond to :color")
     end
 
     it "fails if target responds to the attribute but requires arguments" do
       expect {
         expect(person).to_not have_attributes(:name => correct_name, :parent => 'Billy')
-      }.to fail_matching("expected #{object_inspect person} to respond to :parent with 0 arguments")
+      }.to fail_including("expected #{object_inspect person} to respond to :parent with 0 arguments")
     end
   end
 

--- a/spec/rspec/matchers/built_in/include_spec.rb
+++ b/spec/rspec/matchers/built_in/include_spec.rb
@@ -256,13 +256,13 @@ RSpec.describe "#include matcher" do
       it "fails if the target includes all of the expected keys" do
         expect {
           expect({ :a => 1, :b => 2 }).not_to include(:a, :b)
-        }.to fail_matching(%r|expected #{hash_inspect :a => 1, :b => 2} not to include :a and :b|)
+        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 2} not to include :a and :b|)
       end
 
       it "fails if the target includes some (but not all) of the expected keys" do
         expect {
           expect({ :a => 1, :b => 2 }).not_to include(:d, :b)
-        }.to fail_matching(%r|expected #{hash_inspect :a => 1, :b => 2} not to include :d and :b|)
+        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 2} not to include :d and :b|)
       end
     end
 
@@ -332,7 +332,7 @@ RSpec.describe "#include matcher" do
       it "fails if target includes the key/value pair among others" do
         expect {
           expect({:key => 'value', :other => 'different'}).not_to include(:key => 'value')
-        }.to fail_matching(%r|expected #{hash_inspect :key => "value", :other => "different"} not to include \{:key => "value"\}|)
+        }.to fail_with(%r|expected #{hash_inspect :key => "value", :other => "different"} not to include \{:key => "value"\}|)
       end
 
       it "passes if target has a different value for key" do
@@ -370,25 +370,25 @@ RSpec.describe "#include matcher" do
       it "fails if target has a different value for one of the keys" do
         expect {
           expect({:a => 1, :b => 2}).to include(:a => 2, :b => 2)
-        }.to fail_matching(%r|expected #{hash_inspect :a => 1, :b => 2} to include #{hash_inspect :a => 2, :b => 2}|)
+        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 2} to include #{hash_inspect :a => 2, :b => 2}|)
       end
 
       it "fails if target has a different value for both of the keys" do
         expect {
           expect({:a => 1, :b => 1}).to include(:a => 2, :b => 2)
-        }.to fail_matching(%r|expected #{hash_inspect :a => 1, :b => 1} to include #{hash_inspect :a => 2, :b => 2}|)
+        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 1} to include #{hash_inspect :a => 2, :b => 2}|)
       end
 
       it "fails if target lacks one of the keys" do
         expect {
           expect({:a => 1, :b => 1}).to include(:a => 1, :c => 1)
-        }.to fail_matching(%r|expected #{hash_inspect :a => 1, :b => 1} to include #{hash_inspect :a => 1, :c => 1}|)
+        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 1} to include #{hash_inspect :a => 1, :c => 1}|)
       end
 
       it "fails if target lacks both of the keys" do
         expect {
           expect({:a => 1, :b => 1}).to include(:c => 1, :d => 1)
-        }.to fail_matching(%r|expected #{hash_inspect :a => 1, :b => 1} to include #{hash_inspect :c => 1, :d => 1}|)
+        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 1} to include #{hash_inspect :c => 1, :d => 1}|)
       end
     end
 
@@ -396,7 +396,7 @@ RSpec.describe "#include matcher" do
       it "fails if the target does not contain the given hash" do
         expect {
           expect(['a', 'b']).to include(:a => 1, :b => 1)
-        }.to fail_matching(%r|expected \["a", "b"\] to include #{hash_inspect :a => 1, :b => 1}|)
+        }.to fail_with(%r|expected \["a", "b"\] to include #{hash_inspect :a => 1, :b => 1}|)
       end
 
       it "passes if the target contains the given hash" do
@@ -410,20 +410,20 @@ RSpec.describe "#include matcher" do
       it "fails if target includes the key/value pairs" do
         expect {
           expect({:a => 1, :b => 2}).not_to include(:a => 1, :b => 2)
-        }.to fail_matching(%r|expected #{hash_inspect :a => 1, :b => 2} not to include #{hash_inspect :a => 1, :b => 2}|)
+        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 2} not to include #{hash_inspect :a => 1, :b => 2}|)
       end
 
       it "fails if target includes the key/value pairs among others" do
         hash = {:a => 1, :b => 2, :c => 3}
         expect {
           expect(hash).not_to include(:a => 1, :b => 2)
-        }.to fail_matching(%r|expected #{hash_inspect :a => 1, :b => 2, :c => 3} not to include #{hash_inspect :a => 1, :b => 2}|)
+        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 2, :c => 3} not to include #{hash_inspect :a => 1, :b => 2}|)
       end
 
       it "fails if target has a different value for one of the keys" do
         expect {
           expect({:a => 1, :b => 2}).not_to include(:a => 2, :b => 2)
-        }.to fail_matching(%r|expected #{hash_inspect :a => 1, :b => 2} not to include #{hash_inspect :a => 2, :b => 2}|)
+        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 2} not to include #{hash_inspect :a => 2, :b => 2}|)
       end
 
       it "passes if target has a different value for both of the keys" do
@@ -433,7 +433,7 @@ RSpec.describe "#include matcher" do
       it "fails if target lacks one of the keys" do
         expect {
           expect({:a => 1, :b => 1}).not_to include(:a => 1, :c => 1)
-        }.to fail_matching(%r|expected #{hash_inspect :a => 1, :b => 1} not to include #{hash_inspect :a => 1, :c => 1}|)
+        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 1} not to include #{hash_inspect :a => 1, :c => 1}|)
       end
 
       it "passes if target lacks both of the keys" do
@@ -449,7 +449,7 @@ RSpec.describe "#include matcher" do
       it "fails if the target contains the given hash" do
         expect {
           expect(['a', { :a => 1, :b => 2 } ]).not_to include(:a => 1, :b => 2)
-        }.to fail_matching(%r|expected \["a", #{hash_inspect :a => 1, :b => 2}\] not to include #{hash_inspect :a => 1, :b => 2}|)
+        }.to fail_with(%r|expected \["a", #{hash_inspect :a => 1, :b => 2}\] not to include #{hash_inspect :a => 1, :b => 2}|)
       end
     end
   end
@@ -582,6 +582,13 @@ RSpec.describe "#include matcher" do
     def hash_inspect(hash)
       improve_hash_formatting hash.inspect
     end
+  end
+
+  # `fail_including` uses the `include` matcher internally, and using a matcher
+  # to test itself is potentially problematic, so just for this spec file we
+  # use `fail_matching` instead, which converts to a regex instead.
+  def fail_matching(message)
+    raise_error(RSpec::Expectations::ExpectationNotMetError, /#{Regexp.escape(message)}/)
   end
 end
 

--- a/spec/rspec/matchers/built_in/output_spec.rb
+++ b/spec/rspec/matchers/built_in/output_spec.rb
@@ -85,13 +85,13 @@ RSpec.shared_examples "output_to_stream" do |stream_name, matcher_method, helper
     it "fails if the block does not output to #{stream_name}" do
       expect {
         expect { }.to matcher(/foo/)
-      }.to fail_matching("expected block to output /foo/ to #{stream_name}, but output nothing\nDiff")
+      }.to fail_including("expected block to output /foo/ to #{stream_name}, but output nothing\nDiff")
     end
 
     it "fails if the block outputs a string to #{stream_name} that does not match" do
       expect {
         expect { print_to_stream 'foo' }.to matcher(/food/)
-      }.to fail_matching("expected block to output /food/ to #{stream_name}, but output \"foo\"\nDiff")
+      }.to fail_including("expected block to output /food/ to #{stream_name}, but output \"foo\"\nDiff")
     end
   end
 
@@ -107,7 +107,7 @@ RSpec.shared_examples "output_to_stream" do |stream_name, matcher_method, helper
     it "fails if the block outputs a string to #{stream_name} that matches the regex" do
       expect {
         expect { print_to_stream 'foo' }.to_not matcher(/foo/)
-      }.to fail_matching("expected block to not output /foo/ to #{stream_name}, but output \"foo\"\nDiff")
+      }.to fail_including("expected block to not output /foo/ to #{stream_name}, but output \"foo\"\nDiff")
     end
   end
 
@@ -119,7 +119,7 @@ RSpec.shared_examples "output_to_stream" do |stream_name, matcher_method, helper
     it "fails if the block outputs a string to #{stream_name} that does not pass the given matcher" do
       expect {
         expect { print_to_stream 'foo' }.to matcher(a_string_starting_with("b"))
-      }.to fail_matching("expected block to output a string starting with \"b\" to #{stream_name}, but output \"foo\"\nDiff")
+      }.to fail_including("expected block to output a string starting with \"b\" to #{stream_name}, but output \"foo\"\nDiff")
     end
   end
 
@@ -131,7 +131,7 @@ RSpec.shared_examples "output_to_stream" do |stream_name, matcher_method, helper
     it "fails if the block outputs a string to #{stream_name} that passes the given matcher" do
       expect {
         expect { print_to_stream 'foo' }.to_not matcher(a_string_starting_with("f"))
-      }.to fail_matching("expected block to not output a string starting with \"f\" to #{stream_name}, but output \"foo\"\nDiff")
+      }.to fail_including("expected block to not output a string starting with \"f\" to #{stream_name}, but output \"foo\"\nDiff")
     end
   end
 end

--- a/spec/rspec/matchers/built_in/raise_error_spec.rb
+++ b/spec/rspec/matchers/built_in/raise_error_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe "Composing matchers with `raise_error`" do
     it 'fails with a clear message when the matcher does not match the raised error' do
       expect {
         expect { raise FooError }.to raise_error(an_error_with_attribute(:foo).equal_to(3))
-      }.to fail_matching("expected an error with attribute :foo equal to 3, got #<FooError: FooError>")
+      }.to fail_including("expected an error with attribute :foo equal to 3, got #<FooError: FooError>")
     end
 
     it 'provides a description' do
@@ -418,7 +418,7 @@ RSpec.describe "Composing matchers with `raise_error`" do
     it 'fails with a clear message when the matcher does not match the raised error' do
       expect {
         expect { raise FooError, "food" }.to raise_error(FooError, a_string_including("bar"))
-      }.to fail_matching('expected FooError with a string including "bar", got #<FooError: food')
+      }.to fail_including('expected FooError with a string including "bar", got #<FooError: food')
     end
 
     it 'provides a description' do
@@ -435,7 +435,7 @@ RSpec.describe "Composing matchers with `raise_error`" do
     it 'fails with a clear message when the matcher does not match the raised error' do
       expect {
         expect { raise FooError, "food" }.to raise_error(FooError).with_message(a_string_including("bar"))
-      }.to fail_matching('expected FooError with a string including "bar", got #<FooError: food')
+      }.to fail_including('expected FooError with a string including "bar", got #<FooError: food')
     end
 
     it 'provides a description' do

--- a/spec/rspec/matchers/built_in/start_and_end_with_spec.rb
+++ b/spec/rspec/matchers/built_in/start_and_end_with_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "expect(...).to start_with" do
 
       expect {
         expect([s1, 10]).to start_with(s2)
-      }.to fail_matching("expected [#{s1.inspect}, 10] to start with #{s2.inspect}")
+      }.to fail_including("expected [#{s1.inspect}, 10] to start with #{s2.inspect}")
     end
   end
 
@@ -97,7 +97,7 @@ RSpec.describe "expect(...).to start_with" do
 
       expect {
         expect([s1, 10]).to start_with(s2)
-      }.to fail_matching(%Q{expected [#{s1.inspect}, 10] to start with #{s2.inspect}})
+      }.to fail_including(%Q{expected [#{s1.inspect}, 10] to start with #{s2.inspect}})
     end
   end
 
@@ -279,7 +279,7 @@ RSpec.describe "expect(...).to end_with" do
 
       expect {
         expect([10, s1]).to end_with(s2)
-      }.to fail_matching("expected [10, #{s1.inspect}] to end with #{s2.inspect}")
+      }.to fail_including("expected [10, #{s1.inspect}] to end with #{s2.inspect}")
     end
   end
 
@@ -305,7 +305,7 @@ RSpec.describe "expect(...).to end_with" do
 
       expect {
         expect([10, s1]).to end_with(s2)
-      }.to fail_matching(%Q{expected [10, #{s1.inspect}] to end with #{s2.inspect}})
+      }.to fail_including(%Q{expected [10, #{s1.inspect}] to end with #{s2.inspect}})
     end
   end
 

--- a/spec/rspec/matchers_spec.rb
+++ b/spec/rspec/matchers_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe RSpec::Matchers do
     in_sub_process do
       main.instance_eval do
         include RSpec::Matchers
+        include FailMatchers
+
         expect(3).to eq(3)
         expect(3).to be_odd
 

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -32,24 +32,27 @@ RSpec::Matchers.define :have_string_length do |expected|
   end
 end
 
-module RSpec
-  module Matchers
-    def fail
-      raise_error(RSpec::Expectations::ExpectationNotMetError)
-    end
+module FailMatchers
+  def fail
+    raise_error(RSpec::Expectations::ExpectationNotMetError)
+  end
 
-    def fail_with(message)
-      raise_error(RSpec::Expectations::ExpectationNotMetError, message)
-    end
+  def fail_with(message)
+    raise_error(RSpec::Expectations::ExpectationNotMetError, message)
+  end
 
-    def fail_matching(message)
-      if String === message
-        regexp = /#{Regexp.escape(message)}/
-      else
-        regexp = message
-      end
-      raise_error(RSpec::Expectations::ExpectationNotMetError, regexp)
+  def fail_matching(message)
+    if String === message
+      regexp = /#{Regexp.escape(message)}/
+    else
+      regexp = message
     end
+    raise_error(RSpec::Expectations::ExpectationNotMetError, regexp)
   end
 end
+
+RSpec.configure do |config|
+  config.include FailMatchers
+end
+
 RSpec::Matchers.define_negated_matcher :a_string_excluding, :a_string_including

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -41,13 +41,11 @@ module FailMatchers
     raise_error(RSpec::Expectations::ExpectationNotMetError, message)
   end
 
-  def fail_matching(message)
-    if String === message
-      regexp = /#{Regexp.escape(message)}/
-    else
-      regexp = message
-    end
-    raise_error(RSpec::Expectations::ExpectationNotMetError, regexp)
+  def fail_including(snippet)
+    raise_error(
+      RSpec::Expectations::ExpectationNotMetError,
+      a_string_including(snippet)
+    )
   end
 end
 

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -85,7 +85,7 @@ RSpec.shared_examples "an RSpec matcher" do |options|
 
     expect {
       expect([invalid_value]).to include(matcher)
-    }.to fail_matching("include (#{matcher.description})")
+    }.to fail_including("include (#{matcher.description})")
   end
 
   it 'can match negatively properly' do


### PR DESCRIPTION
I wouldn't encourage users to directly define methods on `RSpec::Matchers` so we probably shouldn't, either.