### PR TITLE
removes whitespace from README to fix failing test

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you want to use rspec-expectations with another tool, like Test::Unit,
 Minitest, or Cucumber, you can install it directly:
 
     gem install rspec-expectations
-    
+
 ## Contributing
 
 Once you've set up the environment, you'll need to cd into the working


### PR DESCRIPTION
Whitespace in README from last update resulted in a failing test. This removes that whitespace