### PR TITLE
[Draft] clean up error message with change and has_attributes

### DIFF
--- a/lib/rspec/matchers/built_in/change.rb
+++ b/lib/rspec/matchers/built_in/change.rb
@@ -195,11 +195,33 @@ module RSpec
         end
 
         def before_value_failure
-          "expected #{@change_details.message} to have initially been #{description_of @expected_before}, but was #{description_of @change_details.actual_before}"
+          if @expected_before.class == RSpec::Matchers::BuiltIn::HaveAttributes
+            "expected #{@change_details.message} to not change, but changed and has attributes #{ formatted_values(get_actual_values(@expected_before.expected)) }"
+          else
+            "expected #{@change_details.message} to have initially been #{description_of @expected_before}, but was #{description_of @change_details.actual_before}"
+          end
         end
 
         def after_value_failure
-          "expected #{@change_details.message} to have changed to #{description_of @expected_after}, but is now #{description_of @change_details.actual_after}"
+          if @expected_after.class == RSpec::Matchers::BuiltIn::HaveAttributes
+            "expected #{@change_details.message} to have changed to #{description_of @expected_after}, but had attributes #{ formatted_values(get_actual_values(@expected_after.expected)) }"
+          else
+            "expected #{@change_details.message} to have changed to #{description_of @expected_after}, but is now #{description_of @change_details.actual_after}"
+          end
+        end
+
+        def formatted_values(expected)
+          values = RSpec::Support::ObjectFormatter.format(expected)
+          improve_hash_formatting(values)
+        end
+
+        def get_actual_values(expectation)
+          actual_values = {}
+          expectation.each do |attribute_key, _attribute_value|
+            actual_value = @change_details.actual_after.__send__(attribute_key)
+            actual_values[attribute_key] = actual_value
+          end
+          actual_values
         end
 
         def did_not_change_failure
@@ -207,7 +229,11 @@ module RSpec
         end
 
         def did_change_failure
-          "expected #{@change_details.message} not to have changed, but did change from #{description_of @change_details.actual_before} to #{description_of @change_details.actual_after}"
+          if @expected_before.class == RSpec::Matchers::BuiltIn::HaveAttributes
+            "expected #{@change_details.message} not to have changed, but changed and has attributes #{ formatted_values(get_actual_values(@expected_before.expected))}"
+          else
+            "expected #{@change_details.message} not to have changed, but did change from #{description_of @change_details.actual_before} to #{description_of @change_details.actual_after}"
+          end
         end
 
         def not_given_a_block_failure

--- a/spec/rspec/matchers/built_in/change_spec.rb
+++ b/spec/rspec/matchers/built_in/change_spec.rb
@@ -778,6 +778,56 @@ RSpec.describe "Composing a matcher with `change`" do
       }.to fail_with(/expected result to have initially been a value within 0.1 of 1.5, but was 0.51/)
     end
   end
+
+  describe "expect(...).to change{...}.to have_attributes()" do
+    Movie = Struct.new(:name, :year)
+
+    let(:wrong_name) { "Wrong Name" }
+    let(:wrong_year) { 2011 }
+
+    let(:correct_name) { "Correct name" }
+    let(:correct_year) { 2013 }
+
+    let(:movie) { Movie.new(correct_name, correct_year) }
+
+    it "fails on 'have_attributes' and gives informative error message" do
+      expect {
+        expect { movie.year = wrong_year }.to change { movie }.to have_attributes({:year => correct_year})
+      }.to fail_including("expected result to have changed to have attributes {:year => #{correct_year}}, but had attributes {:year => #{wrong_year}}")
+    end
+
+    it "fails the 'change' check and gives informative error message" do
+      expect {
+        expect { movie.year = correct_year }.to change { movie }.to have_attributes({:year => correct_year})
+      }.to fail_including("expected result to have changed to have attributes {:year => #{correct_year}}, but did not change")
+    end
+
+    it "fails on negation with 'have_attributes' and gives informative error message" do
+      expect {
+        expect { movie.year = wrong_year }.not_to change { movie }.from have_attributes({:year => correct_year})
+      }.to fail_including("expected result not to have changed, but changed and has attributes {:year => #{wrong_year}}")
+    end
+
+    it "fails on negation with 'not_change' with informative error messages" do
+      expect {
+        expect { movie.year = wrong_year }.not_to change { movie }.from have_attributes({:year => wrong_year})
+      }.to fail_including("expected result to not change, but changed and has attributes {:year => #{wrong_year}}")
+    end
+
+    it "fails on both change and have_attributes and gives informative error message" do
+      expect {
+        expect { movie.year = correct_year }.to change { movie }.to have_attributes({:year => wrong_year})
+      }.to fail_including("expected result to have changed to have attributes {:year => #{wrong_year}}, but did not change")
+    end
+
+    it "fails on negation for both change and have_attributes and gives informative error message" do
+      expect {
+        expect { movie.year = wrong_year }.not_to change { movie }.from have_attributes({:year => correct_year})
+      }.to fail_including("expected result not to have changed, but changed and has attributes {:year => #{wrong_year}}")
+    end
+
+  end
+
 end
 
 RSpec.describe RSpec::Matchers::BuiltIn::Change do

--- a/spec/rspec/matchers/built_in/have_attributes_spec.rb
+++ b/spec/rspec/matchers/built_in/have_attributes_spec.rb
@@ -205,6 +205,46 @@ RSpec.describe "#have_attributes matcher" do
     end
   end
 
+  describe "expect(...).to change{...}.to have_attributes()" do
+
+    it "fails on 'have_attributes' and gives informative error message" do
+      expect {
+        expect { person.age = wrong_age }.to change { person }.to have_attributes({:age => correct_age})
+      }.to fail_including("expected result to have changed to have attributes {:age => 33}, but had attributes {:age => 11}")
+    end
+
+    it "fails the 'change' check and gives informative error message" do
+      expect {
+        expect { person.age = correct_age }.to change { person }.to have_attributes({:age => correct_age})
+      }.to fail_including("expected result to have changed to have attributes {:age => #{correct_age}}, but did not change")
+    end
+
+    it "fails on negation with 'have_attributes' and gives informative error message" do
+      expect {
+        expect { person.age = wrong_age }.not_to change { person }.from have_attributes({:age => correct_age})
+      }.to fail_including("expected result not to have changed, but changed and has attributes {:age => #{wrong_age}}")
+    end
+
+    it "fails on negation with 'not_change' with informative error messages" do
+      expect {
+        expect { person.age = wrong_age }.not_to change { person }.from have_attributes({:age => wrong_age})
+      }.to fail_including("expected result to not change, but changed and has attributes {:age => 11}")
+    end
+
+    it "fails on both change and have_attributes and gives informative error message" do
+      expect {
+        expect { person.age = correct_age }.to change { person }.to have_attributes({:age => wrong_age})
+      }.to fail_including("expected result to have changed to have attributes {:age => 11}, but did not change")
+    end
+
+    it "fails on negation for both change and have_attributes and gives informative error message" do
+      expect {
+        expect { person.age = wrong_age }.not_to change { person }.from have_attributes({:age => correct_age})
+      }.to fail_including("expected result not to have changed, but changed and has attributes {:age => #{wrong_age}}")
+    end
+
+  end
+
   include RSpec::Matchers::Composable
   # a helper for failure message assertion
   def object_inspect(object)

--- a/spec/rspec/matchers/built_in/have_attributes_spec.rb
+++ b/spec/rspec/matchers/built_in/have_attributes_spec.rb
@@ -205,46 +205,6 @@ RSpec.describe "#have_attributes matcher" do
     end
   end
 
-  describe "expect(...).to change{...}.to have_attributes()" do
-
-    it "fails on 'have_attributes' and gives informative error message" do
-      expect {
-        expect { person.age = wrong_age }.to change { person }.to have_attributes({:age => correct_age})
-      }.to fail_including("expected result to have changed to have attributes {:age => 33}, but had attributes {:age => 11}")
-    end
-
-    it "fails the 'change' check and gives informative error message" do
-      expect {
-        expect { person.age = correct_age }.to change { person }.to have_attributes({:age => correct_age})
-      }.to fail_including("expected result to have changed to have attributes {:age => #{correct_age}}, but did not change")
-    end
-
-    it "fails on negation with 'have_attributes' and gives informative error message" do
-      expect {
-        expect { person.age = wrong_age }.not_to change { person }.from have_attributes({:age => correct_age})
-      }.to fail_including("expected result not to have changed, but changed and has attributes {:age => #{wrong_age}}")
-    end
-
-    it "fails on negation with 'not_change' with informative error messages" do
-      expect {
-        expect { person.age = wrong_age }.not_to change { person }.from have_attributes({:age => wrong_age})
-      }.to fail_including("expected result to not change, but changed and has attributes {:age => 11}")
-    end
-
-    it "fails on both change and have_attributes and gives informative error message" do
-      expect {
-        expect { person.age = correct_age }.to change { person }.to have_attributes({:age => wrong_age})
-      }.to fail_including("expected result to have changed to have attributes {:age => 11}, but did not change")
-    end
-
-    it "fails on negation for both change and have_attributes and gives informative error message" do
-      expect {
-        expect { person.age = wrong_age }.not_to change { person }.from have_attributes({:age => correct_age})
-      }.to fail_including("expected result not to have changed, but changed and has attributes {:age => #{wrong_age}}")
-    end
-
-  end
-
   include RSpec::Matchers::Composable
   # a helper for failure message assertion
   def object_inspect(object)


### PR DESCRIPTION
I've been working on a way to clean up the error message when a test fails using both the change and has_attributes matchers. Currently, the test

``` ruby
expect { person.age = 10 }.to change{ person }.to have_attributes({:age => 6})
```

will fail with the message `expected result to have changed to have attributes {:age => 6}, but is now #<struct Person name="Correct name", age=10>`

This can become annoying when an object has a lot of attributes because you have to parse through the output to find the attribute you pass into `have_attributes`

This change modifies the error message to say `expected result to have changed to have attributes {:age => 6}, but had attributes {:age => 10}`

While this is the behavior I was looking for, the implementation could be improved. I was wondering if anyone had any ideas on ways to clean this up, and not rely on a special case.
