### PR TITLE
Make a context where RSpec::Matchers is included respond to missing be_* or have_*

### DIFF
--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -915,6 +915,7 @@ module RSpec
 
     BE_PREDICATE_REGEX = /^(be_(?:an?_)?)(.*)/
     HAS_REGEX = /^(?:have_)(.*)/
+    DYNAMIC_MATCHER_REGEX = Regexp.union(BE_PREDICATE_REGEX, HAS_REGEX)
 
     def method_missing(method, *args, &block)
       case method.to_s
@@ -925,6 +926,18 @@ module RSpec
       else
         super
       end
+    end
+
+    if RUBY_VERSION.to_f >= 1.9
+      def respond_to_missing?(method, *)
+        method =~ DYNAMIC_MATCHER_REGEX || super
+      end
+    else # for 1.8.7
+      def respond_to?(method, *)
+        method = method.to_s
+        method =~ DYNAMIC_MATCHER_REGEX || super
+      end
+      public :respond_to?
     end
 
     # @api private

--- a/spec/rspec/matchers_spec.rb
+++ b/spec/rspec/matchers_spec.rb
@@ -24,6 +24,22 @@ RSpec.describe RSpec::Matchers do
       end
     end
   end
+
+  describe "#respond_to?" do
+    it "handles dynamic matcher methods" do
+      expect(self).to respond_to(:be_happy, :have_eyes_closed)
+    end
+
+    it "supports the optional `include_private` arg" do
+      expect(self.respond_to?(:puts, true)).to eq true
+      expect(self.respond_to?(:puts, false)).to eq false
+      expect(self.respond_to?(:puts)).to eq false
+    end
+
+    it "allows `method` to get dynamic matcher methods", :if => RUBY_VERSION.to_f >= 1.9 do
+      expect(method(:be_happy).call).to be_a(be_happy.class)
+    end
+  end
 end
 
 module RSpec


### PR DESCRIPTION
Fixes https://github.com/rspec/rspec-expectations/issues/745