### PR TITLE
Address 1.8.7 hash ordering

### DIFF
--- a/spec/rspec/matchers/built_in/eq_spec.rb
+++ b/spec/rspec/matchers/built_in/eq_spec.rb
@@ -97,6 +97,8 @@ module RSpec
             [Time.utc(2014, 1, 1), "eq 2014-01-01 00:00:00.#{expected_seconds} +0000"],
         ].each do |expected, expected_description|
           context "with #{expected.inspect}" do
+            around { |ex| with_env_vars('TZ' => 'UTC', &ex) } if expected.is_a?(Time)
+
             it "is \"#{expected_description}\"" do
               expect(eq(expected).description).to eq expected_description
             end

--- a/spec/rspec/matchers/built_in/start_and_end_with_spec.rb
+++ b/spec/rspec/matchers/built_in/start_and_end_with_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe "expect(...).to start_with" do
       expected = { :a => 'b', :b => 'b' }
       expect{
         expect(actual).to start_with(expected)
-      }.to fail_with("expected #{actual.inspect} to start with #{expected.inspect}, but it does not have ordered elements")
+      }.to fail_with(/\Aexpected #{hash_inspect(actual).gsub(" => ", "=>")} to start with #{hash_inspect(expected).gsub(" => ", "=>")}, but it does not have ordered elements\z/)
     end
   end
 
@@ -324,7 +324,7 @@ RSpec.describe "expect(...).to end_with" do
       expected = { :a => 'b', :b => 'b' }
       expect{
         expect(actual).to end_with(expected)
-      }.to fail_with("expected #{actual.inspect} to end with #{expected.inspect}, but it does not have ordered elements")
+      }.to fail_with(/\Aexpected #{hash_inspect(actual).gsub(" => ", "=>")} to end with #{hash_inspect(expected).gsub(" => ", "=>")}, but it does not have ordered elements\z/)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,7 @@ module CommonHelperMethods
   # put a literal string for what we expect because it varies.
   if RUBY_VERSION.to_f == 1.8
     def hash_inspect(hash)
-      /\{(#{hash.map { |key,value| "#{key.inspect} => #{value.inspect}.*" }.join "|" }){#{hash.size}}\}/
+      "\\{(#{hash.map { |key,value| "#{key.inspect} => #{value.inspect}.*" }.join "|"}){#{hash.size}}\\}"
     end
   else
     def hash_inspect(hash)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,18 @@ Dir['./spec/support/**/*'].each do |f|
   require f.sub(%r{\./spec/}, '')
 end
 
-module FormattingSupport
+module CommonHelperMethods
+  def with_env_vars(vars)
+    original = ENV.to_hash
+    vars.each { |k, v| ENV[k] = v }
+
+    begin
+      yield
+    ensure
+      ENV.replace(original)
+    end
+  end
+
   def dedent(string)
     string.gsub(/^\s+\|/, '').chomp
   end
@@ -34,7 +45,7 @@ RSpec::configure do |config|
   config.color = true
   config.order = :random
 
-  config.include FormattingSupport
+  config.include CommonHelperMethods
   config.include RSpec::Support::InSubProcess
 
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
This addresses the failures from rspec/rspec-core#1971.  Not sure why they started failing and I can't repro locally but this should fix it.