### PR TITLE
Suggest `be_truthy`/`be true` when using `be_true`

### DIFF
--- a/lib/rspec/matchers/built_in/be.rb
+++ b/lib/rspec/matchers/built_in/be.rb
@@ -264,7 +264,15 @@ module RSpec
           return nil if predicate_accessible?
 
           msg = "expected #{@actual} to respond to `#{predicate}`"
-          msg << " but `#{predicate}` is a private method" if private_predicate?
+
+          if private_predicate?
+            msg << " but `#{predicate}` is a private method"
+          elsif predicate == :true?
+            msg << " or perhaps you meant `be true` or `be_truthy`"
+          elsif predicate == :false?
+            msg << " or perhaps you meant `be false` or `be_falsey`"
+          end
+
           msg
         end
       end

--- a/spec/rspec/matchers/built_in/be_spec.rb
+++ b/spec/rspec/matchers/built_in/be_spec.rb
@@ -124,6 +124,34 @@ RSpec.describe "expect(...).to be_predicate" do
     value = double(:happy? => false)
     expect(matcher == value).to be false
   end
+
+  it "indicates `be true` or `be_truthy` when using `be_true`" do
+    actual = double("actual")
+    expect {
+      expect(actual).to be_true
+    }.to fail_with(/or perhaps you meant `be true` or `be_truthy`/)
+  end
+
+  it "shows no message if actual responds to `true?` when using `be_true`" do
+    actual = double("actual", :true? => true)
+    expect {
+      expect(actual).to be_true
+    }.not_to raise_error
+  end
+
+  it "indicates `be false` or `be_falsey` when using `be_false`" do
+    actual = double("actual")
+    expect {
+      expect(actual).to be_false
+    }.to fail_with(/or perhaps you meant `be false` or `be_falsey`/)
+  end
+
+  it "shows no message if actual responds to `false?` when using `be_false`" do
+    actual = double("actual", :false? => true)
+    expect {
+      expect(actual).to be_false
+    }.not_to raise_error
+  end
 end
 
 RSpec.describe "expect(...).not_to be_predicate" do
@@ -690,4 +718,3 @@ RSpec.describe "be_an_instance_of" do
     expect(5).not_to be_an_instance_of(Numeric)
   end
 end
-


### PR DESCRIPTION
Applies the same for `be_false`. Still fails as expected, but adds an
additional message to suggest an alternative if still using the
deprecated `be_true`/`be_false`.

Little unsure of the wording here - this most likely needs revision.

https://github.com/rspec/rspec-expectations/issues/741