### PR TITLE
This adds the `any`-matcher

### DIFF
--- a/features/.nav
+++ b/features/.nav
@@ -4,6 +4,7 @@
   - predicates.feature
   - types.feature
   - all.feature
+  - any.feature
   - be.feature
   - be_within.feature
   - exist.feature

--- a/features/built_in_matchers/all.feature
+++ b/features/built_in_matchers/all.feature
@@ -30,13 +30,18 @@ Feature: `all` matcher
         it { is_expected.to all( be_a(String) ) }
         it { is_expected.to all( be > 2 ) }
       end
+
+      RSpec.describe [1, 'a', 5] do
+        it { is_expected.to all( be < 10 ) }
+      end
       """
     When I run `rspec array_all_matcher_spec.rb`
     Then the output should contain all of these:
-      | 6 examples, 3 failures                        |
+      | 7 examples, 4 failures                        |
       | expected [1, 3, 5] to all be even             |
       | expected [1, 3, 5] to all be a kind of String |
       | expected [1, 3, 5] to all be > 2              |
+      | expected [1, "a", 5] to all be < 10           |
 
   Scenario: compound matcher usage
     Given a file named "compound_all_matcher_spec.rb" with:

--- a/features/built_in_matchers/any.feature
+++ b/features/built_in_matchers/any.feature
@@ -1,0 +1,61 @@
+Feature: `any` matcher
+
+  Use the `any` matcher to specify that a collection's objects any pass an expected matcher.
+  This works on any enumerable object.
+
+    ```ruby
+    expect([1, 4, 5]).to any( be_odd )
+    expect([1, 3, 'a']).to any( be_an(Integer) )
+    expect([1, 3, 11]).to any( be < 10 )
+    ```
+
+  The matcher also supports compound matchers:
+
+    ```ruby
+    expect([1, 'a', 11]).to any( be_odd.and be < 10 )
+    ```
+
+  Scenario: array usage
+    Given a file named "array_any_matcher_spec.rb" with:
+      """ruby
+      RSpec.describe [1, 4, 'a', 11] do
+        it { is_expected.to any( be_odd ) }
+        it { is_expected.to any( be_an(Integer) ) }
+        it { is_expected.to any( be < 10 ) }
+      end
+
+      RSpec.describe [14, 'a'] do
+        it { is_expected.to any( be_odd ) }
+        it { is_expected.to any( be_an(Symbol) ) }
+        it { is_expected.to any( be < 10 ) }
+      end
+      """
+    When I run `rspec array_any_matcher_spec.rb`
+    Then the output should contain all of these:
+       | 6 examples, 3 failures                        |
+       | expected [14, "a"] to any be odd              |
+       | expected [14, "a"] to any be a kind of Symbol |
+       | expected [14, "a"] to any be < 10             |
+
+  Scenario: compound matcher usage
+    Given a file named "compound_any_matcher_spec.rb" with:
+      """ruby
+      RSpec.describe [1, 'anything', 'something'] do
+        it { is_expected.to any( be_a(String).and include("thing") ) }
+        it { is_expected.to any( be_a(String).and end_with("g") ) }
+        it { is_expected.to any( start_with("s").or include("y") ) }
+      end
+
+      RSpec.describe ['anything', 'something'] do
+        it { is_expected.to any( be_a(Integer).and include("thing") ) }
+        it { is_expected.to any( be_a(Integer).and end_with("z") ) }
+        it { is_expected.to any( start_with("z").or include("1") ) }
+      end
+      """
+    When I run `rspec compound_any_matcher_spec.rb`
+    Then the output should contain all of these:
+       | 6 examples, 3 failures                                                             |
+       | expected ["anything", "something"] to any be a kind of Integer and include "thing" |
+       | expected ["anything", "something"] to any be a kind of Integer and end with "z"    |
+       | expected ["anything", "something"] to any start with "z" or include "1"            |
+

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -666,6 +666,24 @@ module RSpec
       BuiltIn::All.new(expected)
     end
 
+    # Passes if the provided matcher passes when checked against any
+    # element of the collection.
+    #
+    # @example
+    #   expect([1, 4, 5]).to any be_odd
+    #
+    # @note The negative form `not_to any` is not supported. Instead
+    #   use `not_to include` or pass a negative form of a matcher
+    #   as the argument (e.g. `all exclude(:foo)` - mind it's `all` here).
+    #
+    # @note You can also use this with compound matchers as well.
+    #
+    # @example
+    #   expect([1, 4, 'a']).to any( be_odd.and be_an(Integer) )
+    def any(expected)
+      BuiltIn::Any.new(expected)
+    end
+
     # Given a `Regexp` or `String`, passes if `actual.match(pattern)`
     # Given an arbitrary nested data structure (e.g. arrays and hashes),
     # matches if `expected === actual` || `actual == expected` for each

--- a/lib/rspec/matchers/built_in.rb
+++ b/lib/rspec/matchers/built_in.rb
@@ -33,6 +33,7 @@ module RSpec
       autoload :HaveAttributes,          'rspec/matchers/built_in/have_attributes'
       autoload :Include,                 'rspec/matchers/built_in/include'
       autoload :All,                     'rspec/matchers/built_in/all'
+      autoload :Any,                     'rspec/matchers/built_in/any'
       autoload :Match,                   'rspec/matchers/built_in/match'
       autoload :NegativeOperatorMatcher, 'rspec/matchers/built_in/operators'
       autoload :OperatorMatcher,         'rspec/matchers/built_in/operators'

--- a/lib/rspec/matchers/built_in/all.rb
+++ b/lib/rspec/matchers/built_in/all.rb
@@ -50,7 +50,13 @@ module RSpec
         def index_failed_objects
           actual.each_with_index do |actual_item, index|
             cloned_matcher = matcher.clone
-            matches = cloned_matcher.matches?(actual_item)
+
+            begin
+              matches = cloned_matcher.matches?(actual_item)
+            rescue StandardError
+              matches = nil
+            end
+
             failed_objects[index] = cloned_matcher.failure_message unless matches
           end
         end

--- a/lib/rspec/matchers/built_in/any.rb
+++ b/lib/rspec/matchers/built_in/any.rb
@@ -1,0 +1,54 @@
+module RSpec
+  module Matchers
+    module BuiltIn
+      # @api private
+      # Provides the implementation for `all`.
+      # Not intended to be instantiated directly.
+      class Any < All
+        # @private
+        attr_reader :matcher, :failed_objects
+        # @private
+        attr_accessor :any_succeeded_object
+
+        def initialize(matcher)
+          @matcher = matcher
+          @failed_objects = {}
+          @any_succeeded_object = false
+        end
+
+        # @api private
+        # @return [String]
+        def description
+          improve_hash_formatting "any #{description_of matcher}"
+        end
+
+      private
+
+        def match(_expected, _actual)
+          return false unless iterable?
+
+          index_failed_objects
+          any_succeeded_object == true
+        end
+
+        def index_failed_objects
+          actual.each_with_index do |actual_item, index|
+            cloned_matcher = matcher.clone
+            begin
+              matches = cloned_matcher.matches?(actual_item)
+            rescue StandardError
+              matches = nil
+            end
+
+            if matches
+              self.any_succeeded_object = true
+              break
+            else
+              failed_objects[index] = cloned_matcher.failure_message
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
You guys already added the `all`-matcher. This is very helpful. Unfortunately there's no `any`-matcher available. I hope I do not oversaw a similar functionality.

To have the `any`-matcher along this would make code at cucumber/aurba easier. This PR adds this matcher. It is based on the `All`-matcher and is a sub-class of this and re-uses most code given there.

BTW:
This PR also changes the behaviour of `all` when an exception - aka `ArgumentError` - is raised. Now the `matches`-call is wrapped with in a `begin; end`-block to make it check all objects and not to stop on the first one where the exception occured.