### PR TITLE
Change error for `expect { }.not_to raise_error(something_specific)` to warn and respect new config

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,8 @@ Enhancements:
   may cause false positives. (Jon Rowe, #768)
 * Warn when using a bare `raise_error` matcher that you may be subject to
   false positives. (Jon Rowe, #768)
+* Warn rather than raise when using the`raise_error` matcher in negative
+  expectations that may be subject to false positives. (Jon Rowe, #775)
 
 Bug Fixes:
 

--- a/lib/rspec/matchers/built_in/raise_error.rb
+++ b/lib/rspec/matchers/built_in/raise_error.rb
@@ -11,9 +11,7 @@ module RSpec
         def initialize(expected_error_or_message=nil, expected_message=nil, &block)
           @block = block
           @actual_error = nil
-          @warn_about_bare_error =
-            RSpec::Expectations.configuration.warn_about_potential_false_positives? &&
-            expected_error_or_message.nil?
+          @warn_about_bare_error = warn_about_potential_false_positives? && expected_error_or_message.nil?
 
           case expected_error_or_message
           when nil
@@ -64,7 +62,7 @@ module RSpec
 
         # @private
         def does_not_match?(given_proc)
-          prevent_invalid_expectations
+          warn_for_false_positives
           !matches?(given_proc, :negative_expectation) && Proc === given_proc
         end
 
@@ -128,19 +126,23 @@ module RSpec
           values_match?(@expected_message, @actual_error.message.to_s)
         end
 
-        def prevent_invalid_expectations
-          what_to_raise = if expecting_specific_exception? && @expected_message
-                            "`expect { }.not_to raise_error(SpecificErrorClass, message)`"
-                          elsif expecting_specific_exception?
-                            "`expect { }.not_to raise_error(SpecificErrorClass)`"
-                          elsif @expected_message
-                            "`expect { }.not_to raise_error(message)`"
-                          end
+        def warn_for_false_positives
+          return unless warn_about_potential_false_positives?
+          expression = if expecting_specific_exception? && @expected_message
+                         "`expect { }.not_to raise_error(SpecificErrorClass, message)`"
+                       elsif expecting_specific_exception?
+                         "`expect { }.not_to raise_error(SpecificErrorClass)`"
+                       elsif @expected_message
+                         "`expect { }.not_to raise_error(message)`"
+                       end
 
-          return unless what_to_raise
+          return unless expression
 
-          specific_class_error = ArgumentError.new("#{what_to_raise} is not valid, use `expect { }.not_to raise_error` (with no args) instead")
-          raise specific_class_error
+          warn_about_negative_false_positive expression
+        end
+
+        def warn_about_potential_false_positives?
+          RSpec::Expectations.configuration.warn_about_potential_false_positives?
         end
 
         def warning_about_bare_error
@@ -155,6 +157,16 @@ module RSpec
                         "without even executing the method you are intending to call. " \
                         "Instead consider providing a specific error class or message. " \
                         "This message can be supressed by setting: " \
+                        "`RSpec::Expectations.configuration.warn_about_potential_false_positives = false`")
+        end
+
+        def warn_about_negative_false_positive(expression)
+          RSpec.warning("Using #{expression} risks false positives, since literally " \
+                        "any other error would cause the expectation to pass, " \
+                        "including those raised by Ruby (e.g. NoMethodError, NameError " \
+                        "and ArgumentError), meaning the code you are intending to test " \
+                        "may not even get reached. Instead consider using " \
+                        "`expect {}.not_to raise_error`. This message can be supressed by setting: " \
                         "`RSpec::Expectations.configuration.warn_about_potential_false_positives = false`")
         end
 

--- a/spec/rspec/matchers/built_in/raise_error_spec.rb
+++ b/spec/rspec/matchers/built_in/raise_error_spec.rb
@@ -130,10 +130,15 @@ end
 RSpec.describe "expect { ... }.not_to raise_error" do
 
   context "with a specific error class" do
-    it "is invalid" do
-      expect {
-        expect {"bees"}.not_to raise_error(RuntimeError)
-      }.to raise_error(/`expect \{ \}\.not_to raise_error\(SpecificErrorClass\)` is not valid/)
+    it "issues a warning" do
+      expect_warning_with_call_site __FILE__, __LINE__+1, /risks false positives/
+      expect {"bees"}.not_to raise_error(RuntimeError)
+    end
+
+    it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
+      RSpec::Expectations.configuration.warn_about_potential_false_positives = false
+      expect_no_warnings
+      expect {"bees"}.not_to raise_error(RuntimeError)
     end
   end
 
@@ -239,10 +244,15 @@ RSpec.describe "expect { ... }.to raise_error.with_message(message)" do
 end
 
 RSpec.describe "expect { ... }.not_to raise_error(message)" do
-  it "is invalid" do
-    expect {
-      expect {raise 'blarg'}.not_to raise_error(/blah/)
-    }.to raise_error(/`expect \{ \}\.not_to raise_error\(message\)` is not valid/)
+  it "issues a warning" do
+    expect_warning_with_call_site __FILE__, __LINE__+1, /risks false positives/
+    expect {raise 'blarg'}.not_to raise_error(/blah/)
+  end
+
+  it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
+    RSpec::Expectations.configuration.warn_about_potential_false_positives = false
+    expect_no_warnings
+    expect {raise 'blarg'}.not_to raise_error(/blah/)
   end
 end
 
@@ -271,10 +281,15 @@ RSpec.describe "expect { ... }.to raise_error(NamedError)" do
 end
 
 RSpec.describe "expect { ... }.not_to raise_error(NamedError)" do
-  it "is invalid" do
-    expect {
-      expect { }.not_to raise_error(NameError)
-    }.to raise_error(/`expect \{ \}\.not_to raise_error\(SpecificErrorClass\)` is not valid/)
+  it "issues a warning" do
+    expect_warning_with_call_site __FILE__, __LINE__+1, /risks false positives/
+    expect { }.not_to raise_error(NameError)
+  end
+
+  it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
+    RSpec::Expectations.configuration.warn_about_potential_false_positives = false
+    expect_no_warnings
+    expect { }.not_to raise_error(NameError)
   end
 end
 
@@ -303,10 +318,15 @@ RSpec.describe "expect { ... }.to raise_error(NamedError, error_message) with St
 end
 
 RSpec.describe "expect { ... }.not_to raise_error(NamedError, error_message) with String" do
-  it "is invalid" do
-    expect {
-      expect {}.not_to raise_error(RuntimeError, "example message")
-    }.to raise_error(/`expect \{ \}\.not_to raise_error\(SpecificErrorClass, message\)` is not valid/)
+  it "issues a warning" do
+    expect_warning_with_call_site __FILE__, __LINE__+1, /risks false positives/
+    expect {}.not_to raise_error(RuntimeError, "example message")
+  end
+
+  it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
+    RSpec::Expectations.configuration.warn_about_potential_false_positives = false
+    expect_no_warnings
+    expect {}.not_to raise_error(RuntimeError, "example message")
   end
 end
 
@@ -335,10 +355,15 @@ RSpec.describe "expect { ... }.to raise_error(NamedError, error_message) with Re
 end
 
 RSpec.describe "expect { ... }.not_to raise_error(NamedError, error_message) with Regexp" do
-  it "is invalid" do
-    expect {
-      expect {}.not_to raise_error(RuntimeError, /ample mess/)
-    }.to raise_error(/`expect \{ \}\.not_to raise_error\(SpecificErrorClass, message\)` is not valid/)
+  it "issues a warning" do
+    expect_warning_with_call_site __FILE__, __LINE__+1, /risks false positives/
+    expect {}.not_to raise_error(RuntimeError, /ample mess/)
+  end
+
+  it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
+    RSpec::Expectations.configuration.warn_about_potential_false_positives = false
+    expect_no_warnings
+    expect {}.not_to raise_error(RuntimeError, /ample mess/)
   end
 end
 
@@ -416,10 +441,15 @@ RSpec.describe "expect { ... }.to raise_error(NamedError, error_message) { |err|
 end
 
 RSpec.describe "expect { ... }.not_to raise_error(NamedError, error_message) { |err| ... }" do
-  it "is invalid" do
-    expect {
-      expect {}.not_to raise_error(RuntimeError, "example message") { |err| }
-    }.to raise_error(/`expect \{ \}\.not_to raise_error\(SpecificErrorClass, message\)` is not valid/)
+  it "issues a warning" do
+    expect_warning_with_call_site __FILE__, __LINE__+1, /risks false positives/
+    expect {}.not_to raise_error(RuntimeError, "example message") { |err| }
+  end
+
+  it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
+    RSpec::Expectations.configuration.warn_about_potential_false_positives = false
+    expect_no_warnings
+    expect {}.not_to raise_error(RuntimeError, "example message") { |err| }
   end
 end
 


### PR DESCRIPTION
Follow up to #768.  @JonRowe said he planned to do this but I wanted to open an issue so we don't forget.