### PR TITLE
Use precision based formatting provided by rspec-support

### DIFF
--- a/lib/rspec/expectations/expectation_target.rb
+++ b/lib/rspec/expectations/expectation_target.rb
@@ -98,21 +98,15 @@ module RSpec
       def enforce_block_expectation(matcher)
         return if supports_block_expectations?(matcher)
 
-        raise ExpectationNotMetError, "You must pass an argument rather than " \
-          "a block to use the provided matcher (#{description_of matcher}), or " \
-          "the matcher must implement `supports_block_expectations?`."
+        raise ExpectationNotMetError, "You must pass an argument rather than a block to use the provided " \
+          "matcher (#{RSpec::Support::ObjectInspector.inspect(matcher)}), or the matcher must implement " \
+          "`supports_block_expectations?`."
       end
 
       def supports_block_expectations?(matcher)
         matcher.supports_block_expectations?
       rescue NoMethodError
         false
-      end
-
-      def description_of(matcher)
-        matcher.description
-      rescue NoMethodError
-        matcher.inspect
       end
     end
   end

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -135,11 +135,11 @@ module RSpec
   #       end
   #
   #       def failure_message
-  #         "expected #{@target.inspect} to be in Zone #{@expected}"
+  #         "expected #{RSpec::Support::ObjectInspector.inspect(@target)} to be in Zone #{@expected}"
   #       end
   #
   #       def failure_message_when_negated
-  #         "expected #{@target.inspect} not to be in Zone #{@expected}"
+  #         "expected #{RSpec::Support::ObjectInspector.inspect(@target)} not to be in Zone #{@expected}"
   #       end
   #     end
   #

--- a/lib/rspec/matchers/built_in/base_matcher.rb
+++ b/lib/rspec/matchers/built_in/base_matcher.rb
@@ -80,6 +80,16 @@ module RSpec
           false
         end
 
+        # @api private
+        def expected_formatted
+          RSpec::Support::ObjectInspector.inspect(@expected)
+        end
+
+        # @api private
+        def actual_formatted
+          RSpec::Support::ObjectInspector.inspect(@actual)
+        end
+
         # @private
         def self.matcher_name
           @matcher_name ||= underscore(name.split("::").last)
@@ -141,7 +151,7 @@ module RSpec
           # you often only need to override `description`.
           # @return [String]
           def failure_message
-            "expected #{actual.inspect} to #{description}"
+            "expected #{RSpec::Support::ObjectInspector.inspect(@actual)} to #{description}"
           end
 
           # @api private
@@ -150,7 +160,7 @@ module RSpec
           # you often only need to override `description`.
           # @return [String]
           def failure_message_when_negated
-            "expected #{actual.inspect} not to #{description}"
+            "expected #{RSpec::Support::ObjectInspector.inspect(@actual)} not to #{description}"
           end
 
           # @private

--- a/lib/rspec/matchers/built_in/be.rb
+++ b/lib/rspec/matchers/built_in/be.rb
@@ -8,13 +8,13 @@ module RSpec
         # @api private
         # @return [String]
         def failure_message
-          "expected: truthy value\n     got: #{actual.inspect}"
+          "expected: truthy value\n     got: #{actual_formatted}"
         end
 
         # @api private
         # @return [String]
         def failure_message_when_negated
-          "expected: falsey value\n     got: #{actual.inspect}"
+          "expected: falsey value\n     got: #{actual_formatted}"
         end
 
       private
@@ -31,13 +31,13 @@ module RSpec
         # @api private
         # @return [String]
         def failure_message
-          "expected: falsey value\n     got: #{actual.inspect}"
+          "expected: falsey value\n     got: #{actual_formatted}"
         end
 
         # @api private
         # @return [String]
         def failure_message_when_negated
-          "expected: truthy value\n     got: #{actual.inspect}"
+          "expected: truthy value\n     got: #{actual_formatted}"
         end
 
       private
@@ -54,7 +54,7 @@ module RSpec
         # @api private
         # @return [String]
         def failure_message
-          "expected: nil\n     got: #{actual.inspect}"
+          "expected: nil\n     got: #{actual_formatted}"
         end
 
         # @api private
@@ -83,7 +83,7 @@ module RSpec
         end
 
         def inspected_args
-          @args.map { |a| a.inspect }
+          @args.map { |a| RSpec::Support::ObjectInspector.inspect(a) }
         end
 
         def expected_to_sentence
@@ -108,13 +108,13 @@ module RSpec
         # @api private
         # @return [String]
         def failure_message
-          "expected #{@actual.inspect} to evaluate to true"
+          "expected #{actual_formatted} to evaluate to true"
         end
 
         # @api private
         # @return [String]
         def failure_message_when_negated
-          "expected #{@actual.inspect} to evaluate to false"
+          "expected #{actual_formatted} to evaluate to false"
         end
 
         [:==, :<, :<=, :>=, :>, :===, :=~].each do |operator|
@@ -149,13 +149,13 @@ module RSpec
         # @api private
         # @return [String]
         def failure_message
-          "expected: #{@operator} #{@expected.inspect}\n     got: #{@operator.to_s.gsub(/./, ' ')} #{@actual.inspect}"
+          "expected: #{@operator} #{expected_formatted}\n     got: #{@operator.to_s.gsub(/./, ' ')} #{actual_formatted}"
         end
 
         # @api private
         # @return [String]
         def failure_message_when_negated
-          message = "`expect(#{@actual.inspect}).not_to be #{@operator} #{@expected.inspect}`"
+          message = "`expect(#{actual_formatted}).not_to be #{@operator} #{expected_formatted}`"
           if [:<, :>, :<=, :>=].include?(@operator)
             message + " not only FAILED, it is a bit confusing."
           else
@@ -257,7 +257,7 @@ module RSpec
 
         def failure_message_expecting(value)
           validity_message ||
-            "expected `#{@actual.inspect}.#{predicate}#{args_to_s}` to return #{value}, got #{@predicate_matches.inspect}"
+            "expected `#{actual_formatted}.#{predicate}#{args_to_s}` to return #{value}, got #{@predicate_matches.inspect}"
         end
 
         def validity_message

--- a/lib/rspec/matchers/built_in/be_within.rb
+++ b/lib/rspec/matchers/built_in/be_within.rb
@@ -38,13 +38,13 @@ module RSpec
         # @api private
         # @return [String]
         def failure_message
-          "expected #{@actual.inspect} to #{description}#{not_numeric_clause}"
+          "expected #{actual_formatted} to #{description}#{not_numeric_clause}"
         end
 
         # @api private
         # @return [String]
         def failure_message_when_negated
-          "expected #{@actual.inspect} not to #{description}"
+          "expected #{actual_formatted} not to #{description}"
         end
 
         # @api private

--- a/lib/rspec/matchers/built_in/contain_exactly.rb
+++ b/lib/rspec/matchers/built_in/contain_exactly.rb
@@ -9,14 +9,14 @@ module RSpec
         # @return [String]
         def failure_message
           if Array === actual
-            message  = "expected collection contained:  #{safe_sort(surface_descriptions_in expected).inspect}\n"
-            message += "actual collection contained:    #{safe_sort(actual).inspect}\n"
-            message += "the missing elements were:      #{safe_sort(surface_descriptions_in missing_items).inspect}\n" unless missing_items.empty?
-            message += "the extra elements were:        #{safe_sort(extra_items).inspect}\n" unless extra_items.empty?
+            message  = "expected collection contained:  #{RSpec::Support::ObjectInspector.inspect(safe_sort(surface_descriptions_in expected))}\n"
+            message += "actual collection contained:    #{RSpec::Support::ObjectInspector.inspect(safe_sort(actual))}\n"
+            message += "the missing elements were:      #{RSpec::Support::ObjectInspector.inspect(safe_sort(surface_descriptions_in missing_items))}\n" unless missing_items.empty?
+            message += "the extra elements were:        #{RSpec::Support::ObjectInspector.inspect(safe_sort(extra_items))}\n" unless extra_items.empty?
             message
           else
             "expected a collection that can be converted to an array with " \
-            "`#to_ary` or `#to_a`, but got #{actual.inspect}"
+            "`#to_ary` or `#to_a`, but got #{actual_formatted}"
           end
         end
 
@@ -24,7 +24,7 @@ module RSpec
         # @return [String]
         def failure_message_when_negated
           list = EnglishPhrasing.list(surface_descriptions_in(expected))
-          "expected #{actual.inspect} not to contain exactly#{list}"
+          "expected #{actual_formatted} not to contain exactly#{list}"
         end
 
         # @api private

--- a/lib/rspec/matchers/built_in/eq.rb
+++ b/lib/rspec/matchers/built_in/eq.rb
@@ -8,19 +8,19 @@ module RSpec
         # @api private
         # @return [String]
         def failure_message
-          "\nexpected: #{format_object(expected)}\n     got: #{format_object(actual)}\n\n(compared using ==)\n"
+          "\nexpected: #{expected_formatted}\n     got: #{actual_formatted}\n\n(compared using ==)\n"
         end
 
         # @api private
         # @return [String]
         def failure_message_when_negated
-          "\nexpected: value != #{format_object(expected)}\n     got: #{format_object(actual)}\n\n(compared using ==)\n"
+          "\nexpected: value != #{expected_formatted}\n     got: #{actual_formatted}\n\n(compared using ==)\n"
         end
 
         # @api private
         # @return [String]
         def description
-          "eq #{@expected.inspect}"
+          "eq #{expected_formatted}"
         end
 
         # @api private
@@ -33,41 +33,6 @@ module RSpec
 
         def match(expected, actual)
           actual == expected
-        end
-
-        def format_object(object)
-          if Time === object
-            format_time(object)
-          elsif defined?(DateTime) && DateTime === object
-            format_date_time(object)
-          elsif defined?(BigDecimal) && BigDecimal === object
-            "#{object.to_s 'F'} (#{object.inspect})"
-          else
-            object.inspect
-          end
-        end
-
-        TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
-
-        if Time.method_defined?(:nsec)
-          def format_time(time)
-            time.strftime("#{TIME_FORMAT}.#{"%09d" % time.nsec} %z")
-          end
-        else # for 1.8.7
-          def format_time(time)
-            time.strftime("#{TIME_FORMAT}.#{"%06d" % time.usec} %z")
-          end
-        end
-
-        DATE_TIME_FORMAT = "%a, %d %b %Y %H:%M:%S.%N %z"
-        # ActiveSupport sometimes overrides inspect. If `ActiveSupport` is
-        # defined use a custom format string that includes more time precision.
-        def format_date_time(date_time)
-          if defined?(ActiveSupport)
-            date_time.strftime(DATE_TIME_FORMAT)
-          else
-            date_time.inspect
-          end
         end
       end
     end

--- a/lib/rspec/matchers/built_in/eql.rb
+++ b/lib/rspec/matchers/built_in/eql.rb
@@ -8,13 +8,13 @@ module RSpec
         # @api private
         # @return [String]
         def failure_message
-          "\nexpected: #{expected.inspect}\n     got: #{actual.inspect}\n\n(compared using eql?)\n"
+          "\nexpected: #{expected_formatted}\n     got: #{actual_formatted}\n\n(compared using eql?)\n"
         end
 
         # @api private
         # @return [String]
         def failure_message_when_negated
-          "\nexpected: value != #{expected.inspect}\n     got: #{actual.inspect}\n\n(compared using eql?)\n"
+          "\nexpected: value != #{expected_formatted}\n     got: #{actual_formatted}\n\n(compared using eql?)\n"
         end
 
         # @api private

--- a/lib/rspec/matchers/built_in/equal.rb
+++ b/lib/rspec/matchers/built_in/equal.rb
@@ -48,14 +48,14 @@ MESSAGE
 
         def actual_inspected
           if LITERAL_SINGLETONS.include?(actual)
-            actual.inspect
+            actual_formatted
           else
             inspect_object(actual)
           end
         end
 
         def simple_failure_message
-          "\nexpected #{expected.inspect}\n     got #{actual_inspected}\n"
+          "\nexpected #{expected_formatted}\n     got #{actual_inspected}\n"
         end
 
         def detailed_failure_message
@@ -73,7 +73,7 @@ MESSAGE
         end
 
         def inspect_object(o)
-          "#<#{o.class}:#{o.object_id}> => #{o.inspect}"
+          "#<#{o.class}:#{o.object_id}> => #{RSpec::Support::ObjectInspector.inspect(o)}"
         end
       end
     end

--- a/lib/rspec/matchers/built_in/exist.rb
+++ b/lib/rspec/matchers/built_in/exist.rb
@@ -28,13 +28,13 @@ module RSpec
         # @api private
         # @return [String]
         def failure_message
-          "expected #{@actual.inspect} to exist#{@test.validity_message}"
+          "expected #{actual_formatted} to exist#{@test.validity_message}"
         end
 
         # @api private
         # @return [String]
         def failure_message_when_negated
-          "expected #{@actual.inspect} not to exist#{@test.validity_message}"
+          "expected #{actual_formatted} not to exist#{@test.validity_message}"
         end
 
         # @api private

--- a/lib/rspec/matchers/built_in/has.rb
+++ b/lib/rspec/matchers/built_in/has.rb
@@ -80,7 +80,7 @@ module RSpec
 
         def args_description
           return nil if @args.empty?
-          @args.map { |arg| arg.inspect }.join(', ')
+          @args.map { |arg| RSpec::Support::ObjectInspector.inspect(arg) }.join(', ')
         end
 
         def failure_message_args_description

--- a/lib/rspec/matchers/built_in/have_attributes.rb
+++ b/lib/rspec/matchers/built_in/have_attributes.rb
@@ -42,7 +42,7 @@ module RSpec
         # @return [String]
         def description
           described_items = surface_descriptions_in(expected)
-          improve_hash_formatting "have attributes #{described_items.inspect}"
+          improve_hash_formatting "have attributes #{RSpec::Support::ObjectInspector.inspect(described_items)}"
         end
 
         # @api private
@@ -55,14 +55,14 @@ module RSpec
         # @return [String]
         def failure_message
           respond_to_failure_message_or do
-            "expected #{@actual.inspect} to #{description} but had attributes #{ formatted_values }"
+            "expected #{actual_formatted} to #{description} but had attributes #{ formatted_values }"
           end
         end
 
         # @api private
         # @return [String]
         def failure_message_when_negated
-          respond_to_failure_message_or { "expected #{@actual.inspect} not to #{description}" }
+          respond_to_failure_message_or { "expected #{actual_formatted} not to #{description}" }
         end
 
       private
@@ -105,7 +105,8 @@ module RSpec
         end
 
         def formatted_values
-          improve_hash_formatting(@values.inspect)
+          values = RSpec::Support::ObjectInspector.inspect(@values)
+          improve_hash_formatting(values)
         end
       end
     end

--- a/lib/rspec/matchers/built_in/operators.rb
+++ b/lib/rspec/matchers/built_in/operators.rb
@@ -98,10 +98,15 @@ module RSpec
         def __delegate_operator(actual, operator, expected)
           if actual.__send__(operator, expected)
             true
-          elsif ['==', '===', '=~'].include?(operator)
-            fail_with_message("expected: #{expected.inspect}\n     got: #{actual.inspect} (using #{operator})")
           else
-            fail_with_message("expected: #{operator} #{expected.inspect}\n     got: #{operator.gsub(/./, ' ')} #{actual.inspect}")
+            expected_formatted = RSpec::Support::ObjectInspector.inspect(expected)
+            actual_formatted   = RSpec::Support::ObjectInspector.inspect(actual)
+
+            if ['==', '===', '=~'].include?(operator)
+              fail_with_message("expected: #{expected_formatted}\n     got: #{actual_formatted} (using #{operator})")
+            else
+              fail_with_message("expected: #{operator} #{expected_formatted}\n     got: #{operator.gsub(/./, ' ')} #{actual_formatted}")
+            end
           end
         end
       end
@@ -111,7 +116,11 @@ module RSpec
       class NegativeOperatorMatcher < OperatorMatcher
         def __delegate_operator(actual, operator, expected)
           return false unless actual.__send__(operator, expected)
-          fail_with_message("expected not: #{operator} #{expected.inspect}\n         got: #{operator.gsub(/./, ' ')} #{actual.inspect}")
+
+          expected_formatted = RSpec::Support::ObjectInspector.inspect(expected)
+          actual_formatted   = RSpec::Support::ObjectInspector.inspect(actual)
+
+          fail_with_message("expected not: #{operator} #{expected_formatted}\n         got: #{operator.gsub(/./, ' ')} #{actual_formatted}")
         end
       end
     end

--- a/lib/rspec/matchers/built_in/output.rb
+++ b/lib/rspec/matchers/built_in/output.rb
@@ -113,7 +113,7 @@ module RSpec
 
         def actual_output_description
           return "nothing" unless captured?
-          @actual.inspect
+          actual_formatted
         end
       end
 

--- a/lib/rspec/matchers/built_in/raise_error.rb
+++ b/lib/rspec/matchers/built_in/raise_error.rb
@@ -136,11 +136,11 @@ module RSpec
         def expected_error
           case @expected_message
           when nil
-            description_of(@expected_error)
+            RSpec::Support::ObjectInspector.inspect(@expected_error)
           when Regexp
-            "#{@expected_error} with message matching #{@expected_message.inspect}"
+            "#{@expected_error} with message matching #{RSpec::Support::ObjectInspector.inspect(@expected_message)}"
           else
-            "#{@expected_error} with #{description_of @expected_message}"
+            "#{@expected_error} with #{RSpec::Support::ObjectInspector.inspect(@expected_message)}"
           end
         end
 
@@ -155,7 +155,7 @@ module RSpec
 
           backtrace = format_backtrace(@actual_error.backtrace)
           [
-            ", got #{@actual_error.inspect} with backtrace:",
+            ", got #{RSpec::Support::ObjectInspector.inspect(@actual_error)} with backtrace:",
             *backtrace
           ].join("\n  # ")
         end

--- a/lib/rspec/matchers/built_in/yield.rb
+++ b/lib/rspec/matchers/built_in/yield.rb
@@ -317,7 +317,7 @@ module RSpec
           elsif all_args_match?
             "yielded with expected arguments" \
               "\nexpected not: #{surface_descriptions_in(@expected).inspect}" +
-              "\n         got: #{@actual.inspect}"
+              "\n         got: #{actual_formatted}"
           else
             "did"
           end
@@ -332,7 +332,7 @@ module RSpec
           unless (match = all_args_match?)
             @positive_args_failure = "yielded with unexpected arguments" \
               "\nexpected: #{surface_descriptions_in(@expected).inspect}" +
-              "\n     got: #{@actual.inspect}"
+              "\n     got: #{actual_formatted}"
           end
 
           match
@@ -400,7 +400,7 @@ module RSpec
 
           "yielded with unexpected arguments" \
           "\nexpected: #{surface_descriptions_in(@expected).inspect}" \
-          "\n     got: #{@actual.inspect}"
+          "\n     got: #{actual_formatted}"
         end
 
         def negative_failure_reason
@@ -408,7 +408,7 @@ module RSpec
 
           "yielded with expected arguments" \
           "\nexpected not: #{surface_descriptions_in(@expected).inspect}" \
-          "\n         got: #{@actual.inspect}"
+          "\n         got: #{actual_formatted}"
         end
       end
     end

--- a/lib/rspec/matchers/composable.rb
+++ b/lib/rspec/matchers/composable.rb
@@ -80,8 +80,7 @@ module RSpec
       #
       # @!visibility public
       def description_of(object)
-        return object.description if Matchers.is_a_describable_matcher?(object)
-        object.inspect
+        RSpec::Support::ObjectInspector.inspect(object)
       end
 
       # Transforms the given data structue (typically a hash or array)

--- a/spec/rspec/expectations/expectation_target_spec.rb
+++ b/spec/rspec/expectations/expectation_target_spec.rb
@@ -117,25 +117,27 @@ module RSpec
           end
 
           it "uses the matcher's `description` in the error message" do
-            custom_matcher = Module.new do
-              def self.supports_block_expectations?; false; end
-              def self.description; "matcher-description"; end
+            RSpec::Matchers.define :custom_matcher_with_description do
+              def supports_block_expectations?; false; end
+
+              match { true }
+              description { "matcher-description" }
             end
 
             expect {
-              expect { }.to custom_matcher
+              expect { }.to custom_matcher_with_description
             }.to fail_with(/\(matcher-description\)/)
           end
 
           context 'when the matcher does not define `description` (since it is an optional part of the protocol)' do
             it 'uses `inspect` in the error message instead' do
-              custom_matcher = Module.new do
-                def self.supports_block_expectations?; false; end
-                def self.inspect; "matcher-inspect"; end
+              RSpec::Matchers.define :custom_matcher_without_description do
+                def supports_block_expectations?; false; end
+                def inspect; "matcher-inspect"; end
               end
 
               expect {
-                expect { }.to custom_matcher
+                expect { }.to custom_matcher_without_description
               }.to fail_with(/\(matcher-inspect\)/)
             end
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'rspec/support/object_inspector'
 require 'rspec/support/spec'
 require 'rspec/support/spec/in_sub_process'
 


### PR DESCRIPTION
Precision output was moved to rspec-support, this commit removes the code that was moved. As part of rspec/rspec-mocks#898