### PR TITLE
Omit all Ruby < 1.9 only code from test coverage

### DIFF
--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -933,11 +933,13 @@ module RSpec
         method =~ DYNAMIC_MATCHER_REGEX || super
       end
     else # for 1.8.7
+      # :nocov:
       def respond_to?(method, *)
         method = method.to_s
         method =~ DYNAMIC_MATCHER_REGEX || super
       end
       public :respond_to?
+      # :nocov:
     end
 
     # @api private

--- a/lib/rspec/matchers/built_in/base_matcher.rb
+++ b/lib/rspec/matchers/built_in/base_matcher.rb
@@ -116,9 +116,11 @@ module RSpec
         end
 
         if RUBY_VERSION.to_f < 1.9
+          # :nocov:
           def present_ivars
             instance_variables.map { |v| v.to_sym }
           end
+          # :nocov:
         else
           alias present_ivars instance_variables
         end

--- a/lib/rspec/matchers/built_in/be.rb
+++ b/lib/rspec/matchers/built_in/be.rb
@@ -220,9 +220,11 @@ module RSpec
 
         # support 1.8.7, evaluate once at load time for performance
         if String === methods.first
+          # :nocov:
           def private_predicate?
             @actual.private_methods.include? predicate.to_s
           end
+          # :nocov:
         else
           def private_predicate?
             @actual.private_methods.include? predicate

--- a/lib/rspec/matchers/built_in/has.rb
+++ b/lib/rspec/matchers/built_in/has.rb
@@ -49,9 +49,11 @@ module RSpec
 
         # support 1.8.7, evaluate once at load time for performance
         if String === methods.first
+          # :nocov:
           def private_predicate?
             @actual.private_methods.include? predicate.to_s
           end
+          # :nocov:
         else
           def private_predicate?
             @actual.private_methods.include? predicate

--- a/lib/rspec/matchers/built_in/yield.rb
+++ b/lib/rspec/matchers/built_in/yield.rb
@@ -78,6 +78,7 @@ module RSpec
                   "matcher. Pass the argument as a block on to the method you are testing."
           end
         else
+          # :nocov:
           # On 1.8.7, `lambda { }.arity` and `lambda { |*a| }.arity` both return -1,
           # so we can't distinguish between accepting no args and an arg splat.
           # It's OK to skip, this, though; it just provides a nice error message
@@ -86,6 +87,7 @@ module RSpec
           def assert_valid_expect_block!
             # nothing to do
           end
+          # :nocov:
         end
       end
 

--- a/lib/rspec/matchers/composable.rb
+++ b/lib/rspec/matchers/composable.rb
@@ -148,6 +148,7 @@ module RSpec
       end
 
       if String.ancestors.include?(Enumerable) # 1.8.7
+        # :nocov:
         # Strings are not enumerable on 1.9, and on 1.8 they are an infinitely
         # nested enumerable: since ruby lacks a character class, it yields
         # 1-character strings, which are themselves enumerable, composed of a
@@ -158,6 +159,7 @@ module RSpec
           return false if String === item
           Enumerable === item && !(Range === item)
         end
+        # :nocov:
       else
         # @api private
         def should_enumerate?(item)

--- a/lib/rspec/matchers/dsl.rb
+++ b/lib/rspec/matchers/dsl.rb
@@ -24,9 +24,11 @@ module RSpec
           end
         end
       else
+        # :nocov:
         def warn_about_block_args(*)
           # There's no way to detect block params on 1.8 since the method reflection APIs don't expose it
         end
+        # :nocov:
       end
 
       RSpec.configure { |c| c.extend self } if RSpec.respond_to?(:configure)
@@ -410,11 +412,13 @@ module RSpec
             super || @matcher_execution_context.respond_to?(method, include_private)
           end
         else # for 1.8.7
+          # :nocov:
           # Indicates that this matcher responds to messages
           # from the `@matcher_execution_context` as well.
           def respond_to?(method, include_private=false)
             super || @matcher_execution_context.respond_to?(method, include_private)
           end
+          # :nocov:
         end
 
       private

--- a/lib/rspec/matchers/matcher_delegator.rb
+++ b/lib/rspec/matchers/matcher_delegator.rb
@@ -19,9 +19,11 @@ module RSpec
           super || base_matcher.respond_to?(name, include_all)
         end
       else
+        # :nocov:
         def respond_to?(name, include_all=false)
           super || base_matcher.respond_to?(name, include_all)
         end
+        # :nocov:
       end
 
       def initialize_copy(other)


### PR DESCRIPTION
Part of #767, omits code specific to older versions of Ruby from test coverage.