### PR TITLE
Docs: Recommend the USE_GIT_REPOS var

### DIFF
--- a/DEV-README.md
+++ b/DEV-README.md
@@ -3,6 +3,7 @@
     git clone git://github.com/rspec/rspec-expectations.git
     cd rspec-expectations
     gem install bundler
+    export USE_GIT_REPOS=1 # optional
     bundle install
 
 Now you should be able to run any of:
@@ -26,3 +27,9 @@ The Gemfile includes the gems you'll need to be able to run specs. If you want
 to customize your dev enviroment with additional tools like guard or
 ruby-debug, add any additional gem declarations to Gemfile-custom (see
 Gemfile-custom.sample for some examples).
+
+## Use gem dependencies from filesystem
+
+To use rspec dependencies (rspec, rspec-core, rspec-mocks, or
+rspec-support) from the filesystem, instead of from git,
+omit the `USE_GIT_REPOS` above.


### PR DESCRIPTION
As a first-time contributor to rspec, I was unfamiliar with the dynamic Gemfile, and I ran into trouble because I had an old clone sitting in just the right place.  The dynamic Gemfile thought I wanted to use that old clone, so I got a dependency conflict.

It seems to me that using dependencies from the filesystem is a less common use-case than simply using the latest from git, so I think the instructions should explicity USE_GIT_REPOS.