### PR TITLE
Isolate a spec depending on set from the main process

### DIFF
--- a/spec/rspec/matchers/built_in/contain_exactly_spec.rb
+++ b/spec/rspec/matchers/built_in/contain_exactly_spec.rb
@@ -1,3 +1,4 @@
+require 'rspec/support/spec/in_sub_process'
 require 'timeout'
 
 class UnsortableObject
@@ -278,6 +279,8 @@ RSpec.describe "expect(...).not_to contain_exactly(:with, :multiple, :args)" do
 end
 
 RSpec.describe "matching against things that aren't arrays" do
+  include RSpec::Support::InSubProcess
+
   it "fails with nil and the expected error message is given" do
     expect {
       expect(nil).to contain_exactly(1, 2, 3)
@@ -297,10 +300,13 @@ RSpec.describe "matching against things that aren't arrays" do
   end
 
   it 'works with other collection objects' do
-    expect(Set.new([3, 2, 1])).to contain_exactly(1, 2, 3)
-    expect {
-      expect(Set.new([3, 2, 1])).to contain_exactly(1, 2)
-    }.to fail_including("expected collection contained:  [1, 2]")
+    in_sub_process do
+      require 'set'
+      expect(Set.new([3, 2, 1])).to contain_exactly(1, 2, 3)
+      expect {
+        expect(Set.new([3, 2, 1])).to contain_exactly(1, 2)
+      }.to fail_including("expected collection contained:  [1, 2]")
+    end
   end
 
   it 'works with non-enumerables that implement `to_ary`' do


### PR DESCRIPTION
This is breaking my attempts to remove our usage of `Set` in `rspec-core` because we don't require it before use here, but I also don't want to poison our own env so isolate it in a sub process (we use this trick on rspec-core to test similar things).