### PR TITLE
Leverage new differ autoload.

### DIFF
--- a/lib/rspec/expectations/fail_with.rb
+++ b/lib/rspec/expectations/fail_with.rb
@@ -1,5 +1,3 @@
-RSpec::Support.require_rspec_support 'differ'
-
 module RSpec
   module Expectations
     class << self

--- a/spec/rspec/expectations_spec.rb
+++ b/spec/rspec/expectations_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "RSpec::Expectations" do
     ],
     :allowed_loaded_feature_regexps => [
       /stringio/, # Used by `output` matcher. Can't be easily avoided.
-      /prettyprint.rb/, /pp.rb/, /diff\/lcs/, /rbconfig/ # required by rspec-support
+      /rbconfig/  # required by rspec-support
     ]
 
   it 'does not allow expectation failures to be caught by a bare rescue' do


### PR DESCRIPTION
Builds on rspec/rspec-support#181. This avoids the
cost of loading diff/lcs, pp, etc for cases where
we don’t need to print any diffs.