### PR TITLE
Prep for extra options on failure_notifier

### DIFF
--- a/lib/rspec/expectations/failure_aggregator.rb
+++ b/lib/rspec/expectations/failure_aggregator.rb
@@ -41,7 +41,7 @@ module RSpec
 
       # This method is defined to satisfy the callable interface
       # expected by `RSpec::Support.with_failure_notifier`.
-      def call(failure)
+      def call(failure, options = {})
         failure.set_backtrace(caller) unless failure.backtrace
         failures << failure
       end

--- a/lib/rspec/matchers/dsl.rb
+++ b/lib/rspec/matchers/dsl.rb
@@ -60,7 +60,7 @@ module RSpec
           define_user_override(:matches?, match_block) do |actual|
             begin
               @actual = actual
-              RSpec::Support.with_failure_notifier(RAISE_METHOD) do
+              RSpec::Support.with_failure_notifier(FAILURE_RAISER) do
                 super(*actual_arg_for(match_block))
               end
             rescue RSpec::Expectations::ExpectationNotMetError
@@ -71,6 +71,10 @@ module RSpec
 
         # @private
         RAISE_METHOD = method(:raise)
+
+        # @private
+        # we only need to instantiate this proc once, but want to not repeat capture of the method
+        FAILURE_RAISER = proc { |failure| RAISE_METHOD.call(failure) }
 
         # Use this to define the block for a negative expectation (`expect(...).not_to`)
         # when the positive and negative forms require different handling. This


### PR DESCRIPTION
We wrap the `RAISE_METHOD` in a similarly captured proc so that adding options to the failure_notifier won't break it, similarly we prep aggregate_failures for receiving options.