### PR TITLE
Reduce scope of rescue in `safe_sort`

### DIFF
--- a/lib/rspec/matchers/built_in/contain_exactly.rb
+++ b/lib/rspec/matchers/built_in/contain_exactly.rb
@@ -61,7 +61,7 @@ module RSpec
 
         def safe_sort(array)
           array.sort
-        rescue Exception
+        rescue
           array
         end
 


### PR DESCRIPTION
Rescue `StandardError` instead of `Exception`. `StandardError` will almost certainly encapsulate every exception we want to rescue (including `NameError`), while `Exception` encapsulates numerous exceptions we probably don't want to rescue (including `Interrupt`).  

I stumbled across this and haven't checked the rest of the codebase for similar `rescue`s. If this is helpful, I can check for other instances of this.
 
Further discussion:
http://stackoverflow.com/questions/10048173/why-is-it-bad-style-to-rescue-exception-e-in-ruby
https://robots.thoughtbot.com/rescue-standarderror-not-exception
http://daniel.fone.net.nz/blog/2013/05/28/why-you-should-never-rescue-exception-in-ruby/ (My own thoughts)