### PR TITLE
Aggregate failures

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,7 @@ inherit_from: .rubocop_rspec_base.yml
 # Over time we'd like to get this down, but this is what we're at now.
 LineLength:
   Max: 186
+
+# We have some situations where we need to use `raise ExceptionClass.new(argument)`.
+Style/RaiseArgs:
+  Enabled: false

--- a/Changelog.md
+++ b/Changelog.md
@@ -31,6 +31,9 @@ Enhancements:
   that will be used in the `description`, `failure_message` and
   `failure_message_when_negated` in place of the undescriptive
   "sastify block". (Chris Arcand, #783)
+* Add new `aggregate_failures` API that allows multiple independent
+  expectations to all fail and be listed in the failure output, rather
+  than the example aborting on the first failure. (Myron Marston, #776)
 
 Bug Fixes:
 

--- a/benchmarks/caller_vs_raise_for_backtrace.rb
+++ b/benchmarks/caller_vs_raise_for_backtrace.rb
@@ -1,0 +1,77 @@
+require 'benchmark/ips'
+
+def create_stack_trace(n, &block)
+  return create_stack_trace(n - 1, &block) if n > 0
+  yield
+end
+
+[10, 50, 100].each do |frames|
+  create_stack_trace(frames) do
+    Benchmark.ips do |x|
+      x.report("use caller (#{caller.count} frames)") do
+        exception = RuntimeError.new("boom")
+        exception.set_backtrace caller
+        exception.backtrace
+      end
+
+      x.report("use raise (#{caller.count} frames)") do
+        exception = begin
+          raise "boom"
+        rescue => e
+          e
+        end
+
+        exception.backtrace
+      end
+
+      x.compare!
+    end
+  end
+end
+
+__END__
+
+Calculating -------------------------------------
+use caller (16 frames)
+                         4.986k i/100ms
+use raise (16 frames)
+                         4.255k i/100ms
+-------------------------------------------------
+use caller (16 frames)
+                         52.927k (± 9.9%) i/s -    264.258k
+use raise (16 frames)
+                         50.079k (±10.1%) i/s -    251.045k
+
+Comparison:
+use caller (16 frames):    52927.3 i/s
+use raise (16 frames):    50078.6 i/s - 1.06x slower
+
+Calculating -------------------------------------
+use caller (56 frames)
+                         2.145k i/100ms
+use raise (56 frames)
+                         2.065k i/100ms
+-------------------------------------------------
+use caller (56 frames)
+                         22.282k (± 9.3%) i/s -    111.540k
+use raise (56 frames)
+                         21.428k (± 9.9%) i/s -    107.380k
+
+Comparison:
+use caller (56 frames):    22281.5 i/s
+use raise (56 frames):    21428.1 i/s - 1.04x slower
+
+Calculating -------------------------------------
+use caller (106 frames)
+                         1.284k i/100ms
+use raise (106 frames)
+                         1.253k i/100ms
+-------------------------------------------------
+use caller (106 frames)
+                         12.437k (±10.6%) i/s -     62.916k
+use raise (106 frames)
+                         10.873k (±12.6%) i/s -     53.879k
+
+Comparison:
+use caller (106 frames):    12437.4 i/s
+use raise (106 frames):    10873.2 i/s - 1.14x slower

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -7,4 +7,4 @@ end
 %>
 
 default: --require features --tags <%= tags("~@wip") %> --format progress
-wip: --require features --tags <%= tags("@wip:3") --wip features
+wip: --require features --tags @wip:3 --wip features

--- a/features/.nav
+++ b/features/.nav
@@ -29,6 +29,7 @@
   - define_matcher_with_fluent_interface.feature
   - access_running_example.feature
   - define_matcher_outside_rspec.feature
+- aggregating_failures.feature
 - composing_matchers.feature
 - compound_expectations.feature
 - define_negated_matcher.feature

--- a/features/aggregating_failures.feature
+++ b/features/aggregating_failures.feature
@@ -4,6 +4,8 @@ Feature: Aggregating Failures
 
   `aggregate_failures` takes an optional string argument that will be used in the aggregated failure message as a label.
 
+  RSpec::Core expands this feature a bit; see [the rspec-core docs](../../rspec-core/docs/expectation-framework-integration/aggregating-failures) for more detail.
+
   Note: The implementation of `aggregate_failures` uses a thread-local variable, which means that if you have an expectation failure in another thread, it'll abort like normal.
 
   Scenario: Multiple expectation failures within `aggregate_failures` are all reported

--- a/features/aggregating_failures.feature
+++ b/features/aggregating_failures.feature
@@ -1,0 +1,97 @@
+@wip @announce
+Feature: Aggregating Failures
+
+  Normally, an expectation failure causes the example to immediately bail.  Sometimes, however, you have multiple, independent expectations, and you'd like to be able to see all of the failures rather than just the first.  One solution is to split off a separate example for each expectation, but if the setup for the examples is slow, that's going to take extra time and slow things down. `aggregate_failures` provides an alternate solution. Within the block, expectation failures will not abort the example like normal; instead, the failures will be aggregated into a single exception that is raised at the end of the block, allowing you to see all expectations that failed.
+
+  `aggregate_failures` takes an optional string argument that will be used in the aggregated failure message as a label.
+
+  Scenario: Multiple Expectation Failures in the same example are all reported
+    Given a file named "spec/aggregated_failure_spec.rb" with:
+      """ruby
+      RSpec.describe "An aggregated failure" do
+        it "lists each of the individual failures in the failure output" do
+          aggregate_failures "testing equality" do
+            expect(1).to eq(2)
+            expect(2).to eq(3)
+            expect(3).to eq(4)
+          end
+        end
+      end
+      """
+    When I run `rspec spec/aggregated_failure_spec.rb`
+    Then it should fail listing all the failures:
+      """
+      Failures:
+
+        1) An aggregated failure lists each of the individual failures in the failure output
+           Got 3 failures from failure aggregation block "testing equality".
+           # ./spec/aggregated_failure_spec.rb:3:in `block (2 levels) in <top (required)>'
+
+           1.1) Failure/Error: expect(1).to eq(2)
+
+                  expected: 2
+                       got: 1
+
+                  (compared using ==)
+                # ./spec/aggregated_failure_spec.rb:4:in `block (3 levels) in <top (required)>'
+
+           1.2) Failure/Error: expect(2).to eq(3)
+
+                  expected: 3
+                       got: 2
+
+                  (compared using ==)
+                # ./spec/aggregated_failure_spec.rb:5:in `block (3 levels) in <top (required)>'
+
+           1.3) Failure/Error: expect(3).to eq(4)
+
+                  expected: 4
+                       got: 3
+
+                  (compared using ==)
+                # ./spec/aggregated_failure_spec.rb:6:in `block (3 levels) in <top (required)>'
+      """
+
+  Scenario: Use `:aggregated_failures` metadata
+    Given a file named "spec/aggregated_failure_spec.rb" with:
+      """ruby
+      RSpec.describe "An aggregated failure" do
+        it "lists each of the individual failures in the failure output", :aggregate_failures do
+          expect(1).to eq(2)
+          expect(2).to eq(3)
+          expect(3).to eq(4)
+        end
+      end
+      """
+    When I run `rspec spec/aggregated_failure_spec.rb`
+    Then it should fail listing all the failures:
+      """
+      Failures:
+
+        1) An aggregated failure lists each of the individual failures in the failure output
+           Got 3 failures:
+
+           1.1) Failure/Error: expect(1).to eq(2)
+
+                  expected: 2
+                       got: 1
+
+                  (compared using ==)
+                # ./spec/aggregated_failure_spec.rb:3:in `block (3 levels) in <top (required)>'
+
+           1.2) Failure/Error: expect(2).to eq(3)
+
+                  expected: 3
+                       got: 2
+
+                  (compared using ==)
+                # ./spec/aggregated_failure_spec.rb:4:in `block (3 levels) in <top (required)>'
+
+           1.3) Failure/Error: expect(3).to eq(4)
+
+                  expected: 4
+                       got: 3
+
+                  (compared using ==)
+                # ./spec/aggregated_failure_spec.rb:5:in `block (3 levels) in <top (required)>'
+      """

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -20,16 +20,3 @@ Then /^the example should fail$/ do
   step %q{the output should contain "1 failure"}
   step %q{the exit status should not be 0}
 end
-
-Then(/^it should fail listing all the failures:$/) do |string|
-  step %q{the exit status should not be 0}
-  expect(normalize_whitespace_and_backtraces(all_output)).to include(normalize_whitespace_and_backtraces(string))
-end
-
-module WhitespaceNormalization
-  def normalize_whitespace_and_backtraces(text)
-    text.lines.map { |line| line.sub(/\s+$/, '').sub(/:in .*$/, '') }.join
-  end
-end
-
-World(WhitespaceNormalization)

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -20,3 +20,16 @@ Then /^the example should fail$/ do
   step %q{the output should contain "1 failure"}
   step %q{the exit status should not be 0}
 end
+
+Then(/^it should fail listing all the failures:$/) do |string|
+  step %q{the exit status should not be 0}
+  expect(normalize_whitespace_and_backtraces(all_output)).to include(normalize_whitespace_and_backtraces(string))
+end
+
+module WhitespaceNormalization
+  def normalize_whitespace_and_backtraces(text)
+    text.lines.map { |line| line.sub(/\s+$/, '').sub(/:in .*$/, '') }.join
+  end
+end
+
+World(WhitespaceNormalization)

--- a/features/test_frameworks/minitest.feature
+++ b/features/test_frameworks/minitest.feature
@@ -36,9 +36,17 @@ Feature: Minitest integration
         def test_custom_matcher_with_deprecation_warning
           expect(1).to be_an_int
         end
+
+        def test_using_aggregate_failures
+          aggregate_failures do
+            expect(1).to be_even
+            expect(2).to be_odd
+          end
+        end
       end
       """
      When I run `ruby rspec_expectations_test.rb`
-     Then the output should contain "3 runs, 3 assertions, 1 failures, 0 errors"
+     Then the output should contain "4 runs, 5 assertions, 2 failures, 0 errors"
       And the output should contain "expected `[1, 2].empty?` to return true, got false"
       And the output should contain "be_an_int is deprecated"
+      And the output should contain "Got 2 failures from failure aggregation block"

--- a/lib/rspec/expectations.rb
+++ b/lib/rspec/expectations.rb
@@ -64,7 +64,18 @@ module RSpec
     # the user sets an expectation, it can't be caught in their
     # code by a bare `rescue`.
     # @api public
-    class ExpectationNotMetError < ::Exception
+    class ExpectationNotMetError < Exception
     end
+
+    # Exception raised from `aggregate_failures` when multiple expectations fail.
+    #
+    # @note The constant is defined here but the extensive logic of this class
+    #   is lazily defined when `FailureAggregator` is autoloaded, since we do
+    #   not need to waste time defining that functionality unless
+    #   `aggregate_failures` is used.
+    class MultipleExpectationsNotMetError < ExpectationNotMetError
+    end
+
+    autoload :FailureAggregator, "rspec/expectations/failure_aggregator"
   end
 end

--- a/lib/rspec/expectations/fail_with.rb
+++ b/lib/rspec/expectations/fail_with.rb
@@ -24,7 +24,7 @@ module RSpec
 
         message = ::RSpec::Matchers::ExpectedsForMultipleDiffs.from(expected).message_with_diff(message, differ, actual)
 
-        raise RSpec::Expectations::ExpectationNotMetError, message
+        RSpec::Support.notify_failure(RSpec::Expectations::ExpectationNotMetError.new message)
       end
     end
   end

--- a/lib/rspec/expectations/failure_aggregator.rb
+++ b/lib/rspec/expectations/failure_aggregator.rb
@@ -9,8 +9,21 @@ module RSpec
           begin
             yield
           rescue ExpectationNotMetError => e
+            # Normally, expectation failures will be notified via the `call` method, below,
+            # but since the failure notifier uses a thread local variable, failing expectations
+            # in another thread will still raise. We handle that here and categorize it as part
+            # of `failures` rather than letting it fall through and be categorized as part of
+            # `other_errors`.
             failures << e
           rescue Exception => e
+            # While it is normally a bad practice to rescue `Exception`, it's important we do
+            # so here. It's low risk (`notify_aggregated_failures` below will re-raise the exception,
+            # or raise a `MultipleExpectationsNotMetError` that includes the exception), and it's
+            # essential that the user is notified of expectation failures that may have already
+            # occurred in the `aggregate_failures` block. Those expectation failures may provide
+            # important diagnostics for understanding why this exception occurred, and if simply
+            # allowed this exception to be raised as-is, it would (wrongly) suggest to the user
+            # that the expectation passed when it did not, which would be quite confusing.
             other_errors << e
           end
         end

--- a/lib/rspec/expectations/failure_aggregator.rb
+++ b/lib/rspec/expectations/failure_aggregator.rb
@@ -29,6 +29,7 @@ module RSpec
       # This method is defined to satisfy the callable interface
       # expected by `RSpec::Support.with_failure_notifier`.
       def call(failure)
+        failure.set_backtrace(caller) unless failure.backtrace
         failures << failure
       end
 

--- a/lib/rspec/expectations/failure_aggregator.rb
+++ b/lib/rspec/expectations/failure_aggregator.rb
@@ -15,7 +15,7 @@ module RSpec
           end
         end
 
-        raise_aggregated_failures
+        notify_aggregated_failures
       end
 
       def failures
@@ -40,13 +40,13 @@ module RSpec
         @metadata    = metadata
       end
 
-      def raise_aggregated_failures
+      def notify_aggregated_failures
         all_errors = failures + other_errors
 
         case all_errors.size
         when 0 then return nil
-        when 1 then raise all_errors.first
-        else raise MultipleExpectationsNotMetError.new(self)
+        when 1 then RSpec::Support.notify_failure all_errors.first
+        else RSpec::Support.notify_failure MultipleExpectationsNotMetError.new(self)
         end
       end
     end

--- a/lib/rspec/expectations/failure_aggregator.rb
+++ b/lib/rspec/expectations/failure_aggregator.rb
@@ -21,7 +21,7 @@ module RSpec
             # or raise a `MultipleExpectationsNotMetError` that includes the exception), and it's
             # essential that the user is notified of expectation failures that may have already
             # occurred in the `aggregate_failures` block. Those expectation failures may provide
-            # important diagnostics for understanding why this exception occurred, and if simply
+            # important diagnostics for understanding why this exception occurred, and if we simply
             # allowed this exception to be raised as-is, it would (wrongly) suggest to the user
             # that the expectation passed when it did not, which would be quite confusing.
             other_errors << e

--- a/lib/rspec/expectations/failure_aggregator.rb
+++ b/lib/rspec/expectations/failure_aggregator.rb
@@ -1,0 +1,158 @@
+module RSpec
+  module Expectations
+    # @private
+    class FailureAggregator
+      attr_reader :block_label, :metadata
+
+      def aggregate
+        RSpec::Support.with_failure_notifier(self) do
+          begin
+            yield
+          rescue ExpectationNotMetError => e
+            failures << e
+          rescue Exception => e
+            other_errors << e
+          end
+        end
+
+        raise_aggregated_failures
+      end
+
+      def failures
+        @failures ||= []
+      end
+
+      def other_errors
+        @other_errors ||= []
+      end
+
+      # This method is defined to satisfy the callable interface
+      # expected by `RSpec::Support.with_failure_notifier`.
+      def call(failure)
+        failures << failure
+      end
+
+    private
+
+      def initialize(block_label, metadata)
+        @block_label = block_label
+        @metadata    = metadata
+      end
+
+      def raise_aggregated_failures
+        all_errors = failures + other_errors
+
+        case all_errors.size
+        when 0 then return nil
+        when 1 then raise all_errors.first
+        else raise MultipleExpectationsNotMetError.new(self)
+        end
+      end
+    end
+
+    # Exception raised from `aggregate_failures` when multiple expectations fail.
+    class MultipleExpectationsNotMetError
+      # @return [String] The fully formatted exception message.
+      def message
+        @message ||= (["#{summary}:"] + enumerated_failures + enumerated_errors).join("\n\n")
+      end
+
+      # @return [Array<RSpec::Expectations::ExpectationNotMetError>] The list of expectation failures.
+      def failures
+        @failure_aggregator.failures
+      end
+
+      # @return [Array<Exception>] The list of other exceptions.
+      def other_errors
+        @failure_aggregator.other_errors
+      end
+
+      # @return [Array<Exception>] The list of expectation failures and other exceptions, combined.
+      def all_exceptions
+        failures + other_errors
+      end
+
+      # @return [String] The user-assigned label for the aggregation block.
+      def aggregation_block_label
+        @failure_aggregator.block_label
+      end
+
+      # @return [Hash] The metadata hash passed to `aggregate_failures`.
+      def aggregation_metadata
+        @failure_aggregator.metadata
+      end
+
+      # @return [String] A summary of the failure, including the block label and a count of failures.
+      def summary
+        "Got #{exception_count_description} from failure aggregation " \
+        "block#{block_description}"
+      end
+
+      # return [String] A description of the failure/error counts.
+      def exception_count_description
+        failure_count = pluralize("failure", failures.size)
+        return failure_count if other_errors.empty?
+        error_count = pluralize("other error", other_errors.size)
+        "#{failure_count} and #{error_count}"
+      end
+
+    private
+
+      def initialize(failure_aggregator)
+        @failure_aggregator = failure_aggregator
+      end
+
+      def block_description
+        return "" unless aggregation_block_label
+        " #{aggregation_block_label.inspect}"
+      end
+
+      def pluralize(noun, count)
+        "#{count} #{noun}#{'s' unless count == 1}"
+      end
+
+      def enumerated(exceptions, index_offset)
+        exceptions.each_with_index.map do |exception, index|
+          index += index_offset
+          formatted_message = yield exception
+          "#{index_label index}#{indented formatted_message, index}"
+        end
+      end
+
+      def enumerated_failures
+        enumerated(failures, 0, &:message)
+      end
+
+      def enumerated_errors
+        enumerated(other_errors, failures.size) do |error|
+          "#{error.class}: #{error.message}"
+        end
+      end
+
+      def indented(failure_message, index)
+        line_1, *rest = failure_message.strip.lines.to_a
+        first_line_indentation = ' ' * (longest_index_label_width - width_of_label(index))
+
+        first_line_indentation + line_1 + rest.map do |line|
+          line =~ /\S/ ? indentation + line : line
+        end.join
+      end
+
+      def indentation
+        @indentation ||= ' ' * longest_index_label_width
+      end
+
+      def longest_index_label_width
+        @longest_index_label_width ||= width_of_label(failures.size)
+      end
+
+      def width_of_label(index)
+        index_label(index).chars.count
+      end
+
+      def index_label(index)
+        "  #{index + 1}) "
+      end
+    end
+  end
+end

--- a/lib/rspec/expectations/minitest_integration.rb
+++ b/lib/rspec/expectations/minitest_integration.rb
@@ -7,6 +7,19 @@ Minitest::Test.class_eval do
     assert(true) # so each expectation gets counted in minitest's assertion stats
     super
   end
+
+  # Convert a `MultipleExpectationsNotMetError` to an `Minitest::Assertion` error so
+  # it gets counted in minitest's summary stats as a failure rather than an error.
+  # It would be nice to make `MultipleExpectationsNotMetError` subclass
+  # `Minitest::Assertion`, but Minitest's implementation does not treat subclasses
+  # the same, so this is the best we can do.
+  def aggregate_failures(*args, &block)
+    super
+  rescue RSpec::Expectations::MultipleExpectationsNotMetError => e
+    assertion_failed = Minitest::Assertion.new(e.message)
+    assertion_failed.set_backtrace e.backtrace
+    raise assertion_failed
+  end
 end
 
 module RSpec

--- a/lib/rspec/expectations/minitest_integration.rb
+++ b/lib/rspec/expectations/minitest_integration.rb
@@ -8,7 +8,7 @@ Minitest::Test.class_eval do
     super
   end
 
-  # Convert a `MultipleExpectationsNotMetError` to an `Minitest::Assertion` error so
+  # Convert a `MultipleExpectationsNotMetError` to a `Minitest::Assertion` error so
   # it gets counted in minitest's summary stats as a failure rather than an error.
   # It would be nice to make `MultipleExpectationsNotMetError` subclass
   # `Minitest::Assertion`, but Minitest's implementation does not treat subclasses

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -278,7 +278,7 @@ module RSpec
     end
 
     # Allows multiple expectations in the provided block to fail, and then
-    # aggregates them into a single exception, rather than bailing on the
+    # aggregates them into a single exception, rather than aborting on the
     # first expectation failure like normal. This allows you to see all
     # failures from an entire set of expectations without splitting each
     # off into its own example (which may slow things down if the example
@@ -288,7 +288,8 @@ module RSpec
     #   included in the aggregated exception message.
     # @param metadata [Hash] additional metadata about this failure aggregation
     #   block. If multiple expectations fail, it will be exposed from the
-    #   {Expectations::MultipleExpectationsNotMetError} exception.
+    #   {Expectations::MultipleExpectationsNotMetError} exception. Mostly
+    #   intended for internal RSpec use but you can use it as well.
     # @yield Block containing as many expectation as you want. The block is
     #   simply yielded to, so you can trust that anything that works outside
     #   the block should work within it.
@@ -304,6 +305,10 @@ module RSpec
     #     expect(response.headers).to include("Content-Type" => "text/plain")
     #     expect(response.body).to include("Success")
     #   end
+    #
+    # @note The implementation of this feature uses a thread-local variable,
+    #   which means that if you have an expectation failure in another thread,
+    #   it'll abort like normal.
     def aggregate_failures(label=nil, metadata={}, &block)
       Expectations::FailureAggregator.new(label, metadata).aggregate(&block)
     end

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -277,6 +277,37 @@ module RSpec
       alias_matcher(negated_name, base_name, :klass => AliasedNegatedMatcher, &description_override)
     end
 
+    # Allows multiple expectations in the provided block to fail, and then
+    # aggregates them into a single exception, rather than bailing on the
+    # first expectation failure like normal. This allows you to see all
+    # failures from an entire set of expectations without splitting each
+    # off into its own example (which may slow things down if the example
+    # setup is expensive).
+    #
+    # @param label [String] label for this aggregation block, which will be
+    #   included in the aggregated exception message.
+    # @param metadata [Hash] additional metadata about this failure aggregation
+    #   block. If multiple expectations fail, it will be exposed from the
+    #   {Expectations::MultipleExpectationsNotMetError} exception.
+    # @yield Block containing as many expectation as you want. The block is
+    #   simply yielded to, so you can trust that anything that works outside
+    #   the block should work within it.
+    # @raise [Expectations::MultipleExpectationsNotMetError] raised when
+    #   multiple expectations fail.
+    # @raise [Expectations::ExpectationNotMetError] raised when a single
+    #   expectation fails.
+    # @raise [Exception] other sorts of exceptions will be raised as normal.
+    #
+    # @example
+    #   aggregate_failures("verifying response") do
+    #     expect(response.status).to eq(200)
+    #     expect(response.headers).to include("Content-Type" => "text/plain")
+    #     expect(response.body).to include("Success")
+    #   end
+    def aggregate_failures(label=nil, metadata={}, &block)
+      Expectations::FailureAggregator.new(label, metadata).aggregate(&block)
+    end
+
     # Passes if actual is truthy (anything but false or nil)
     def be_truthy
       BuiltIn::BeTruthy.new

--- a/lib/rspec/matchers/dsl.rb
+++ b/lib/rspec/matchers/dsl.rb
@@ -60,12 +60,17 @@ module RSpec
           define_user_override(:matches?, match_block) do |actual|
             begin
               @actual = actual
-              super(*actual_arg_for(match_block))
+              RSpec::Support.with_failure_notifier(RAISE_METHOD) do
+                super(*actual_arg_for(match_block))
+              end
             rescue RSpec::Expectations::ExpectationNotMetError
               false
             end
           end
         end
+
+        # @private
+        RAISE_METHOD = method(:raise)
 
         # Use this to define the block for a negative expectation (`expect(...).not_to`)
         # when the positive and negative forms require different handling. This

--- a/lib/rspec/matchers/fail_matchers.rb
+++ b/lib/rspec/matchers/fail_matchers.rb
@@ -14,8 +14,8 @@ module RSpec
       #
       # @example
       #   expect { some_expectation }.to fail
-      def fail
-        raise_error(RSpec::Expectations::ExpectationNotMetError)
+      def fail(&block)
+        raise_error(RSpec::Expectations::ExpectationNotMetError, &block)
       end
 
       # Matches if an expectation fails with the provided message
@@ -31,10 +31,10 @@ module RSpec
       #
       # @example
       #   expect { some_expectation }.to fail_including("portion of some failure message")
-      def fail_including(snippet)
+      def fail_including(*snippets)
         raise_error(
           RSpec::Expectations::ExpectationNotMetError,
-          a_string_including(snippet)
+          a_string_including(*snippets)
         )
       end
     end

--- a/spec/rspec/expectations/failure_aggregator_spec.rb
+++ b/spec/rspec/expectations/failure_aggregator_spec.rb
@@ -66,6 +66,31 @@ module RSpec::Expectations
       end
     end
 
+    it 'supports nested `aggregate_failures` blocks' do
+      expect {
+        aggregate_failures("outer") do
+          aggregate_failures("inner 2") do
+            expect(2).to be_odd
+            expect(3).to be_even
+          end
+
+          aggregate_failures("inner 1") do
+            expect(1).to be_even
+          end
+
+          expect(1).to be_even
+        end
+      }.to raise_error do |error|
+        aggregate_failures("failure expectations") do
+          expect(error.failures.count).to eq(3)
+          expect(error.failures[0]).to be_an_instance_of(RSpec::Expectations::MultipleExpectationsNotMetError)
+          expect(error.failures[0].failures.count).to eq(2)
+          expect(error.failures[1]).to be_an_instance_of(RSpec::Expectations::ExpectationNotMetError)
+          expect(error.failures[2]).to be_an_instance_of(RSpec::Expectations::ExpectationNotMetError)
+        end
+      end
+    end
+
     it 'raises a normal `ExpectationNotMetError` when only one expectation fails' do
       expect {
         aggregate_failures do

--- a/spec/rspec/expectations/failure_aggregator_spec.rb
+++ b/spec/rspec/expectations/failure_aggregator_spec.rb
@@ -1,0 +1,287 @@
+module RSpec::Expectations
+  RSpec.describe FailureAggregator, "when used via `aggregate_failures`" do
+    it 'does not raise an error when no expectations fail' do
+      expect {
+        aggregate_failures do
+          expect(1).to be_odd
+          expect(2).to be_even
+          expect(3).to be_odd
+        end
+      }.not_to raise_error
+    end
+
+    it 'aggregates multiple failures into one exception that exposes all the failures' do
+      expect {
+        aggregate_failures('block label', :some => :metadata) do
+          expect(1).to be_even
+          expect(2).to be_odd
+          expect(3).to be_even
+        end
+      }.to raise_error(an_object_having_attributes(
+        :class => MultipleExpectationsNotMetError,
+        :failures => [
+          an_object_having_attributes(:message => "expected `1.even?` to return true, got false"),
+          an_object_having_attributes(:message => "expected `2.odd?` to return true, got false"),
+          an_object_having_attributes(:message => "expected `3.even?` to return true, got false")
+        ],
+        :other_errors => [],
+        :aggregation_block_label => 'block label',
+        :aggregation_metadata => { :some => :metadata }
+      ))
+    end
+
+    it 'raises a normal `ExpectationNotMetError` when only one expectation fails' do
+      expect {
+        aggregate_failures do
+          expect(1).to be_odd
+          expect(2).to be_odd
+          expect(3).to be_odd
+        end
+      }.to fail_with("expected `2.odd?` to return true, got false")
+    end
+
+    context "when an error other than an expectation failure occurs" do
+      def expect_error_included_in_aggregated_failure(error)
+        expect {
+          aggregate_failures do
+            expect(2).to be_odd
+            raise error
+          end
+        }.to raise_error(an_object_having_attributes(
+          :class => MultipleExpectationsNotMetError,
+          :failures => [an_object_having_attributes(
+            :message => "expected `2.odd?` to return true, got false"
+          )],
+          :other_errors => [error]
+        ))
+      end
+
+      it "includes the error in the raised aggregated failure when an expectation failed as well" do
+        expect_error_included_in_aggregated_failure StandardError.new("boom")
+      end
+
+      it "handles direct `Exceptions` and not just `StandardError` and descendents" do
+        expect_error_included_in_aggregated_failure Exception.new("boom")
+      end
+
+      it "allows the error to propagate as-is if there have been no expectation failures so far" do
+        error = StandardError.new("boom")
+
+        expect {
+          aggregate_failures do
+            raise error
+          end
+        }.to raise_error(error)
+      end
+
+      it "prevents later expectations from even running" do
+        error = StandardError.new("boom")
+        later_expectation_executed = false
+
+        expect {
+          aggregate_failures do
+            raise error
+
+            later_expectation_executed = true
+            expect(1).to eq(1)
+          end
+        }.to raise_error(error)
+
+        expect(later_expectation_executed).to be false
+      end
+
+      it 'provides an `all_exceptions` array containing failures and other errors' do
+        error = StandardError.new("boom")
+
+        expect {
+          aggregate_failures do
+            expect(2).to be_odd
+            raise error
+          end
+        }.to raise_error do |aggregate_error|
+          expect(aggregate_error).to have_attributes(
+            :class => MultipleExpectationsNotMetError,
+            :all_exceptions => [
+              an_object_having_attributes(:message => "expected `2.odd?` to return true, got false"),
+              error
+            ]
+          )
+        end
+      end
+    end
+
+    context "when an expectation failure happens in another thread" do
+      it "includes the failure in the failures array if there are other failures" do
+        expect {
+          aggregate_failures do
+            expect(1).to be_even
+            Thread.new { expect(2).to be_odd }.join
+          end
+        }.to raise_error(an_object_having_attributes(
+          :class => MultipleExpectationsNotMetError,
+          :failures => [
+            an_object_having_attributes(:message => "expected `1.even?` to return true, got false"),
+            an_object_having_attributes(:message => "expected `2.odd?` to return true, got false")
+          ],
+          :other_errors => []
+        ))
+      end
+
+      it "propagates it as-is if there are no other failures or errors" do
+        expect {
+          aggregate_failures { Thread.new { expect(2).to be_odd }.join }
+        }.to fail_with("expected `2.odd?` to return true, got false")
+      end
+    end
+
+    describe "message formatting" do
+      it "enumerates the failures with an index label and blank line in between" do
+        expect {
+          aggregate_failures do
+            expect(1).to be_even
+            expect(2).to be_odd
+            expect(3).to be_even
+          end
+        }.to fail_including { dedent <<-EOS }
+          |  1) expected `1.even?` to return true, got false
+          |
+          |  2) expected `2.odd?` to return true, got false
+          |
+          |  3) expected `3.even?` to return true, got false
+        EOS
+      end
+
+      it 'mentions how many failures there are' do
+        expect {
+          aggregate_failures do
+            expect(1).to be_even
+            expect(2).to be_odd
+            expect(3).to be_even
+          end
+        }.to fail_including { dedent <<-EOS }
+          |Got 3 failures from failure aggregation block:
+          |
+          |  1) expected `1.even?` to return true, got false
+        EOS
+      end
+
+      it 'allows the user to name the `aggregate_failures` block' do
+        expect {
+          aggregate_failures("testing odd vs even") do
+            expect(1).to be_even
+            expect(2).to be_odd
+            expect(3).to be_even
+          end
+        }.to fail_including { dedent <<-EOS }
+          |Got 3 failures from failure aggregation block "testing odd vs even":
+          |
+          |  1) expected `1.even?` to return true, got false
+        EOS
+      end
+
+      context "when another error has occcured" do
+        it 'includes it in the failure message' do
+          expect {
+            aggregate_failures do
+              expect(1).to be_even
+              raise "boom"
+            end
+          }.to fail_including { dedent <<-EOS }
+            |Got 1 failure and 1 other error from failure aggregation block:
+            |
+            |  1) expected `1.even?` to return true, got false
+            |
+            |  2) RuntimeError: boom
+          EOS
+        end
+      end
+
+      context "when the failure messages have multiple lines" do
+        RSpec::Matchers.define :fail_with_multiple_lines do
+          match { false }
+          failure_message do |actual|
+            "line 1\n#{actual}\nline 3"
+          end
+        end
+
+        it "indents them appropriately so that they still line up" do
+          expect {
+            aggregate_failures do
+              expect(:a).to fail_with_multiple_lines
+              expect(:b).to fail_with_multiple_lines
+            end
+          }.to fail_including { dedent <<-EOS }
+            |  1) line 1
+            |     a
+            |     line 3
+            |
+            |  2) line 1
+            |     b
+            |     line 3
+          EOS
+        end
+
+        it 'accounts for the width of the index when indenting' do
+          expect {
+            aggregate_failures do
+              1.upto(10) do |i|
+                expect(i).to fail_with_multiple_lines
+              end
+            end
+          }.to fail_including { dedent <<-EOS }
+            |  9)  line 1
+            |      9
+            |      line 3
+            |
+            |  10) line 1
+            |      10
+            |      line 3
+          EOS
+        end
+      end
+
+      context "when the failure messages starts and ends with line breaks (as the `eq` failure message does)" do
+        before do
+          expect { expect(1).to eq(2) }.to fail_with(
+            a_string_starting_with("\n") & ending_with("\n")
+          )
+        end
+
+        it 'strips the excess line breaks so that it formats well' do
+          expect {
+            aggregate_failures do
+              expect(1).to eq 2
+              expect(1).to eq 3
+              expect(1).to eq 4
+            end
+          }.to fail_including { dedent <<-EOS }
+            |  1) expected: 2
+            |          got: 1
+            |
+            |     (compared using ==)
+            |
+            |  2) expected: 3
+            |          got: 1
+            |
+            |     (compared using ==)
+            |
+            |  3) expected: 4
+            |          got: 1
+            |
+            |     (compared using ==)
+          EOS
+        end
+      end
+
+      # Use a normal `expect(...).to include` expectation rather than
+      # a composed matcher here. This provides better failure output
+      # because `MultipleExpectationsNotMetError#message` is lazily
+      # computed (rather than being computed in `initialize` and passed
+      # to `super`), which causes the `inspect` output of the exception
+      # to not include the message for some reason.
+      def fail_including
+        fail { |e| expect(e.message).to include(yield) }
+      end
+    end
+  end
+end

--- a/spec/rspec/expectations/minitest_integration_spec.rb
+++ b/spec/rspec/expectations/minitest_integration_spec.rb
@@ -10,12 +10,12 @@ module RSpec
     context "once required", :slow do
       include MinitestIntegration
 
-      it "includes itself in Minitest::Test" do
+      it "includes itself in Minitest::Test, and sets up our exceptions to be counted as assertion failures" do
         with_minitest_loaded do
           minitest_case = MiniTest::Test.allocate
-          sample_matchers.each do |sample_matcher|
-              expect(minitest_case).to respond_to(sample_matcher)
-          end
+          expect(minitest_case).to respond_to(*sample_matchers)
+
+          expect(RSpec::Expectations::ExpectationNotMetError).to be ::Minitest::Assertion
         end
       end
 


### PR DESCRIPTION
This is the beginning of my solution for #733.

TODOs:

- [x] Finish cuke.
- [x] Ensure this works well with our minitest integration (we reassign the `ExpectationNotMetError` constant there which could cause problems for the new exception class since it is a subclass).
- [x] Update docs to mention how this interacts with threading.
- [x] Update rspec-core to integrate with this.
- [x] Update rspec-mocks to use the rspec-support failure notifier so that mock failures can participate in this.
- [x] Figure out how this interacts with using an expectation from within a DSL-defined custom matcher.