### PR TITLE
Exception failures in `match_when_negated`; Fix `NegativeExpectationHandler::handle_matcher`

### DIFF
--- a/lib/rspec/expectations/handler.rb
+++ b/lib/rspec/expectations/handler.rb
@@ -69,7 +69,7 @@ module RSpec
       def self.handle_matcher(actual, initial_matcher, message=nil, &block)
         ExpectationHelper.with_matcher(self, initial_matcher, message) do |matcher|
           return ::RSpec::Matchers::BuiltIn::NegativeOperatorMatcher.new(actual) unless initial_matcher
-          !(does_not_match?(matcher, actual, &block) || ExpectationHelper.handle_failure(matcher, message, :failure_message_when_negated))
+          does_not_match?(matcher, actual, &block) || ExpectationHelper.handle_failure(matcher, message, :failure_message_when_negated)
         end
       end
 

--- a/lib/rspec/matchers/dsl.rb
+++ b/lib/rspec/matchers/dsl.rb
@@ -80,8 +80,14 @@ module RSpec
         # @yield [Object] actual the actual value (i.e. the value wrapped by `expect`)
         def match_when_negated(&match_block)
           define_user_override(:does_not_match?, match_block) do |actual|
-            @actual = actual
-            super(*actual_arg_for(match_block))
+            begin
+              @actual = actual
+              RSpec::Support.with_failure_notifier(RAISE_NOTIFIER) do
+                super(*actual_arg_for(match_block))
+              end
+            rescue RSpec::Expectations::ExpectationNotMetError
+              false
+            end
           end
         end
 


### PR DESCRIPTION
Fixes #788 

This fixes two issues; The second was found after testing the first led to it, and is dependent on it.

* Fixes `match_when_negated` to work as `match` does. The definition of #match in the matcher DSL rescues ExpectationNotMetError and returns false, allowing expectations to be used in match blocks. This changes #match_when_negated to act similarly.
* Using a negative matcher _with differing values_ (ie: `expect("foo").not_to eq "bar"`) has returned `false` for a long time, instead of the handler properly raising `ExpectationNotMetError`. This changes the handler to similarly do it as the positive handler does. See commit message in 7880b129963f8196dd288bdf834167f1204fe760 for more details.