### PR TITLE
Special case formatting for objects inside objects

### DIFF
--- a/lib/rspec/matchers/built_in/base_matcher.rb
+++ b/lib/rspec/matchers/built_in/base_matcher.rb
@@ -113,6 +113,33 @@ module RSpec
           alias present_ivars instance_variables
         end
 
+        module TimeFormatting
+          TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+          if Time.method_defined?(:nsec)
+            def format_time(time)
+              time.strftime("#{TIME_FORMAT}.#{"%09d" % time.nsec} %z")
+            end
+          else # for 1.8.7
+            def format_time(time)
+              time.strftime("#{TIME_FORMAT}.#{"%06d" % time.usec} %z")
+            end
+          end
+
+          DATE_TIME_FORMAT = "%a, %d %b %Y %H:%M:%S.%N %z"
+          # ActiveSupport sometimes overrides inspect. If `ActiveSupport` is
+          # defined use a custom format string that includes more time precision.
+          def format_date_time(date_time)
+            if defined?(ActiveSupport)
+              date_time.strftime(DATE_TIME_FORMAT)
+            else
+              date_time.inspect
+            end
+          end
+        end
+
+        include TimeFormatting
+
         # @private
         module HashFormatting
           # `{ :a => 5, :b => 2 }.inspect` produces:

--- a/lib/rspec/matchers/built_in/base_matcher.rb
+++ b/lib/rspec/matchers/built_in/base_matcher.rb
@@ -113,6 +113,14 @@ module RSpec
           alias present_ivars instance_variables
         end
 
+        module BigDecimalFormatting
+          def format_big_decimal(object)
+            "#{object.to_s 'F'} (#{object.inspect})"
+          end
+        end
+
+        include BigDecimalFormatting
+
         module TimeFormatting
           TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 

--- a/lib/rspec/matchers/built_in/eq.rb
+++ b/lib/rspec/matchers/built_in/eq.rb
@@ -46,29 +46,6 @@ module RSpec
             object.inspect
           end
         end
-
-        TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
-
-        if Time.method_defined?(:nsec)
-          def format_time(time)
-            time.strftime("#{TIME_FORMAT}.#{"%09d" % time.nsec} %z")
-          end
-        else # for 1.8.7
-          def format_time(time)
-            time.strftime("#{TIME_FORMAT}.#{"%06d" % time.usec} %z")
-          end
-        end
-
-        DATE_TIME_FORMAT = "%a, %d %b %Y %H:%M:%S.%N %z"
-        # ActiveSupport sometimes overrides inspect. If `ActiveSupport` is
-        # defined use a custom format string that includes more time precision.
-        def format_date_time(date_time)
-          if defined?(ActiveSupport)
-            date_time.strftime(DATE_TIME_FORMAT)
-          else
-            date_time.inspect
-          end
-        end
       end
     end
   end

--- a/lib/rspec/matchers/built_in/eq.rb
+++ b/lib/rspec/matchers/built_in/eq.rb
@@ -50,6 +50,8 @@ module RSpec
               end.join(', ')
               }}
             OUTPUT
+          elsif defined?(Array) && Array === object
+            "[#{object.map { |element| format_object(element) }.join(', ')}]"
           else
             object.inspect
           end

--- a/lib/rspec/matchers/built_in/eq.rb
+++ b/lib/rspec/matchers/built_in/eq.rb
@@ -42,6 +42,14 @@ module RSpec
             format_date_time(object)
           elsif defined?(BigDecimal) && BigDecimal === object
             format_big_decimal(object)
+          elsif defined?(Hash) && Hash === object
+            <<-OUTPUT.strip
+              {#{
+              object.map do |k, v|
+                "#{format_object(k)}=>#{format_object(v)}"
+              end.join(', ')
+              }}
+            OUTPUT
           else
             object.inspect
           end

--- a/lib/rspec/matchers/built_in/eq.rb
+++ b/lib/rspec/matchers/built_in/eq.rb
@@ -41,7 +41,7 @@ module RSpec
           elsif defined?(DateTime) && DateTime === object
             format_date_time(object)
           elsif defined?(BigDecimal) && BigDecimal === object
-            "#{object.to_s 'F'} (#{object.inspect})"
+            format_big_decimal(object)
           else
             object.inspect
           end

--- a/spec/rspec/matchers/built_in/eq_spec.rb
+++ b/spec/rspec/matchers/built_in/eq_spec.rb
@@ -213,6 +213,17 @@ module RSpec
             end
           end
         end
+
+        context 'inside of Array objects' do
+          it 'fails with a conventional representation of the decimal inside an array' do
+            in_sub_process_if_possible do
+              require 'bigdecimal'
+              expect {
+                expect([]).to eq([[decimal]])
+              }.to fail_including "expected: [[3.3 (#<BigDecimal"
+            end
+          end
+        end
       end
     end
   end

--- a/spec/rspec/matchers/built_in/eq_spec.rb
+++ b/spec/rspec/matchers/built_in/eq_spec.rb
@@ -202,6 +202,17 @@ module RSpec
             expect(5).to eq(4)
           }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
         end
+
+        context 'inside of Hash objects' do
+          it 'fails with a conventional representation of the decimal inside the hash' do
+            in_sub_process_if_possible do
+              require 'bigdecimal'
+              expect {
+                expect({}).to eq({decimal => 'value'})
+              }.to fail_including "expected: {3.3 (#<BigDecimal"
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
On `rspec-expectations` some work had been done to improve the formatting of BigDecimal and Dates in expected failures.
However, this doesn't extend to objects of those types within Arrays and Hashes.

Here is my pull request to resolve the formatting within Arrays and Hashes.

Note: This might not be the best way to go out about this, and my code might not adhere to the current style guide. I'm simply providing this proof-of-concept to encourage discussion.

#### Example Test

``` ruby
      it 'x' do
        require 'bigdecimal'
        require 'active_support'
        expect(
          {
            BigDecimal('3') => nil,
            DateTime.new(2015,1,1) => nil,
            nil => {
              BigDecimal('4') => nil
            }
          }
        ).to eq ({
            nil => {
              BigDecimal('4') => nil
            }
        })
      end
```

#### Old
```
  1) eq x
     Failure/Error: expect(

       expected: {nil=>{#<BigDecimal:7fedc2e0ce20,'0.4E1',9(18)>=>nil}}
            got: {#<BigDecimal:7fedc2e0cfb0,'0.3E1',9(18)>=>nil, #<DateTime: 2015-01-01T00:00:00+00:00 ((2457024j,0s,0n),
+0s,2299161j)>=>nil, nil=>{#<BigDecimal:7fedc2e0cf10,'0.4E1',9(18)>=>nil}}
```

#### New
```
  1) eq x
     Failure/Error: expect(

       expected: {nil=>{4.0 (#<BigDecimal:7f9ad4d6e9c8,'0.4E1',9(18)>)=>nil}}
            got: {3.0 (#<BigDecimal:7f9ad4d6eb58,'0.3E1',9(18)>)=>nil, Thu, 01 Jan 2015 00:00:00.000000000 +0000=>nil, ni
l=>{4.0 (#<BigDecimal:7f9ad4d6eab8,'0.4E1',9(18)>)=>nil}}
```
