### PR TITLE
Update expectation output

### DIFF
--- a/lib/rspec/matchers/built_in/eq.rb
+++ b/lib/rspec/matchers/built_in/eq.rb
@@ -1,3 +1,5 @@
+RSpec::Support.require_rspec_support('object_inspector')
+
 module RSpec
   module Matchers
     module BuiltIn
@@ -36,38 +38,7 @@ module RSpec
         end
 
         def format_object(object)
-          if Time === object
-            format_time(object)
-          elsif defined?(DateTime) && DateTime === object
-            format_date_time(object)
-          elsif defined?(BigDecimal) && BigDecimal === object
-            "#{object.to_s 'F'} (#{object.inspect})"
-          else
-            object.inspect
-          end
-        end
-
-        TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
-
-        if Time.method_defined?(:nsec)
-          def format_time(time)
-            time.strftime("#{TIME_FORMAT}.#{"%09d" % time.nsec} %z")
-          end
-        else # for 1.8.7
-          def format_time(time)
-            time.strftime("#{TIME_FORMAT}.#{"%06d" % time.usec} %z")
-          end
-        end
-
-        DATE_TIME_FORMAT = "%a, %d %b %Y %H:%M:%S.%N %z"
-        # ActiveSupport sometimes overrides inspect. If `ActiveSupport` is
-        # defined use a custom format string that includes more time precision.
-        def format_date_time(date_time)
-          if defined?(ActiveSupport)
-            date_time.strftime(DATE_TIME_FORMAT)
-          else
-            date_time.inspect
-          end
+          RSpec::Support::ObjectInspector.inspect(object)
         end
       end
     end

--- a/spec/rspec/matchers/built_in/eq_spec.rb
+++ b/spec/rspec/matchers/built_in/eq_spec.rb
@@ -216,6 +216,19 @@ module RSpec
           end
         end
       end
+
+      context 'with Array objects with special case objects inside them' do
+        let(:decimal) { BigDecimal("3.3") }
+
+        it 'formats the special case objects inside it when failing' do
+          in_sub_process_if_possible do
+            require 'bigdecimal'
+            expect {
+              expect(true).to eq([[decimal]])
+            }.to fail_including "expected: [[3.3 (#<BigDecimal"
+          end
+        end
+      end
     end
   end
 end

--- a/spec/rspec/matchers/built_in/eq_spec.rb
+++ b/spec/rspec/matchers/built_in/eq_spec.rb
@@ -203,6 +203,19 @@ module RSpec
           }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
         end
       end
+
+      context 'with Hash objects with special case objects inside them' do
+        let(:decimal) { BigDecimal("3.3") }
+
+        it 'formats the special case objects inside it when failing' do
+          in_sub_process_if_possible do
+            require 'bigdecimal'
+            expect {
+              expect(true).to eq(:key => decimal)
+            }.to fail_including "expected: :key => 3.3 (#<BigDecimal"
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Now that `rspec-support` has the ObjectInspector, it makes sense to have the expectation formatter use that.
It would also be nice if it also formatted these special case objects when they appear inside Hashes and Arrays.
I've extended to ObjectInspector to do this in https://github.com/rspec/rspec-support/pull/191

In `rspec-expectations` it's a simple matter of having the `format_object` method pass it's data into the ObjectInspector,
and then adding a few tests.

#### Example Test

``` ruby
      it 'x' do
        require 'bigdecimal'
        require 'active_support'
        expect(
          {
            BigDecimal('3') => nil,
            DateTime.new(2015,1,1) => nil,
            nil => {
              BigDecimal('4') => nil
            }
          }
        ).to eq ({
            nil => {
              BigDecimal('4') => nil
            }
        })
      end
```

#### Old
```
  1) eq x
     Failure/Error: expect(

       expected: {nil=>{#<BigDecimal:7fedc2e0ce20,'0.4E1',9(18)>=>nil}}
            got: {#<BigDecimal:7fedc2e0cfb0,'0.3E1',9(18)>=>nil, #<DateTime: 2015-01-01T00:00:00+00:00 ((2457024j,0s,0n),
+0s,2299161j)>=>nil, nil=>{#<BigDecimal:7fedc2e0cf10,'0.4E1',9(18)>=>nil}}
```

#### New
```
  1) eq x
     Failure/Error: expect(

       expected: {nil=>{4.0 (#<BigDecimal:7f9ad4d6e9c8,'0.4E1',9(18)>)=>nil}}
            got: {3.0 (#<BigDecimal:7f9ad4d6eb58,'0.3E1',9(18)>)=>nil, Thu, 01 Jan 2015 00:00:00.000000000 +0000=>nil, ni
l=>{4.0 (#<BigDecimal:7f9ad4d6eab8,'0.4E1',9(18)>)=>nil}}
```
