### PR TITLE
Removed deprecated option from .gemspec

### DIFF
--- a/rspec-expectations.gemspec
+++ b/rspec-expectations.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |s|
   s.summary     = "rspec-expectations-#{RSpec::Expectations::Version::STRING}"
   s.description = "rspec-expectations provides a simple, readable API to express expected outcomes of a code example."
 
-  s.rubyforge_project  = "rspec"
-
   s.files            = `git ls-files -- lib/*`.split("\n")
   s.files           += %w[README.md License.txt Changelog.md .yardopts .document]
   s.test_files       = []


### PR DESCRIPTION
This PR is related to https://github.com/rspec/rspec-core/pull/1974
Thank you. 