### PR TITLE
`satisfy` matcher custom descriptions

### DIFF
--- a/features/built_in_matchers/satisfy.feature
+++ b/features/built_in_matchers/satisfy.feature
@@ -8,9 +8,14 @@ Feature: `satisfy` matcher
     expect(7).not_to satisfy { |v| v % 5 == 0 }
     ```
 
-  This flexibility comes at a cost, however: the failure message ("expected [actual] to satisfy
-  block") is not very descriptive or helpful.  You will usually be better served by using one of
-  the other built-in matchers, or writing a custom matcher.
+  The default failure message ("expected [actual] to satisfy block") is not very descriptive or helpful.
+  To add clarification, you can provide your own description as an argument:
+
+    ```ruby
+    expect(10).to satisfy("be a multiple of 5") do |v|
+      v % 5 == 0
+    end
+    ```
 
   Scenario: basic usage
     Given a file named "satisfy_matcher_spec.rb" with:
@@ -22,11 +27,15 @@ Feature: `satisfy` matcher
         # deliberate failures
         it { is_expected.not_to satisfy { |v| v > 5 } }
         it { is_expected.to satisfy { |v| v > 15 } }
+        it { is_expected.to_not satisfy("be greater than 5") { |v| v > 5 } }
+        it { is_expected.to satisfy("be greater than 15") { |v| v > 15 } }
       end
       """
     When I run `rspec satisfy_matcher_spec.rb`
     Then the output should contain all of these:
-      | 4 examples, 2 failures           |
-      | expected 10 not to satisfy block |
-      | expected 10 to satisfy block     |
+      | 6 examples, 4 failures               |
+      | expected 10 not to satisfy block     |
+      | expected 10 to satisfy block         |
+      | expected 10 not to be greater than 5 |
+      | expected 10 to be greater than 15    |
 

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -767,10 +767,13 @@ module RSpec
     # If you do find yourself in such a situation, you could always write
     # a custom matcher, which would likely make your specs more expressive.
     #
+    # @param description [String] optional description to be used for this matcher.
+    #
     # @example
     #   expect(5).to satisfy { |n| n > 3 }
-    def satisfy(&block)
-      BuiltIn::Satisfy.new(&block)
+    #   expect(5).to satisfy("be greater than 3") { |n| n > 3 }
+    def satisfy(description="satisfy block", &block)
+      BuiltIn::Satisfy.new(description, &block)
     end
     alias_matcher :an_object_satisfying, :satisfy
     alias_matcher :satisfying,           :satisfy

--- a/lib/rspec/matchers/built_in/satisfy.rb
+++ b/lib/rspec/matchers/built_in/satisfy.rb
@@ -5,7 +5,11 @@ module RSpec
       # Provides the implementation for `satisfy`.
       # Not intended to be instantiated directly.
       class Satisfy < BaseMatcher
-        def initialize(&block)
+        # @private
+        attr_reader :description
+
+        def initialize(description="satisfy block", &block)
+          @description = description
           @block = block
         end
 
@@ -19,19 +23,13 @@ module RSpec
         # @api private
         # @return [String]
         def failure_message
-          "expected #{actual_formatted} to satisfy block"
+          "expected #{actual_formatted} to #{description}"
         end
 
         # @api private
         # @return [String]
         def failure_message_when_negated
-          "expected #{actual_formatted} not to satisfy block"
-        end
-
-        # @api private
-        # @return [String]
-        def description
-          "satisfy block"
+          "expected #{actual_formatted} not to #{description}"
         end
       end
     end

--- a/spec/rspec/matchers/built_in/satisfy_spec.rb
+++ b/spec/rspec/matchers/built_in/satisfy_spec.rb
@@ -24,6 +24,30 @@ RSpec.describe "expect(...).to satisfy { block }" do
       end
     end.to fail_with("expected false to satisfy block")
   end
+
+  context "when a custom description is provided" do
+    it "describes itself" do
+      expect(satisfy("be awesome").description).to eq("be awesome")
+    end
+
+    it "passes if block returns true" do
+      expect(true).to satisfy("be true") { |val| val }
+      expect(true).to satisfy("be true") do |val|
+        val
+      end
+    end
+
+    it "fails with the custom description if block returns false" do
+      expect {
+        expect(false).to satisfy("be true") { |val| val }
+      }.to fail_with("expected false to be true")
+      expect do
+        expect(false).to satisfy("be true") do |val|
+          val
+        end
+      end.to fail_with("expected false to be true")
+    end
+  end
 end
 
 RSpec.describe "expect(...).not_to satisfy { block }" do
@@ -38,5 +62,20 @@ RSpec.describe "expect(...).not_to satisfy { block }" do
     expect {
       expect(true).not_to satisfy { |val| val }
     }.to fail_with("expected true not to satisfy block")
+  end
+
+  context "when a custom description is provided" do
+    it "passes if block returns false" do
+      expect(false).not_to satisfy("be true") { |val| val }
+      expect(false).not_to satisfy("be true") do |val|
+        val
+      end
+    end
+
+    it "fails with the custom description if block returns true" do
+      expect {
+        expect(true).not_to satisfy("be true") { |val| val }
+      }.to fail_with("expected true not to be true")
+    end
   end
 end


### PR DESCRIPTION
Closes #719

...So, awkwardly I _just_ stumbled upon https://github.com/rspec/rspec-expectations/pull/259 while searching for the issue this PR is supposed to resolve. 

@myronmarston This PR resolves the open issue as requested, but the closed issue contradicts it. Were you deciding that now this is a good idea?

TBH I had no idea you could pass a description to any matcher like that, and if that's the case I'd tend to agree with your past self :) If you still agree with that, I'll just leave it as is and instead change the documentation for `satisfy` to suggest giving a better description using the existing way.