### PR TITLE
Refactor: expose `all_exceptions` in a way that allows ordered additions.

### DIFF
--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -7,7 +7,11 @@ end
 
 Then /^the output should contain all of these:$/ do |table|
   table.raw.flatten.each do |string|
-    assert_partial_output(string, all_output)
+    if RUBY_VERSION == '1.8.7' && string =~ /\{.+=>.+\}/
+      warn "Skipping checking #{string} on 1.8.7 because hash ordering is not consistent"
+    else
+      assert_partial_output(string, all_output)
+    end
   end
 end
 

--- a/lib/rspec/expectations/failure_aggregator.rb
+++ b/lib/rspec/expectations/failure_aggregator.rb
@@ -105,9 +105,7 @@ module RSpec
       end
 
       # @return [Array<Exception>] The list of expectation failures and other exceptions, combined.
-      def all_exceptions
-        failures + other_errors
-      end
+      attr_reader :all_exceptions
 
       # @return [String] The user-assigned label for the aggregation block.
       def aggregation_block_label
@@ -137,6 +135,7 @@ module RSpec
 
       def initialize(failure_aggregator)
         @failure_aggregator = failure_aggregator
+        @all_exceptions = failures + other_errors
       end
 
       def block_description


### PR DESCRIPTION
Needed by an rspec-core PR that's forthcoming.