### PR TITLE
Avoid diffing for problematic `include` cases

### DIFF
--- a/lib/rspec/matchers/built_in/include.rb
+++ b/lib/rspec/matchers/built_in/include.rb
@@ -46,7 +46,7 @@ module RSpec
         # @api private
         # @return [Boolean]
         def diffable?
-          true
+          !diff_would_wrongly_highlight_matched_item?
         end
 
       private
@@ -99,6 +99,15 @@ module RSpec
           return false unless actual.respond_to?(:any?)
 
           actual.any? { |value| values_match?(expected_item, value) }
+        end
+
+        def diff_would_wrongly_highlight_matched_item?
+          return false unless actual.is_a?(String) && expected.is_a?(Array)
+
+          lines = actual.split("\n")
+          expected.any? do |str|
+            actual.include?(str) && lines.none? { |line| line == str }
+          end
         end
       end
     end

--- a/spec/rspec/matchers/built_in/include_spec.rb
+++ b/spec/rspec/matchers/built_in/include_spec.rb
@@ -51,6 +51,12 @@ RSpec.describe "#include matcher" do
           expect("abc\ndef").to include("g", "h")
         }.to fail_matching("expected \"abc\\ndef\" to include \"g\" and \"h\"\nDiff")
       end
+
+      it "does not diff when lines match but are not an exact match" do
+        expect {
+          expect(" foo\nbar\nbazz").to include("foo", "bar", "gaz")
+        }.to fail_with(a_string_not_matching(/Diff/i))
+      end
     end
 
     context "for an array target" do
@@ -578,4 +584,3 @@ RSpec.describe "#include matcher" do
     raise_error(RSpec::Expectations::ExpectationNotMetError, /#{Regexp.escape(message)}/)
   end
 end
-

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -40,3 +40,4 @@ RSpec.configure do |config|
 end
 
 RSpec::Matchers.define_negated_matcher :a_string_excluding, :a_string_including
+RSpec::Matchers.define_negated_matcher :a_string_not_matching, :match


### PR DESCRIPTION
Avoid diffing for problematic include cases.
    
Include#diffable? will return true unless it detects a multiline string with at least one "expected" that is included in "actual", but is not an exact match for any single line.

This was the most conservative strategy I could think of on this pass, and to my amazement it didn't cause any other tests to fail. (!)

I can squash these commits once this PR is ready, but didn't want to lose my first commit in case I needed that test again. It was by far the hardest part of the task so far!

Addresses https://github.com/rspec/rspec-expectations/issues/746