### PR TITLE
Fixed bug in be_*-matcher

### DIFF
--- a/features/built_in_matchers/comparisons.feature
+++ b/features/built_in_matchers/comparisons.feature
@@ -7,6 +7,7 @@ Feature: Comparison matchers
     expect(9).to be > 6
     expect(3).to be <= 3
     expect(1).to be < 6
+    expect('a').to be < 'b'
     ```
 
   Scenario: numeric operator matchers
@@ -23,10 +24,18 @@ Feature: Comparison matchers
         it { is_expected.to be > 20 }
         it { is_expected.to be <= 17 }
         it { is_expected.to be >= 19 }
+        it { is_expected.to be < 'a' }
+      end
+
+      RSpec.describe 'a' do
+        it { is_expected.to be < 'b' }
+
+        # deliberate failures
+        it { is_expected.to be < 18 }
       end
       """
      When I run `rspec numeric_operator_matchers_spec.rb`
-     Then the output should contain "8 examples, 4 failures"
+     Then the output should contain "11 examples, 6 failures"
       And the output should contain:
       """
            Failure/Error: it { is_expected.to be < 15 }
@@ -51,6 +60,19 @@ Feature: Comparison matchers
              expected: >= 19
                   got:    18
       """
+      And the output should contain:
+      """
+           Failure/Error: it { is_expected.to be < 'a' }
+             expected: < "a"
+                  got:   18
+      """
+      And the output should contain:
+      """
+           Failure/Error: it { is_expected.to be < 18 }
+             expected: < 18
+                  got:   "a"
+      """
+
 
   Scenario: string operator matchers
     Given a file named "string_operator_matchers_spec.rb" with:

--- a/lib/rspec/matchers/built_in/be.rb
+++ b/lib/rspec/matchers/built_in/be.rb
@@ -144,6 +144,8 @@ module RSpec
         def matches?(actual)
           @actual = actual
           @actual.__send__ @operator, @expected
+        rescue ArgumentError
+          false
         end
 
         # @api private

--- a/spec/rspec/matchers/built_in/be_spec.rb
+++ b/spec/rspec/matchers/built_in/be_spec.rb
@@ -460,12 +460,23 @@ end
 RSpec.describe "expect(...).to be <" do
   it "passes when < operator returns true" do
     expect(3).to be < 4
+    expect('a').to be < 'b'
   end
 
   it "fails when < operator returns false" do
     expect {
       expect(3).to be < 3
     }.to fail_with("expected: < 3\n     got:   3")
+
+    expect {
+      expect('a').to be < 'a'
+    }.to fail_with(%(expected: < "a"\n     got:   "a"))
+  end
+
+  it "fails when < operator raises ArgumentErrorr" do
+    expect {
+      expect('a').to be < 1
+    }.to fail_with(%(expected: < 1\n     got:   "a"))
   end
 
   it "describes itself" do
@@ -482,12 +493,24 @@ RSpec.describe "expect(...).to be <=" do
   it "passes when <= operator returns true" do
     expect(3).to be <= 4
     expect(4).to be <= 4
+    expect('a').to be <= 'b'
+    expect('a').to be <= 'a'
   end
 
   it "fails when <= operator returns false" do
     expect {
       expect(3).to be <= 2
     }.to fail_with("expected: <= 2\n     got:    3")
+
+    expect {
+      expect('c').to be <= 'a'
+    }.to fail_with(%(expected: <= "a"\n     got:    "c"))
+  end
+
+  it "fails when < operator raises ArgumentErrorr" do
+    expect {
+      expect('a').to be <= 1
+    }.to fail_with(%(expected: <= 1\n     got:    "a"))
   end
 end
 
@@ -501,6 +524,16 @@ RSpec.describe "expect(...).to be >=" do
     expect {
       expect(3).to be >= 4
     }.to fail_with("expected: >= 4\n     got:    3")
+
+    expect {
+      expect('a').to be >= 'c'
+    }.to fail_with(%(expected: >= "c"\n     got:    "a"))
+  end
+
+  it "fails when < operator raises ArgumentErrorr" do
+    expect {
+      expect('a').to be >= 1
+    }.to fail_with(%(expected: >= 1\n     got:    "a"))
   end
 end
 
@@ -513,6 +546,16 @@ RSpec.describe "expect(...).to be >" do
     expect {
       expect(3).to be > 4
     }.to fail_with("expected: > 4\n     got:   3")
+
+    expect {
+      expect('a').to be > 'a'
+    }.to fail_with(%(expected: > "a"\n     got:   "a"))
+  end
+
+  it "fails when < operator raises ArgumentErrorr" do
+    expect {
+      expect('a').to be > 1
+    }.to fail_with(%(expected: > 1\n     got:   "a"))
   end
 end
 
@@ -525,6 +568,16 @@ RSpec.describe "expect(...).to be ==" do
     expect {
       expect(3).to be == 4
     }.to fail_with("expected: == 4\n     got:    3")
+
+    expect {
+      expect('a').to be == 'c'
+    }.to fail_with(%(expected: == "c"\n     got:    "a"))
+  end
+
+  it "fails when < operator raises ArgumentErrorr" do
+    expect {
+      expect('a').to be == 1
+    }.to fail_with(%(expected: == 1\n     got:    "a"))
   end
 
   it 'works when the target overrides `#send`' do


### PR DESCRIPTION
Hi this is a also a follow up to #807,

I added a `begin; rescue; end` block to rescue `ArgumentError`. Should I also rescue `NoMethodError`? I thought it would be better not to rescue this one, because it is a severe user error which should not be rescued.