### PR TITLE
Fix `contain_exactly` to work with test doubles.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,11 @@ Enhancements:
   `RSpec::Matchers#respond_to?` and `RSpec::Matchers#method` handle
   dynamic predicate matchers. (Andrei Botalov, #751)
 
+Bug Fixes:
+
+* Make `contain_exactly` / `match_array` work with strict test doubles
+  that have not defined `<=>`. (Myron Marston, #758)
+
 ### 3.2.0 / 2015-02-03
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.1.2...v3.2.0)
 

--- a/lib/rspec/matchers/built_in/contain_exactly.rb
+++ b/lib/rspec/matchers/built_in/contain_exactly.rb
@@ -60,7 +60,9 @@ module RSpec
         end
 
         def safe_sort(array)
-          array.sort rescue array
+          array.sort
+        rescue Exception
+          array
         end
 
         def missing_items

--- a/spec/rspec/matchers/built_in/contain_exactly_spec.rb
+++ b/spec/rspec/matchers/built_in/contain_exactly_spec.rb
@@ -124,6 +124,17 @@ RSpec.describe "using contain_exactly with expect" do
       {:a => (a_value < 0)}
     )
   end
+
+  it 'works with strict test doubles (which have not defined `<=>`)' do
+    dbl_1 = double("1")
+    dbl_2 = double("2")
+
+    expect([dbl_1, dbl_2]).to contain_exactly(dbl_2, dbl_1)
+
+    expect {
+      expect([dbl_1, dbl_2]).to contain_exactly(dbl_1)
+    }.to fail
+  end
 end
 
 RSpec.describe "expect(array).to contain_exactly(*other_array)" do


### PR DESCRIPTION
Test doubles do not define `<=>` by default.