### PR TITLE
_Technically_, it's 1.9 _plus_

### DIFF
--- a/features/built_in_matchers/README.md
+++ b/features/built_in_matchers/README.md
@@ -94,7 +94,7 @@ e.g.
     expect([1, 2, 3]).to     contain_exactly(2, 1, 3)
     expect([1, 2, 3]).to     match_array([3, 2, 1])
 
-## Ranges (1.9 only)
+## Ranges (1.9+ only)
 
     expect(1..10).to cover(3)
 


### PR DESCRIPTION
What's our 1.8 deprecation policy again? Drop it in 4?

@rspec/rspec 