### PR TITLE
Show only differing results in #include

### DIFF
--- a/benchmarks/include_matcher.rb
+++ b/benchmarks/include_matcher.rb
@@ -1,0 +1,250 @@
+require 'benchmark/ips'
+require 'rspec/expectations'
+
+include RSpec::Matchers
+
+module RSpec
+  module Matchers
+    module BuiltIn
+      class OldInclude < BaseMatcher
+        def initialize(*expected)
+          @expected = expected
+        end
+
+        def matches?(actual)
+          @actual = actual
+          perform_match(:all?, :all?)
+        end
+
+        def does_not_match?(actual)
+          @actual = actual
+          perform_match(:none?, :any?)
+        end
+
+        def description
+          described_items = surface_descriptions_in(expected)
+          item_list = EnglishPhrasing.list(described_items)
+          improve_hash_formatting "include#{item_list}"
+        end
+
+        def failure_message
+          improve_hash_formatting(super) + invalid_object_message
+        end
+
+        def failure_message_when_negated
+          improve_hash_formatting(super) + invalid_object_message
+        end
+
+        def diffable?
+          !diff_would_wrongly_highlight_matched_item?
+        end
+
+      private
+
+        def invalid_object_message
+          return '' if actual.respond_to?(:include?)
+          ", but it does not respond to `include?`"
+        end
+
+        def perform_match(predicate, hash_subset_predicate)
+          return false unless actual.respond_to?(:include?)
+
+          expected.__send__(predicate) do |expected_item|
+            if comparing_hash_to_a_subset?(expected_item)
+              expected_item.__send__(hash_subset_predicate) do |(key, value)|
+                actual_hash_includes?(key, value)
+              end
+            elsif comparing_hash_keys?(expected_item)
+              actual_hash_has_key?(expected_item)
+            else
+              actual_collection_includes?(expected_item)
+            end
+          end
+        end
+
+        def comparing_hash_to_a_subset?(expected_item)
+          actual.is_a?(Hash) && expected_item.is_a?(Hash)
+        end
+
+        def actual_hash_includes?(expected_key, expected_value)
+          actual_value = actual.fetch(expected_key) { return false }
+          values_match?(expected_value, actual_value)
+        end
+
+        def comparing_hash_keys?(expected_item)
+          actual.is_a?(Hash) && !expected_item.is_a?(Hash)
+        end
+
+        def actual_hash_has_key?(expected_key)
+          actual.key?(expected_key) ||
+          actual.keys.any? { |key| values_match?(expected_key, key) }
+        end
+
+        def actual_collection_includes?(expected_item)
+          return true if actual.include?(expected_item)
+
+          return false unless actual.respond_to?(:any?)
+
+          actual.any? { |value| values_match?(expected_item, value) }
+        end
+
+        def diff_would_wrongly_highlight_matched_item?
+          return false unless actual.is_a?(String) && expected.is_a?(Array)
+
+          lines = actual.split("\n")
+          expected.any? do |str|
+            actual.include?(str) && lines.none? { |line| line == str }
+          end
+        end
+      end
+    end
+
+    def old_include(*expected)
+      BuiltIn::OldInclude.new(*expected)
+    end
+  end
+end
+
+
+array_sizes = [10, 50, 100, 500]
+
+# *maniacal laugh*
+class << self; alias_method :inc, :include; remove_method :include; end
+
+Benchmark.ips do |x|
+  x.report("Old `to include` successes") do
+    array_sizes.each do |n|
+      expect([*1..n]).to old_include(*n/2..n)
+    end
+  end
+
+  x.report("New `to include` successes") do
+    array_sizes.each do |n|
+      expect([*1..n]).to include(*n/2..n)
+    end
+  end
+
+  x.compare!
+end
+
+Benchmark.ips do |x|
+  x.report("Old `to include` failures") do
+    array_sizes.each do |n|
+      begin
+        expect([*1..n]).to old_include(*n+1..n*1.5)
+      rescue RSpec::Expectations::ExpectationNotMetError
+      end
+    end
+  end
+
+  x.report("New `to include` failures") do
+    array_sizes.each do |n|
+      begin
+        expect([*1..n]).to include(*n+1..n*1.5)
+      rescue RSpec::Expectations::ExpectationNotMetError
+      end
+    end
+  end
+
+  x.compare!
+end
+
+Benchmark.ips do |x|
+  x.report("Old `to not include` successes") do
+    array_sizes.each do |n|
+      expect([*1..n]).to_not old_include(*n+1..n*1.5)
+    end
+  end
+
+  x.report("New `to not include` successes") do
+    array_sizes.each do |n|
+      expect([*1..n]).to_not include(*n+1..n*1.5)
+    end
+  end
+
+  x.compare!
+end
+
+Benchmark.ips do |x|
+  x.report("Old `to not include` failures") do
+    array_sizes.each do |n|
+      begin
+        expect([*1..n]).to_not old_include(*n/2..n)
+      rescue RSpec::Expectations::ExpectationNotMetError
+      end
+    end
+  end
+
+  x.report("New `to not include` failures") do
+    array_sizes.each do |n|
+      begin
+        expect([*1..n]).to_not include(*n/2..n)
+      rescue RSpec::Expectations::ExpectationNotMetError
+      end
+    end
+  end
+
+  x.compare!
+end
+
+__END__
+
+Calculating -------------------------------------
+Old `to include` successes
+                        30.000  i/100ms
+New `to include` successes
+                        28.000  i/100ms
+-------------------------------------------------
+Old `to include` successes
+                        307.740  (± 4.2%) i/s -      1.560k
+New `to include` successes
+                        299.321  (± 2.7%) i/s -      1.512k
+
+Comparison:
+Old `to include` successes:      307.7 i/s
+New `to include` successes:      299.3 i/s - 1.03x slower
+
+Calculating -------------------------------------
+Old `to include` failures
+                         2.000  i/100ms
+New `to include` failures
+                         1.000  i/100ms
+-------------------------------------------------
+Old `to include` failures
+                         20.611  (± 4.9%) i/s -    104.000
+New `to include` failures
+                          2.990  (± 0.0%) i/s -     15.000
+
+Comparison:
+Old `to include` failures:       20.6 i/s
+New `to include` failures:        3.0 i/s - 6.89x slower
+
+Calculating -------------------------------------
+Old `to not include` successes
+                         1.000  i/100ms
+New `to not include` successes
+                         1.000  i/100ms
+-------------------------------------------------
+Old `to not include` successes
+                          3.505  (± 0.0%) i/s -     18.000
+New `to not include` successes
+                          3.475  (± 0.0%) i/s -     18.000
+
+Comparison:
+Old `to not include` successes:        3.5 i/s
+New `to not include` successes:        3.5 i/s - 1.01x slower
+
+Calculating -------------------------------------
+Old `to not include` failures
+                         2.000  i/100ms
+New `to include` failures
+                         1.000  i/100ms
+-------------------------------------------------
+Old `to not include` failures
+                         21.187  (± 4.7%) i/s -    106.000
+New `to include` failures
+                         19.899  (± 5.0%) i/s -    100.000
+
+Comparison:
+Old `to not include` failures:       21.2 i/s
+New `to include` failures:       19.9 i/s - 1.06x slower

--- a/features/built_in_matchers/include.feature
+++ b/features/built_in_matchers/include.feature
@@ -58,8 +58,8 @@ Feature: `include` matcher
       | expected [1, 3, 7] not to include 3           |
       | expected [1, 3, 7] not to include 7           |
       | expected [1, 3, 7] not to include 1, 3, and 7 |
-      | expected [1, 3, 7] to include 1 and 9         |
-      | expected [1, 3, 7] not to include 1 and 9     |
+      | expected [1, 3, 7] to include 9               |
+      | expected [1, 3, 7] not to include 1           |
 
   Scenario: string usage
     Given a file named "string_include_matcher_spec.rb" with:
@@ -79,11 +79,11 @@ Feature: `include` matcher
       """
     When I run `rspec string_include_matcher_spec.rb`
     Then the output should contain all of these:
-      | 8 examples, 4 failures                             |
-      | expected "a string" to include "foo"               |
-      | expected "a string" not to include "str"           |
-      | expected "a string" to include "str" and "foo"     |
-      | expected "a string" not to include "str" and "foo" |
+      | 8 examples, 4 failures                   |
+      | expected "a string" to include "foo"     |
+      | expected "a string" not to include "str" |
+      | expected "a string" to include "foo"     |
+      | expected "a string" not to include "str" |
 
   Scenario: hash usage
     Given a file named "hash_include_matcher_spec.rb" with:
@@ -119,5 +119,19 @@ Feature: `include` matcher
       end
       """
     When I run `rspec hash_include_matcher_spec.rb`
-    Then the output should contain "13 failure"
+    Then the output should contain all of these:
+      | 22 examples, 13 failures                                      |
+      | expected {:a => 7, :b => 5} not to include :a                 |
+      | expected {:a => 7, :b => 5} not to include :b and :a          |
+      | expected {:a => 7, :b => 5} not to include {:a => 7}          |
+      | expected {:a => 7, :b => 5} not to include {:a => 7, :b => 5} |
+      | expected {:a => 7, :b => 5} to include :c                     |
+      | expected {:a => 7, :b => 5} to include :c and :d              |
+      | expected {:a => 7, :b => 5} to include {:d => 2}              |
+      | expected {:a => 7, :b => 5} to include {:a => 5}              |
+      | expected {:a => 7, :b => 5} to include {:a => 5, :b => 7}     |
+      | expected {:a => 7, :b => 5} to include :d                     |
+      | expected {:a => 7, :b => 5} not to include :a                 |
+      | expected {:a => 7, :b => 5} to include {:d => 3}              |
+      | expected {:a => 7, :b => 5} not to include {:a => 7}          |
 

--- a/spec/rspec/matchers/built_in/be_between_spec.rb
+++ b/spec/rspec/matchers/built_in/be_between_spec.rb
@@ -65,7 +65,7 @@ module RSpec::Matchers::BuiltIn
 
         expect {
           expect(["baz", 2.14]).to include(matcher(3.1, 3.2), matcher("bar", "foo") )
-        }.to fail_with("expected [\"baz\", 2.14] to include (a value between 3.1 and 3.2 (#{mode})) and (a value between \"bar\" and \"foo\" (#{mode}))")
+        }.to fail_with("expected [\"baz\", 2.14] to include (a value between 3.1 and 3.2 (#{mode}))")
       end
 
       it "provides a description" do
@@ -76,7 +76,7 @@ module RSpec::Matchers::BuiltIn
       it "fails with a clear error message when the matchers do not match" do
         expect {
           expect([nil, 1]).to include(matcher(2, 4), a_nil_value)
-        }.to fail_with("expected [nil, 1] to include (a value between 2 and 4 (#{mode})) and (a nil value)")
+        }.to fail_with("expected [nil, 1] to include (a value between 2 and 4 (#{mode}))")
       end
     end
 

--- a/spec/rspec/matchers/built_in/include_spec.rb
+++ b/spec/rspec/matchers/built_in/include_spec.rb
@@ -129,10 +129,22 @@ RSpec.describe "#include matcher" do
         expect("a string").to include("str", "a")
       end
 
-      it "fails if target does not include any one of the items" do
+      it "fails if target does not include one of the items" do
         expect {
           expect("a string").to include("str", "a", "foo")
-        }.to fail_matching(%Q{expected "a string" to include "str", "a", and "foo"})
+        }.to fail_matching(%Q{expected "a string" to include "foo"})
+      end
+
+      it "fails if target does not include two of the items" do
+        expect {
+          expect("a string").to include("nope", "a", "nada", "str")
+        }.to fail_matching(%Q{expected "a string" to include "nope" and "nada"})
+      end
+
+      it "fails if target does not include many of the items" do
+        expect {
+          expect("a string").to include("nope", "a", "nada", "nein", "ing", "str")
+        }.to fail_matching(%Q{expected "a string" to include "nope", "nada", and "nein"})
       end
     end
 
@@ -141,10 +153,22 @@ RSpec.describe "#include matcher" do
         expect([1,2,3]).to include(1,2,3)
       end
 
-      it "fails if target does not include any one of the items" do
+      it "fails if target does not include one of the items" do
         expect {
           expect([1,2,3]).to include(1,2,4)
-        }.to fail_matching("expected [1, 2, 3] to include 1, 2, and 4")
+        }.to fail_matching("expected [1, 2, 3] to include 4")
+      end
+
+      it "fails if target does not include two of the items" do
+        expect {
+          expect([1,2,3]).to include(5,1,2,4)
+        }.to fail_matching("expected [1, 2, 3] to include 5 and 4")
+      end
+
+      it "fails if target does not include many of the items" do
+        expect {
+          expect([1,2,3]).to include(5,1,6,2,4)
+        }.to fail_matching("expected [1, 2, 3] to include 5, 6, and 4")
       end
     end
 
@@ -153,10 +177,22 @@ RSpec.describe "#include matcher" do
         expect({:key => 'value', :other => 'value'}).to include(:key, :other)
       end
 
-      it 'fails if target is missing any item as a key' do
+      it 'fails if target does not include one of the items as a key' do
         expect {
-          expect({:key => 'value'}).to include(:key, :other)
-        }.to fail_matching(%Q|expected {:key => "value"} to include :key and :other|)
+          expect({:key => 'value', :this => 'that'}).to include(:key, :nope, :this)
+        }.to fail_with(%r|expected #{hash_inspect :key => "value", :this => "that"} to include :nope|)
+      end
+
+      it "fails if target does not include two of the items as keys" do
+        expect {
+          expect({:key => 'value', :this => 'that'}).to include(:nada, :key, :nope, :this)
+        }.to fail_with(%r|expected #{hash_inspect :key => "value", :this => "that"} to include :nada and :nope|)
+      end
+
+      it "fails if target does not include many of the items as keys" do
+        expect {
+          expect({:key => 'value', :this => 'that'}).to include(:nada, :key, :nope, :negative, :this)
+        }.to fail_with(%r|expected #{hash_inspect :key => "value", :this => "that"} to include :nada, :nope, and :negative|)
       end
     end
   end
@@ -245,10 +281,22 @@ RSpec.describe "#include matcher" do
         }.to fail_with('expected "abc" not to include "c" and "a"')
       end
 
-      it "fails if the target includes some (but not all) of the expected" do
+      it "fails if the target includes one (but not all) of the expected" do
         expect {
           expect("abc").not_to include("d", "a")
-        }.to fail_with(%q{expected "abc" not to include "d" and "a"})
+        }.to fail_with(%q{expected "abc" not to include "a"})
+      end
+
+      it "fails if the target includes two (but not all) of the expected" do
+        expect {
+          expect("abc").not_to include("d", "a", "b")
+        }.to fail_with(%q{expected "abc" not to include "a" and "b"})
+      end
+
+      it "fails if the target includes many (but not all) of the expected" do
+        expect {
+          expect("abcd").not_to include("b", "d", "a", "f")
+        }.to fail_with(%q{expected "abcd" not to include "b", "d", and "a"})
       end
     end
 
@@ -263,10 +311,22 @@ RSpec.describe "#include matcher" do
         }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 2} not to include :a and :b|)
       end
 
-      it "fails if the target includes some (but not all) of the expected keys" do
+      it "fails if the target includes one (but not all) of the expected keys" do
         expect {
           expect({ :a => 1, :b => 2 }).not_to include(:d, :b)
-        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 2} not to include :d and :b|)
+        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 2} not to include :b|)
+      end
+
+      it "fails if the target includes two (but not all) of the expected keys" do
+        expect {
+          expect({ :a => 1, :b => 2 }).not_to include(:a, :b, :c)
+        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 2} not to include :a and :b|)
+      end
+
+      it "fails if the target includes many (but not all) of the expected keys" do
+        expect {
+          expect({ :a => 1, :b => 2, :c => 3 }).not_to include(:b, :a, :c, :f)
+        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 2, :c => 3} not to include :b, :a, and :c|)
       end
     end
 
@@ -281,10 +341,22 @@ RSpec.describe "#include matcher" do
         }.to fail_with(%q{expected [1, 2, 3] not to include 3 and 1})
       end
 
-      it "fails if the target includes some (but not all) of the expected" do
+      it "fails if the target includes one (but not all) of the expected" do
         expect {
           expect([1, 2, 3]).not_to include(4, 1)
-        }.to fail_with(%q{expected [1, 2, 3] not to include 4 and 1})
+        }.to fail_with(%q{expected [1, 2, 3] not to include 1})
+      end
+
+      it "fails if the target includes two (but not all) of the expected" do
+        expect {
+          expect([1, 2, 3]).not_to include(4, 1, 2)
+        }.to fail_with(%q{expected [1, 2, 3] not to include 1 and 2})
+      end
+
+      it "fails if the target includes many (but not all) of the expected" do
+        expect {
+          expect([1, 2, 3]).not_to include(5, 4, 2, 1, 3)
+        }.to fail_with(%q{expected [1, 2, 3] not to include 2, 1, and 3})
       end
     end
   end
@@ -374,7 +446,7 @@ RSpec.describe "#include matcher" do
       it "fails if target has a different value for one of the keys" do
         expect {
           expect({:a => 1, :b => 2}).to include(:a => 2, :b => 2)
-        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 2} to include #{hash_inspect :a => 2, :b => 2}|)
+        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 2} to include #{hash_inspect :a => 2}|)
       end
 
       it "fails if target has a different value for both of the keys" do
@@ -386,13 +458,19 @@ RSpec.describe "#include matcher" do
       it "fails if target lacks one of the keys" do
         expect {
           expect({:a => 1, :b => 1}).to include(:a => 1, :c => 1)
-        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 1} to include #{hash_inspect :a => 1, :c => 1}|)
+        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 1} to include #{hash_inspect :c => 1}|)
       end
 
       it "fails if target lacks both of the keys" do
         expect {
           expect({:a => 1, :b => 1}).to include(:c => 1, :d => 1)
         }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 1} to include #{hash_inspect :c => 1, :d => 1}|)
+      end
+
+      it "fails if target lacks one of the keys and has a different value for another" do
+        expect {
+          expect({:a => 1, :b => 2}).to include(:c => 1, :b => 3)
+        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 2} to include #{hash_inspect :c => 1, :b => 3}|)
       end
     end
 
@@ -427,7 +505,7 @@ RSpec.describe "#include matcher" do
       it "fails if target has a different value for one of the keys" do
         expect {
           expect({:a => 1, :b => 2}).not_to include(:a => 2, :b => 2)
-        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 2} not to include #{hash_inspect :a => 2, :b => 2}|)
+        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 2} not to include #{hash_inspect :b => 2}|)
       end
 
       it "passes if target has a different value for both of the keys" do
@@ -437,7 +515,7 @@ RSpec.describe "#include matcher" do
       it "fails if target lacks one of the keys" do
         expect {
           expect({:a => 1, :b => 1}).not_to include(:a => 1, :c => 1)
-        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 1} not to include #{hash_inspect :a => 1, :c => 1}|)
+        }.to fail_with(%r|expected #{hash_inspect :a => 1, :b => 1} not to include #{hash_inspect :a => 1}|)
       end
 
       it "passes if target lacks both of the keys" do
@@ -520,7 +598,7 @@ RSpec.describe "#include matcher" do
       it "fails if target does not include an item satisfying any one of the items" do
         expect {
           expect(['foo', 'bar', 'baz']).to include(a_string_containing("ar"), a_string_containing("abc"))
-        }.to fail_matching(%Q|expected #{['foo', 'bar', 'baz'].inspect} to include (a string containing 'ar') and (a string containing 'abc')|)
+        }.to fail_matching(%Q|expected #{['foo', 'bar', 'baz'].inspect} to include (a string containing 'abc')|)
       end
     end
 
@@ -572,7 +650,7 @@ RSpec.describe "#include matcher" do
       it 'fails if the some (but not all) of the matchers are satisifed' do
         expect {
           expect(['foo', 'bar', 'baz']).not_to include(a_string_containing("ar"), a_string_containing('bz'))
-        }.to fail_matching(%Q|expected #{['foo', 'bar', 'baz'].inspect} not to include (a string containing 'ar') and (a string containing 'bz')|)
+        }.to fail_matching(%Q|expected #{['foo', 'bar', 'baz'].inspect} not to include (a string containing 'ar')|)
       end
     end
   end


### PR DESCRIPTION
Fixes #771 

Reimplements the `include` matcher to account for all divergent items (excluded when expected to be included in actual or included when expected to be excluded in actual) to be used in example failure output. Now when something is missing from an expectation of inclusion, the failure output will more helpfully tell you what exactly was missing rather than a full description of the expected items.

Most basic example:
```plaintext
# Current output
Failure/Error: expect("abc").to include("a", "d", "c")
       expected "abc" to include "a", "d", and "c"

Failure/Error: expect({ :a => 7, :b => 5 }).not_to include(:a => 7, :d => 3)
       expected {:a => 7, :b => 5} not to include {:a => 7, :d => 3}

# Revised output with this PR
Failure/Error: expect("abc").to include("a", "d", "c")
       expected "abc" to include "d"
       # "a" and "c" were indeed included, so only "d" is mentioned

Failure/Error: expect({ :a => 7, :b => 5 }).not_to include(:a => 7, :d => 3)
       expected {:a => 7, :b => 5} not to include {:a => 7}
       # :d => 3 was indeed not included, so only :a => 7 is mentioned
```

~~My ramblings on performance in the associated issue are addressed in this implementation; my first [poorly written] attempt at this prompted my confused comment but I believe this one works quite well and I benchmarked it extensively. It has little to no impact~~

Includes benchmarks; a [potentially] large hit in failures for includes is expected; instead of fulfilling a failed match and stopping execution, we now continue comparing the rest of `expected` to `actual` for the new failure output. 