### PR TITLE
Prevent infinite ranges blowing up matcher descriptions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,11 @@ Enhancements:
   `RSpec::Matchers#respond_to?` and `RSpec::Matchers#method` handle
   dynamic predicate matchers. (Andrei Botalov, #751)
 
+Bug Fixes:
+
+* Prevent `Range`s from being enumerated when generating matcher
+  descriptions. (Jon Rowe, #755)
+
 ### 3.2.0 / 2015-02-03
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.1.2...v3.2.0)
 

--- a/lib/rspec/matchers/built_in/contain_exactly.rb
+++ b/lib/rspec/matchers/built_in/contain_exactly.rb
@@ -52,7 +52,7 @@ module RSpec
         def convert_actual_to_an_array
           if actual.respond_to?(:to_ary)
             @actual = actual.to_ary
-          elsif enumerable?(actual) && actual.respond_to?(:to_a)
+          elsif should_enumerate?(actual) && actual.respond_to?(:to_a)
             @actual = actual.to_a
           else
             return false

--- a/lib/rspec/matchers/composable.rb
+++ b/lib/rspec/matchers/composable.rb
@@ -103,7 +103,7 @@ module RSpec
           Hash[surface_descriptions_in(item.to_a)]
         elsif Struct === item
           item.inspect
-        elsif enumerable?(item)
+        elsif should_enumerate?(item)
           begin
             item.map { |subitem| surface_descriptions_in(subitem) }
           rescue IOError # STDOUT is enumerable but `map` raises an error
@@ -137,7 +137,7 @@ module RSpec
           Hash[with_matchers_cloned(object.to_a)]
         elsif Struct === object
           object
-        elsif enumerable?(object)
+        elsif should_enumerate?(object)
           begin
             object.map { |subobject| with_matchers_cloned(subobject) }
           rescue IOError # STDOUT is enumerable but `map` raises an error
@@ -155,17 +155,17 @@ module RSpec
         # a single 1-character string, which is an enumerable, etc.
         #
         # @api private
-        def enumerable?(item)
+        def should_enumerate?(item)
           return false if String === item
-          Enumerable === item
+          Enumerable === item && !(Range === item)
         end
       else
         # @api private
-        def enumerable?(item)
-          Enumerable === item
+        def should_enumerate?(item)
+          Enumerable === item && !(Range === item)
         end
       end
-      module_function :surface_descriptions_in, :enumerable?
+      module_function :surface_descriptions_in, :should_enumerate?
 
       # Wraps an item in order to surface its `description` via `inspect`.
       # @api private

--- a/spec/rspec/matchers/composable_spec.rb
+++ b/spec/rspec/matchers/composable_spec.rb
@@ -12,6 +12,19 @@ module RSpec
         }.to fail_with(STDOUT.inspect)
       end
 
+      it "does not blow up when surfacing descriptions from an unreadable Range object" do
+        infinite_range = -Float::INFINITY..Float::INFINITY
+        expect {
+          expect(1).to matcher_using_surface_descriptions_in(infinite_range)
+        }.to fail_with(infinite_range.inspect)
+      end
+
+      it "does not enumerate normal ranges" do
+        expect {
+          expect(1).to matcher_using_surface_descriptions_in(1..3)
+        }.to fail_with((1..3).inspect)
+      end
+
       it "doesn't mangle struct descriptions" do
         model = Struct.new(:a).new(1)
         expect {


### PR DESCRIPTION
Prevent infinite ranges blowing up matcher descriptions, like IO it seems they're not always enumerable. Fixes #754.