### PR TITLE
Warn about bare `raise_error`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,10 @@ Enhancements:
 * Use custom Time/DateTime/BigDecimal formatting for all matchers
   so they are consistently represented in failure messages.
   (Gavin Miller, #740)
+* Add configuration to turn off warnings about matcher combinations that
+  may cause false positives. (Jon Rowe, #768)
+* Warn when using a bare `raise_error` matcher that you may be subject to
+  false positives. (Jon Rowe, #768)
 
 Bug Fixes:
 

--- a/lib/rspec/expectations/configuration.rb
+++ b/lib/rspec/expectations/configuration.rb
@@ -18,6 +18,10 @@ module RSpec
     #
     #   RSpec::Expectations.configuration
     class Configuration
+      def initialize
+        @warn_about_false_positives = true
+      end
+
       # Configures the supported syntax.
       # @param [Array<Symbol>, Symbol] values the syntaxes to enable
       # @example
@@ -132,6 +136,19 @@ module RSpec
         def self.format_backtrace(backtrace)
           backtrace
         end
+      end
+
+      # Configures whether RSpec will warn about matcher use which will
+      # potentially cause false positives in tests.
+      #
+      # @param value [Boolean]
+      attr_writer :warn_about_false_positives
+
+      # Indicates whether RSpec will warn about matcher use which will
+      # potentially cause false positives in tests, generally you want to
+      # avoid such scenarios so this defaults to `true`.
+      def warn_about_false_positives?
+        @warn_about_false_positives
       end
     end
 

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -732,7 +732,7 @@ module RSpec
     #   expect { do_something_risky }.to raise_error(PoorRiskDecisionError, /oo ri/)
     #
     #   expect { do_something_risky }.not_to raise_error
-    def raise_error(error=Exception, message=nil, &block)
+    def raise_error(error=nil, message=nil, &block)
       BuiltIn::RaiseError.new(error, message, &block)
     end
     alias_method :raise_exception,  :raise_error

--- a/lib/rspec/matchers/built_in/raise_error.rb
+++ b/lib/rspec/matchers/built_in/raise_error.rb
@@ -44,17 +44,7 @@ module RSpec
           @eval_block = false
           @eval_block_passed = false
 
-          if warning_about_bare_error && !negative_expectation
-            RSpec.warning("Using the `raise_error` matcher without providing a specific " \
-                          "error or message risks false positives, since `raise_error` " \
-                          "will match when Ruby raises a `NoMethodError`, `NameError` or " \
-                          "`ArgumentError`, potentially allowing the expectation to pass " \
-                          "without even executing the method you are intending to call. " \
-                          "Instead consider providing a specific error class or message. " \
-                          "This message can be supressed by setting: " \
-                          "`RSpec::Expectations.configuration.warn_about_false_positives = false`")
-          end
-
+          warn_about_bare_error if warning_about_bare_error && !negative_expectation
           return false unless Proc === given_proc
 
           begin
@@ -155,6 +145,17 @@ module RSpec
 
         def warning_about_bare_error
           @warn_about_bare_error && @block.nil?
+        end
+
+        def warn_about_bare_error
+          RSpec.warning("Using the `raise_error` matcher without providing a specific " \
+                        "error or message risks false positives, since `raise_error` " \
+                        "will match when Ruby raises a `NoMethodError`, `NameError` or " \
+                        "`ArgumentError`, potentially allowing the expectation to pass " \
+                        "without even executing the method you are intending to call. " \
+                        "Instead consider providing a specific error class or message. " \
+                        "This message can be supressed by setting: " \
+                        "`RSpec::Expectations.configuration.warn_about_false_positives = false`")
         end
 
         def expected_error

--- a/lib/rspec/matchers/built_in/raise_error.rb
+++ b/lib/rspec/matchers/built_in/raise_error.rb
@@ -44,7 +44,7 @@ module RSpec
           @eval_block = false
           @eval_block_passed = false
 
-          if @warn_about_bare_error && !negative_expectation && @block.nil?
+          if warning_about_bare_error && !negative_expectation
             RSpec.warning("Using the `raise_error` matcher without providing a specific " \
                           "error or message risks false positives, since `raise_error` " \
                           "will match when Ruby raises a `NoMethodError`, `NameError` or " \
@@ -66,9 +66,7 @@ module RSpec
             end
           end
 
-          unless negative_expectation
-            eval_block if @raised_expected_error && @with_expected_message && @block
-          end
+          eval_block if !negative_expectation && ready_to_eval_block?
 
           expectation_matched?
         end
@@ -121,6 +119,10 @@ module RSpec
           @eval_block ? @eval_block_passed : true
         end
 
+        def ready_to_eval_block?
+          @raised_expected_error && @with_expected_message && @block
+        end
+
         def eval_block
           @eval_block = true
           begin
@@ -149,6 +151,10 @@ module RSpec
 
           specific_class_error = ArgumentError.new("#{what_to_raise} is not valid, use `expect { }.not_to raise_error` (with no args) instead")
           raise specific_class_error
+        end
+
+        def warning_about_bare_error
+          @warn_about_bare_error && @block.nil?
         end
 
         def expected_error

--- a/spec/rspec/expectations/configuration_spec.rb
+++ b/spec/rspec/expectations/configuration_spec.rb
@@ -87,6 +87,23 @@ module RSpec
         end
       end
 
+      describe "#warn_about_false_positives?" do
+        it "is true by default" do
+          expect(config.warn_about_false_positives?).to be true
+        end
+
+        it "can be set to false" do
+          config.warn_about_false_positives = false
+          expect(config.warn_about_false_positives?).to be false
+        end
+
+        it "can be set back to true" do
+          config.warn_about_false_positives = false
+          config.warn_about_false_positives = true
+          expect(config.warn_about_false_positives?).to be true
+        end
+      end
+
       shared_examples "configuring the expectation syntax" do
         before do
           @orig_syntax = RSpec::Matchers.configuration.syntax

--- a/spec/rspec/matchers/built_in/base_matcher_spec.rb
+++ b/spec/rspec/matchers/built_in/base_matcher_spec.rb
@@ -26,7 +26,7 @@ module RSpec::Matchers::BuiltIn
       it "re-raises any error other than one of those specified" do
         expect do
           matcher.match_unless_raises(ArgumentError){ raise "foo" }
-        end.to raise_error
+        end.to raise_error "foo"
       end
 
       it "stores the rescued exception for use in messages" do

--- a/spec/rspec/matchers/built_in/raise_error_spec.rb
+++ b/spec/rspec/matchers/built_in/raise_error_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "expect { ... }.to raise_error" do
     original_value = RSpec::Expectations.configuration.warn_about_false_positives?
     begin
       RSpec::Expectations.configuration.warn_about_false_positives = false
+      expect_no_warnings
       expect { raise }.to raise_error
     ensure
       RSpec::Expectations.configuration.warn_about_false_positives = original_value
@@ -24,14 +25,17 @@ RSpec.describe "expect { ... }.to raise_error" do
   end
 
   it 'does not issue a warning when an exception class is specified (even if it is just `Exception`)' do
+    expect_no_warnings
     expect { raise "error" }.to raise_error Exception
   end
 
   it 'does not issue a warning when a message is specified' do
+    expect_no_warnings
     expect { raise "error" }.to raise_error "error"
   end
 
   it 'does not issue a warning when a block is passed' do
+    expect_no_warnings
     expect { raise "error" }.to raise_error { |_| }
   end
 

--- a/spec/rspec/matchers/built_in/raise_error_spec.rb
+++ b/spec/rspec/matchers/built_in/raise_error_spec.rb
@@ -23,6 +23,18 @@ RSpec.describe "expect { ... }.to raise_error" do
     end
   end
 
+  it 'does not issue a warning when an exception class is specified (even if it is just `Exception`)' do
+    expect { raise "error" }.to raise_error Exception
+  end
+
+  it 'does not issue a warning when a message is specified' do
+    expect { raise "error" }.to raise_error "error"
+  end
+
+  it 'does not issue a warning when a block is passed' do
+    expect { raise "error" }.to raise_error { |_| }
+  end
+
   it "passes if an error instance is expected" do
     s = StandardError.new
     expect {raise s}.to raise_error(s)

--- a/spec/rspec/matchers/built_in/raise_error_spec.rb
+++ b/spec/rspec/matchers/built_in/raise_error_spec.rb
@@ -1,11 +1,26 @@
 RSpec.describe "expect { ... }.to raise_error" do
   it_behaves_like("an RSpec matcher", :valid_value => lambda { raise "boom" },
                                       :invalid_value => lambda { }) do
-    let(:matcher) { raise_error }
+    let(:matcher) { raise_error Exception }
   end
 
   it "passes if anything is raised" do
-    expect {raise}.to raise_error
+    expect { raise "error" }.to raise_error "error"
+  end
+
+  it "issues a warning when used without an error class or message" do
+    expect_warning_with_call_site __FILE__, __LINE__+1, /without providing a specific error/
+    expect { raise }.to raise_error
+  end
+
+  it "can supresses the warning when configured to do so" do
+    original_value = RSpec::Expectations.configuration.warn_about_false_positives?
+    begin
+      RSpec::Expectations.configuration.warn_about_false_positives = false
+      expect { raise }.to raise_error
+    ensure
+      RSpec::Expectations.configuration.warn_about_false_positives = original_value
+    end
   end
 
   it "passes if an error instance is expected" do
@@ -48,14 +63,14 @@ RSpec.describe "expect { ... }.to raise_error" do
 
   it "fails if nothing is raised" do
     expect {
-      expect {}.to raise_error
+      expect { }.to raise_error Exception
     }.to fail_with("expected Exception but nothing was raised")
   end
 end
 
 RSpec.describe "raise_exception aliased to raise_error" do
   it "passes if anything is raised" do
-    expect {raise}.to raise_exception
+    expect { raise "exception" }.to raise_exception "exception"
   end
 end
 

--- a/spec/rspec/matchers/built_in/raise_error_spec.rb
+++ b/spec/rspec/matchers/built_in/raise_error_spec.rb
@@ -13,15 +13,10 @@ RSpec.describe "expect { ... }.to raise_error" do
     expect { raise }.to raise_error
   end
 
-  it "can supresses the warning when configured to do so" do
-    original_value = RSpec::Expectations.configuration.warn_about_false_positives?
-    begin
-      RSpec::Expectations.configuration.warn_about_false_positives = false
-      expect_no_warnings
-      expect { raise }.to raise_error
-    ensure
-      RSpec::Expectations.configuration.warn_about_false_positives = original_value
-    end
+  it "can supresses the warning when configured to do so", :warn_about_false_positives do
+    RSpec::Expectations.configuration.warn_about_false_positives = false
+    expect_no_warnings
+    expect { raise }.to raise_error
   end
 
   it 'does not issue a warning when an exception class is specified (even if it is just `Exception`)' do

--- a/spec/rspec/matchers/description_generation_spec.rb
+++ b/spec/rspec/matchers/description_generation_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe "Matchers should be able to generate their own descriptions" do
   end
 
   example "expect(...).to raise_error" do
-    expect { raise }.to raise_error
+    expect { raise 'foo' }.to raise_error Exception
     expect(RSpec::Matchers.generated_description).to eq "should raise Exception"
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -98,6 +98,12 @@ RSpec.shared_context "isolate include_chain_clauses_in_custom_matcher_descriptio
   end
 end
 
+RSpec.shared_context "with warn_about_false_positives set to false", :warn_about_false_positives do
+  original_value = RSpec::Expectations.configuration.warn_about_false_positives?
+
+  after(:context)  { RSpec::Expectations.configuration.warn_about_false_positives = original_value }
+end
+
 module MinitestIntegration
   include ::RSpec::Support::InSubProcess
 


### PR DESCRIPTION
Issues a warning (which can be supressed) when using a bare `raise_error` call. Fixes #655.