### PR TITLE
Allow custom matchers to use methods in Pretty

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 Enhancements:
 
+* Expose `RSpec::Matchers::EnglishPhrasing` to make it easier to write
+  nice failure messages in custom matchers. (Jared Beck, #736)
 * Make RSpecs fail matchers (for checking examples fail) publically available
   for use by extension/plugin authors. (Charlie Rudolph, #729)
 * Avoid loading `tempfile` (and its dependencies) unless

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -4,6 +4,7 @@ RSpec::Support.define_optimized_require_for_rspec(:matchers) { |f| require_relat
 
 %w[
   pretty
+  english_phrasing
   composable
   built_in
   generated_descriptions
@@ -243,7 +244,7 @@ module RSpec
     #     alias $1 $2
     def self.alias_matcher(new_name, old_name, options={}, &description_override)
       description_override ||= lambda do |old_desc|
-        old_desc.gsub(Pretty.split_words(old_name), Pretty.split_words(new_name))
+        old_desc.gsub(EnglishPhrasing.split_words(old_name), EnglishPhrasing.split_words(new_name))
       end
       klass = options.fetch(:klass) { AliasedMatcher }
 

--- a/lib/rspec/matchers/built_in/base_matcher.rb
+++ b/lib/rspec/matchers/built_in/base_matcher.rb
@@ -53,11 +53,12 @@ module RSpec
         end
 
         # @api private
-        # Generates a "pretty" description using the logic in {Pretty}.
+        # Generates a description using {EnglishPhrasing}.
         # @return [String]
         def description
-          return name_to_sentence unless defined?(@expected)
-          "#{name_to_sentence}#{to_sentence @expected}"
+          desc = EnglishPhrasing.split_words(name)
+          desc << EnglishPhrasing.list(@expected) if defined?(@expected)
+          desc
         end
 
         # @api private
@@ -84,7 +85,8 @@ module RSpec
 
         def assert_ivars(*expected_ivars)
           return unless (expected_ivars - present_ivars).any?
-          raise "#{self.class.name} needs to supply#{to_sentence expected_ivars}"
+          ivar_list = EnglishPhrasing.list(expected_ivars)
+          raise "#{self.class.name} needs to supply#{ivar_list}"
         end
 
         if RUBY_VERSION.to_f < 1.9

--- a/lib/rspec/matchers/built_in/be.rb
+++ b/lib/rspec/matchers/built_in/be.rb
@@ -87,11 +87,11 @@ module RSpec
         end
 
         def expected_to_sentence
-          split_words(@expected)
+          EnglishPhrasing.split_words(@expected)
         end
 
         def args_to_sentence
-          to_sentence(@args)
+          EnglishPhrasing.list(@args)
         end
       end
 
@@ -252,7 +252,7 @@ module RSpec
         end
 
         def prefix_to_sentence
-          split_words(@prefix)
+          EnglishPhrasing.split_words(@prefix)
         end
 
         def failure_message_expecting(value)

--- a/lib/rspec/matchers/built_in/contain_exactly.rb
+++ b/lib/rspec/matchers/built_in/contain_exactly.rb
@@ -23,13 +23,15 @@ module RSpec
         # @api private
         # @return [String]
         def failure_message_when_negated
-          "expected #{actual.inspect} not to contain exactly#{to_sentence(surface_descriptions_in expected)}"
+          list = EnglishPhrasing.list(surface_descriptions_in(expected))
+          "expected #{actual.inspect} not to contain exactly#{list}"
         end
 
         # @api private
         # @return [String]
         def description
-          "contain exactly#{to_sentence(surface_descriptions_in expected)}"
+          list = EnglishPhrasing.list(surface_descriptions_in(expected))
+          "contain exactly#{list}"
         end
 
       private

--- a/lib/rspec/matchers/built_in/eq.rb
+++ b/lib/rspec/matchers/built_in/eq.rb
@@ -20,7 +20,8 @@ module RSpec
         # @api private
         # @return [String]
         def description
-          "#{name_to_sentence} #{@expected.inspect}"
+          english_name = EnglishPhrasing.split_words(name)
+          "#{english_name} #{@expected.inspect}"
         end
 
         # @api private

--- a/lib/rspec/matchers/built_in/include.rb
+++ b/lib/rspec/matchers/built_in/include.rb
@@ -27,7 +27,8 @@ module RSpec
         # @return [String]
         def description
           described_items = surface_descriptions_in(expected)
-          improve_hash_formatting "include#{to_sentence(described_items)}"
+          item_list = EnglishPhrasing.list(described_items)
+          improve_hash_formatting "include#{item_list}"
         end
 
         # @api private

--- a/lib/rspec/matchers/built_in/start_or_end_with.rb
+++ b/lib/rspec/matchers/built_in/start_or_end_with.rb
@@ -26,7 +26,9 @@ module RSpec
         # @return [String]
         def description
           return super unless Hash === expected
-          "#{name_to_sentence} #{surface_descriptions_in(expected).inspect}"
+          english_name = EnglishPhrasing.split_words(name)
+          description_of_expected = surface_descriptions_in(expected).inspect
+          "#{english_name} #{description_of_expected}"
         end
 
       private

--- a/lib/rspec/matchers/dsl.rb
+++ b/lib/rspec/matchers/dsl.rb
@@ -300,7 +300,9 @@ module RSpec
 
         # The default description.
         def description
-          "#{name_to_sentence}#{to_sentence expected}#{chained_method_clause_sentences}"
+          english_name = EnglishPhrasing.split_words(name)
+          expected_list = EnglishPhrasing.list(expected)
+          "#{english_name}#{expected_list}#{chained_method_clause_sentences}"
         end
 
         # Matchers do not support block expectations by default. You
@@ -320,7 +322,9 @@ module RSpec
           return '' unless Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions?
 
           @chained_method_clauses.map do |(method_name, method_args)|
-            " #{split_words(method_name)}#{to_sentence(method_args)}"
+            english_name = EnglishPhrasing.split_words(method_name)
+            arg_list = EnglishPhrasing.list(method_args)
+            " #{english_name}#{arg_list}"
           end.join
         end
       end
@@ -336,7 +340,7 @@ module RSpec
         # Allows expectation expressions to be used in the match block.
         include RSpec::Matchers
 
-        # Converts matcher name and expected args to an English expresion.
+        # Facilitates better descriptions and failure messages.
         include RSpec::Matchers::Pretty
 
         # Supports the matcher composability features of RSpec 3+.

--- a/lib/rspec/matchers/english_phrasing.rb
+++ b/lib/rspec/matchers/english_phrasing.rb
@@ -1,0 +1,57 @@
+module RSpec
+  module Matchers
+    # Facilitates converting ruby objects to English phrases.
+    module EnglishPhrasing
+      # Converts a symbol into an English expression.
+      #
+      #     split_words(:banana_creme_pie) #=> "banana creme pie"
+      #
+      def self.split_words(sym)
+        sym.to_s.gsub(/_/, ' ')
+      end
+
+      # @note The returned string has a leading space except
+      # when given an empty list.
+      #
+      # Converts an object (often a collection of objects)
+      # into an English list.
+      #
+      #     list(['banana', 'kiwi', 'mango'])
+      #     #=> " \"banana\", \"kiwi\", and \"mango\""
+      #
+      # Given an empty collection, returns the empty string.
+      #
+      #     list([]) #=> ""
+      #
+      def self.list(obj)
+        return " #{obj.inspect}" if !obj || Struct === obj
+        items = Array(obj).map { |w| item_description(w) }
+        case items.length
+        when 0
+          ""
+        when 1
+          " #{items[0]}"
+        when 2
+          " #{items[0]} and #{items[1]}"
+        else
+          " #{items[0...-1].join(', ')}, and #{items[-1]}"
+        end
+      end
+
+      def self.is_matcher_with_description?(object)
+        RSpec::Matchers.is_a_matcher?(object) &&
+          object.respond_to?(:description)
+      end
+      private_class_method :is_matcher_with_description?
+
+      def self.item_description(obj)
+        if is_matcher_with_description?(obj)
+          obj.description
+        else
+          obj.inspect
+        end
+      end
+      private_class_method :item_description
+    end
+  end
+end

--- a/lib/rspec/matchers/pretty.rb
+++ b/lib/rspec/matchers/pretty.rb
@@ -10,17 +10,6 @@ module RSpec
         defined?(@name) ? @name : underscore(self.class.name.split("::").last)
       end
 
-      # @private
-      # Borrowed from ActiveSupport
-      def underscore(camel_cased_word)
-        word = camel_cased_word.to_s.dup
-        word.gsub!(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
-        word.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
-        word.tr!("-", "_")
-        word.downcase!
-        word
-      end
-
     private
 
       # `{ :a => 5, :b => 2 }.inspect` produces:
@@ -34,6 +23,17 @@ module RSpec
       # This is idempotent and safe to run on a string multiple times.
       def improve_hash_formatting(inspect_string)
         inspect_string.gsub(/(\S)=>(\S)/, '\1 => \2')
+      end
+
+      # @private
+      # Borrowed from ActiveSupport.
+      def underscore(camel_cased_word)
+        word = camel_cased_word.to_s.dup
+        word.gsub!(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+        word.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
+        word.tr!("-", "_")
+        word.downcase!
+        word
       end
     end
   end

--- a/lib/rspec/matchers/pretty.rb
+++ b/lib/rspec/matchers/pretty.rb
@@ -1,45 +1,9 @@
 module RSpec
   module Matchers
     # @api private
-    # Contains logic to facilitate converting ruby symbols and
-    # objects to english phrases.
+    # Facilitates better matcher descriptions and
+    # failure messages.
     module Pretty
-      # @api private
-      # Converts a symbol into an english expression.
-      def split_words(sym)
-        sym.to_s.gsub(/_/, ' ')
-      end
-      module_function :split_words
-
-      # @api private
-      # Converts a collection of objects into an english expression.
-      def to_sentence(words)
-        return " #{words.inspect}" if !words || Struct === words
-        words = Array(words).map { |w| to_word(w) }
-        case words.length
-        when 0
-          ""
-        when 1
-          " #{words[0]}"
-        when 2
-          " #{words[0]} and #{words[1]}"
-        else
-          " #{words[0...-1].join(', ')}, and #{words[-1]}"
-        end
-      end
-
-      # @api private
-      # Converts the given item to string suitable for use in a list expression.
-      def to_word(item)
-        is_matcher_with_description?(item) ? item.description : item.inspect
-      end
-
-      # @private
-      # Provides an English expression for the matcher name.
-      def name_to_sentence
-        split_words(name)
-      end
-
       # @api private
       # Provides a name for the matcher.
       def name
@@ -59,14 +23,13 @@ module RSpec
 
     private
 
-      def is_matcher_with_description?(object)
-        RSpec::Matchers.is_a_matcher?(object) && object.respond_to?(:description)
-      end
-
       # `{ :a => 5, :b => 2 }.inspect` produces:
-      #    {:a=>5, :b=>2}
+      #
+      #     {:a=>5, :b=>2}
+      #
       # ...but it looks much better as:
-      #    {:a => 5, :b => 2}
+      #
+      #     {:a => 5, :b => 2}
       #
       # This is idempotent and safe to run on a string multiple times.
       def improve_hash_formatting(inspect_string)

--- a/spec/rspec/matchers/built_in/have_attributes_spec.rb
+++ b/spec/rspec/matchers/built_in/have_attributes_spec.rb
@@ -205,7 +205,6 @@ RSpec.describe "#have_attributes matcher" do
     end
   end
 
-
   include RSpec::Matchers::Pretty
   # We have to use Hash#inspect in examples that have multi-entry
   # hashes because the #inspect output on 1.8.7 is non-deterministic

--- a/spec/rspec/matchers/english_phrasing_spec.rb
+++ b/spec/rspec/matchers/english_phrasing_spec.rb
@@ -1,0 +1,81 @@
+module RSpec
+  module Matchers
+    RSpec.describe EnglishPhrasing do
+      describe ".split_words" do
+        it "replaces underscores with spaces" do
+          expect(
+            described_class.split_words(:banana_creme_pie)
+          ).to eq("banana creme pie")
+        end
+
+        it "first casts its argument to string" do
+          arg = double(:to_s => "banana")
+          expect(described_class.split_words(arg)).to eq("banana")
+        end
+      end
+
+      describe ".list" do
+        context "given nil" do
+          it "returns value from inspect, and a leading space" do
+            expect(described_class.list(nil)).to eq(" nil")
+          end
+        end
+
+        context "given a Struct" do
+          it "returns value from inspect, and a leading space" do
+            banana = Struct.new("Banana", :flavor).new
+            expect(
+              described_class.list(banana)
+            ).to eq(" #{banana.inspect}")
+          end
+        end
+
+        context "given an Enumerable" do
+          before do
+            allow(described_class).to(
+              receive(:item_description).and_return("Banana")
+            )
+          end
+
+          context "with zero items" do
+            it "returns the empty string" do
+              expect(described_class.list([])).to eq("")
+            end
+          end
+
+          context "with one item" do
+            let(:list) { [double] }
+            it "returns description, and a leading space" do
+              expect(described_class.list(list)).to eq(" Banana")
+              expect(described_class).to(
+                have_received(:item_description).once
+              )
+            end
+          end
+
+          context "with two items" do
+            let(:list) { [double, double] }
+            it "returns descriptions, and a leading space" do
+              expect(described_class.list(list)).to eq(" Banana and Banana")
+              expect(described_class).to(
+                have_received(:item_description).twice
+              )
+            end
+          end
+
+          context "with three items" do
+            let(:list) { [double, double, double] }
+            it "returns descriptions, and a leading space" do
+              expect(
+                described_class.list(list)
+              ).to eq(" Banana, Banana, and Banana")
+              expect(described_class).to(
+                have_received(:item_description).exactly(3).times
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When writing a `failure_message` for a custom matcher, the methods in `Pretty` are useful.

Maybe we don't need all of them to be public, but some, like `to_sentence` would be nice.

This PR is just to get the conversation started.