### PR TITLE
Stop assuming the format of `test_double.inspect`.

### DIFF
--- a/spec/rspec/matchers/built_in/be_spec.rb
+++ b/spec/rspec/matchers/built_in/be_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "expect(...).to be_predicate" do
       actual = double("actual", :happy? => false)
       expect {
         expect(actual).to be_happy
-      }.to fail_with(/expected `#<RSpec::Mocks::Double:0x[0-9a-f]+ @name=\"actual\">\.happy\?` to return true, got false/)
+      }.to fail_with("expected `#{actual.inspect}.happy?` to return true, got false")
     end
 
     it "only calls :predicate? once" do
@@ -55,7 +55,7 @@ RSpec.describe "expect(...).to be_predicate" do
     actual = double("actual", :happy? => nil)
     expect {
       expect(actual).to be_happy
-    }.to fail_with(/expected `#<RSpec::Mocks::Double:0x[0-9a-f]+ @name=\"actual\">\.happy\?` to return true, got nil/)
+    }.to fail_with("expected `#{actual.inspect}.happy?` to return true, got nil")
   end
 
   it "fails when actual does not respond to :predicate?" do
@@ -169,7 +169,7 @@ RSpec.describe "expect(...).not_to be_predicate" do
     actual = double("actual", :happy? => true)
     expect {
       expect(actual).not_to be_happy
-    }.to fail_with(/expected `#<RSpec::Mocks::Double:0x[0-9a-f]+ @name=\"actual\">\.happy\?` to return false, got true/)
+    }.to fail_with("expected `#{actual.inspect}.happy?` to return false, got true")
   end
 
   it "fails when actual does not respond to :sym?" do
@@ -191,7 +191,7 @@ RSpec.describe "expect(...).to be_predicate(*args)" do
     expect(actual).to receive(:older_than?).with(3).and_return(false)
     expect {
       expect(actual).to be_older_than(3)
-    }.to fail_with(/expected `#<RSpec::Mocks::Double:0x[0-9a-f]+ @name="actual">.older_than\?\(3\)` to return true, got false/)
+    }.to fail_with("expected `#{actual.inspect}.older_than?(3)` to return true, got false")
   end
 
   it "fails when actual does not respond to :predicate?" do
@@ -213,7 +213,7 @@ RSpec.describe "expect(...).not_to be_predicate(*args)" do
     expect(actual).to receive(:older_than?).with(3).and_return(true)
     expect {
       expect(actual).not_to be_older_than(3)
-    }.to fail_with(/expected `#<RSpec::Mocks::Double:0x[0-9a-f]+ @name="actual">.older_than\?\(3\)` to return false, got true/)
+    }.to fail_with("expected `#{actual.inspect}.older_than?(3)` to return false, got true")
   end
 
   it "fails when actual does not respond to :predicate?" do
@@ -239,7 +239,7 @@ RSpec.describe "expect(...).to be_predicate(&block)" do
     expect(delegate).to receive(:check_happy).and_return(false)
     expect {
       expect(actual).to be_happy { delegate.check_happy }
-    }.to fail_with(/expected `#<RSpec::Mocks::Double:0x[0-9a-f]+ @name=\"actual\">\.happy\?` to return true, got false/)
+    }.to fail_with("expected `#{actual.inspect}.happy?` to return true, got false")
   end
 
   it "fails when actual does not respond to :predicate?" do
@@ -320,7 +320,7 @@ RSpec.describe "expect(...).not_to be_predicate(&block)" do
     expect(delegate).to receive(:check_happy).and_return(true)
     expect {
       expect(actual).not_to be_happy { delegate.check_happy }
-    }.to fail_with(/expected `#<RSpec::Mocks::Double:0x[0-9a-f]+ @name=\"actual\">\.happy\?` to return false, got true/)
+    }.to fail_with("expected `#{actual.inspect}.happy?` to return false, got true")
   end
 
   it "fails when actual does not respond to :predicate?" do
@@ -347,7 +347,7 @@ RSpec.describe "expect(...).to be_predicate(*args, &block)" do
     expect(delegate).to receive(:check_older_than).with(3).and_return(false)
     expect {
       expect(actual).to be_older_than(3) { |age| delegate.check_older_than(age) }
-    }.to fail_with(/expected `#<RSpec::Mocks::Double:0x[0-9a-f]+ @name=\"actual\">\.older_than\?\(3\)` to return true, got false/)
+    }.to fail_with("expected `#{actual.inspect}.older_than?(3)` to return true, got false")
   end
 
   it "fails when actual does not respond to :predicate?" do
@@ -374,7 +374,7 @@ RSpec.describe "expect(...).not_to be_predicate(*args, &block)" do
     expect(delegate).to receive(:check_older_than).with(3).and_return(true)
     expect {
       expect(actual).not_to be_older_than(3) { |age| delegate.check_older_than(age) }
-    }.to fail_with(/expected `#<RSpec::Mocks::Double:0x[0-9a-f]+ @name="actual">.older_than\?\(3\)` to return false, got true/)
+    }.to fail_with("expected `#{actual.inspect}.older_than?(3)` to return false, got true")
   end
 
   it "fails when actual does not respond to :predicate?" do


### PR DESCRIPTION
This is necessary for rspec/rspec-mocks#932.