### PR TITLE
Fix `respond_to` for targets that redefine `method`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,9 @@ Bug Fixes:
   wrong type. This allows it to be used in composed matcher expressions
   against heterogeneous objects. (Dennis Günnewig, #809)
 
+* Fix `respond_to` to work properly on target objects
+  that redefine the `method` method. (unmanbearpig)
+
 ### 3.3.0 / 2015-06-12
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.2.1...v3.3.0)
 

--- a/lib/rspec/matchers/built_in/respond_to.rb
+++ b/lib/rspec/matchers/built_in/respond_to.rb
@@ -72,7 +72,7 @@ module RSpec
         def matches_arity?(actual, name)
           return true unless @expected_arity
 
-          signature = Support::MethodSignature.new(actual.method(name))
+          signature = Support::MethodSignature.new(get_method_on_object(actual, name))
           Support::StrictSignatureVerifier.new(signature, Array.new(@expected_arity)).valid?
         end
 
@@ -83,6 +83,11 @@ module RSpec
 
         def pp_names
           @names.length == 1 ? "##{@names.first}" : description_of(@names)
+        end
+
+        def get_method_on_object(object, method_name)
+          # Can't use object.method since it might be overridden
+          Kernel.instance_method(:method).bind(object).call(method_name)
         end
       end
     end

--- a/lib/rspec/matchers/built_in/respond_to.rb
+++ b/lib/rspec/matchers/built_in/respond_to.rb
@@ -72,7 +72,7 @@ module RSpec
         def matches_arity?(actual, name)
           return true unless @expected_arity
 
-          signature = Support::MethodSignature.new(get_method_on_object(actual, name))
+          signature = Support::MethodSignature.new(Support.method_handle_for(actual, name))
           Support::StrictSignatureVerifier.new(signature, Array.new(@expected_arity)).valid?
         end
 
@@ -83,11 +83,6 @@ module RSpec
 
         def pp_names
           @names.length == 1 ? "##{@names.first}" : description_of(@names)
-        end
-
-        def get_method_on_object(object, method_name)
-          # Can't use object.method since it might be overridden
-          Kernel.instance_method(:method).bind(object).call(method_name)
         end
       end
     end

--- a/spec/rspec/matchers/built_in/respond_to_spec.rb
+++ b/spec/rspec/matchers/built_in/respond_to_spec.rb
@@ -63,6 +63,13 @@ RSpec.describe "expect(...).to respond_to(:sym).with(1).argument" do
       expect(obj).to respond_to(:foo).with(1).argument
     }.to fail_with(/expected #<Object.*> to respond to :foo with 1 argument/)
   end
+
+  it "still works if target has overridden the method method" do
+    obj = Object.new
+    def obj.method; end
+    def obj.other_method(arg); end
+    expect(obj).to respond_to(:other_method).with(1).argument
+  end
 end
 
 RSpec.describe "expect(...).to respond_to(message1, message2)" do


### PR DESCRIPTION
Previously it would crash or not work properly when we were trying to
check arity of any method on target object that had overridden the
`method` method.