### PR TITLE
Remove remnant of have(n) matcher tests

### DIFF
--- a/spec/rspec/matchers/description_generation_spec.rb
+++ b/spec/rspec/matchers/description_generation_spec.rb
@@ -179,14 +179,6 @@ RSpec.describe "Matchers should be able to generate their own descriptions" do
     match { expect(1).to eq(1) }
     match_when_negated { expect(1).to eq(1) }
   end
-
-  def team
-    Class.new do
-      def players
-        [1,2,3]
-      end
-    end.new
-  end
 end
 
 RSpec.describe "a Matcher with no description" do


### PR DESCRIPTION
[have(n) matchers were removed here](https://github.com/rspec/rspec-expectations/commit/8f39d4419e7b48bbc7d7a8263c0354249056b7c). This is an old, unused stub class from those tests.
Hey, at least _something_ productive came out of https://github.com/rspec/rspec-expectations/pull/769! :wink: 