### PR TITLE
MatchWithCaptures

### DIFF
--- a/lib/rspec/matchers/built_in.rb
+++ b/lib/rspec/matchers/built_in.rb
@@ -20,6 +20,8 @@ module RSpec
       autoload :BePredicate,             'rspec/matchers/built_in/be'
       autoload :BeTruthy,                'rspec/matchers/built_in/be'
       autoload :BeWithin,                'rspec/matchers/built_in/be_within'
+      autoload :MatchWithCaptures,       'rspec/matchers/built_in/match_with_captures'
+      autoload :MatchWithNamedCaptures,  'rspec/matchers/built_in/match_with_captures'
       autoload :Change,                  'rspec/matchers/built_in/change'
       autoload :Compound,                'rspec/matchers/built_in/compound'
       autoload :ContainExactly,          'rspec/matchers/built_in/contain_exactly'

--- a/lib/rspec/matchers/built_in/match.rb
+++ b/lib/rspec/matchers/built_in/match.rb
@@ -5,19 +5,10 @@ module RSpec
       # Provides the implementation for `match`.
       # Not intended to be instantiated directly.
       class Match < BaseMatcher
-        def initialize(expected)
-          super(expected)
-
-          @expected_captures = nil
-        end
         # @api private
         # @return [String]
         def description
-          if @expected_captures && @expected.match(actual)
-            "match with string #{@expected} have captures #{surface_descriptions_in(@expected_captures).inspect}"
-          else
-            "match #{surface_descriptions_in(expected).inspect}"
-          end
+          "match #{surface_descriptions_in(expected).inspect}"
         end
 
         # @api private
@@ -29,81 +20,59 @@ module RSpec
         # Used to specify the captures we match against
         # @return [self]
         def with_captures(*captures)
-          @expected_captures = captures
-          self
+          expected_captures = ExpectedCaptures.new(captures.last)
+
+          if expected_captures.named?
+            MatchWithNamedCaptures.new @expected, expected_captures.stringify_keys
+          else
+            MatchWithCaptures.new @expected, captures
+          end
         end
 
       private
 
-        def captures_error
-          ArgumentError.new("`with_captures` must be called with a regular expression, multiple strings, or a hash of named captures")
-        end
-
         def match(expected, actual)
-          return match_captures(expected, actual) if @expected_captures
-          return true if values_match?(expected, actual)
-          return false unless can_safely_call_match?(expected, actual)
-          actual.match(expected)
+          if can_safely_call_match?(expected, actual)
+            actual.match(expected)
+          else
+            values_match?(expected, actual)
+          end
         end
 
         def can_safely_call_match?(expected, actual)
           return false unless actual.respond_to?(:match)
+          return false if Regexp === expected && Regexp === actual
 
           !(RSpec::Matchers.is_a_matcher?(expected) &&
             (String === actual || Regexp === actual))
         end
 
-        def match_captures(expected, actual)
-          match = actual.match(expected)
-          if match
-            match = ReliableMatchData.new(match)
-            if match.names.empty?
-              values_match?(@expected_captures, match.captures)
-            else
-              expected_matcher = @expected_captures.last
-              values_match?(expected_matcher, Hash[match.names.zip(match.captures)]) ||
-                values_match?(expected_matcher, Hash[match.names.map(&:to_sym).zip(match.captures)]) ||
-                values_match?(@expected_captures, match.captures)
-            end
-          else
-            false
+        class ExpectedCaptures
+          def initialize(captures)
+            @captures = captures
+          end
+
+          def named?
+            Hash === @captures || is_a_hash_matcher?
+          end
+
+          def stringify_keys
+            captures_hash.replace captures_hash.reduce({}) {|h, (k, v)| h[k.to_s] = v; h }
+            @captures
+          end
+
+          private
+
+          def is_a_hash_matcher?
+            RSpec::Matchers.is_a_matcher?(@captures) &&
+              @captures.expected.respond_to?(:first) &&
+              Hash === @captures.expected.first
+          end
+
+          def captures_hash
+            is_a_hash_matcher? ? @captures.expected.first : @captures
           end
         end
-      end
-
-      # @api private
-      # Used to wrap match data and make it reliable for 1.8.7
-      class ReliableMatchData
-        def initialize(match_data)
-          @match_data = match_data
-        end
-
-        if RUBY_VERSION == "1.8.7"
-          # @api private
-          # Returns match data names for named captures
-          # @return Array
-          def names
-            []
-          end
-        else
-          # @api private
-          # Returns match data names for named captures
-          # @return Array
-          def names
-            match_data.names
-          end
-        end
-
-        # @api private
-        # returns an array of captures from the match data
-        # @return Array
-        def captures
-          match_data.captures
-        end
-
-      protected
-
-        attr_reader :match_data
       end
     end
   end

--- a/lib/rspec/matchers/built_in/match_with_captures.rb
+++ b/lib/rspec/matchers/built_in/match_with_captures.rb
@@ -1,0 +1,78 @@
+module RSpec
+  module Matchers
+    module BuiltIn
+      # @api private
+      # Extends Match behavior to also match against expected captures
+      class MatchWithCaptures < Match
+        def initialize(expected, captures)
+          super(expected)
+          @expected_captures = captures
+        end
+
+        # @api private
+        # @return [String]
+        def description
+          "#{super} with captures #{surface_descriptions_in(@expected_captures).inspect}"
+        end
+
+      private
+
+        def match(expected, actual)
+          (match = super) && values_match?(@expected_captures, actual_captures(match))
+        end
+
+        def actual_captures(match_data)
+          ReliableMatchData.new(match_data).captures
+        end
+      end
+
+      # @api private
+      # Extends MatchWithCaptures behavior to match against *named* captures
+      class MatchWithNamedCaptures < MatchWithCaptures
+      private
+
+        def actual_captures(match_data)
+          ReliableMatchData.new(match_data).named_captures
+        end
+      end
+
+      # @api private
+      # Used to wrap match data and make it reliable for 1.8.7
+      class ReliableMatchData
+        def initialize(match_data)
+          @match_data = match_data
+        end
+
+        # @api private
+        # returns an array of captures from the match data
+        # @return Array
+        def captures
+          @match_data.captures
+        end
+
+        if RUBY_VERSION == "1.8.7"
+          # @api private
+          # Returns match data names for named captures
+          # @return Array
+          def names
+            []
+          end
+        else
+          # @api private
+          # Returns match data names for named captures
+          # @return Array
+          def names
+            @match_data.names
+          end
+        end
+
+        # @api private
+        # returns a hash of named captures from the match data
+        # @return Hash
+        def named_captures
+          Hash[names.map.zip(captures)]
+        end
+      end
+    end
+  end
+end

--- a/spec/rspec/matchers/built_in/captures_spec.rb
+++ b/spec/rspec/matchers/built_in/captures_spec.rb
@@ -22,8 +22,9 @@ RSpec.describe "expect(regex).to match(string).with_captures" do
       it "matches a regex with named captures" do
         expect("a123a").to match(Regexp.new("(?<num>123)")).with_captures(:num => "123")
       end
+
       it "matches a regex with a nested matcher" do
-        expect("a123a").to match(Regexp.new("(?<num>123)(asdf)?")).with_captures(hash_including(:num => "123"))
+        expect("a123a").to match(Regexp.new("(?<num>123)(asdf)?")).with_captures(a_hash_including(:num => "123"))
       end
 
       it "does not match a regex with an incorrect named group match" do
@@ -33,7 +34,7 @@ RSpec.describe "expect(regex).to match(string).with_captures" do
       it "has a sensible failure description with a hash including matcher" do
         expect {
           expect("a123a").not_to match(Regexp.new("(?<num>123)(asdf)?")).with_captures(a_hash_including(:num => "123"))
-        }.to fail_with(/num => "123"/)
+        }.to fail_with(/"num" => "123"/)
       end
 
       it "matches named captures when not passing a hash" do
@@ -65,8 +66,9 @@ RSpec.describe "expect(regex).to match(string).with_captures" do
       it "matches a regex with named captures" do
         expect(Regexp.new("(?<num>123)")).to match("a123a").with_captures(:num => "123")
       end
+
       it "matches a regex with a nested matcher" do
-        expect(Regexp.new("(?<num>123)(asdf)?")).to match("a123a").with_captures(hash_including(:num => "123"))
+        expect(Regexp.new("(?<num>123)(asdf)?")).to match("a123a").with_captures(a_hash_including(:num => "123"))
       end
 
       it "does not match a regex with an incorrect named group match" do
@@ -76,7 +78,7 @@ RSpec.describe "expect(regex).to match(string).with_captures" do
       it "has a sensible failure description with a hash including matcher" do
         expect {
           expect(Regexp.new("(?<num>123)(asdf)?")).not_to match("a123a").with_captures(a_hash_including(:num => "123"))
-        }.to fail_with(/num => "123"/)
+        }.to fail_with(/"num" => "123"/)
       end
 
       it "matches named captures when not passing a hash" do


### PR DESCRIPTION
My attempt at MatchWithCaptures to close #831

originally based on #848 with a couple added tests

The key differences from #848 are:

The logic for `MatchWithCaptures` is a refinement of behavior that *only takes effect when `with_captures` is invoked*. Otherwise, the default `Match` behavior is used. So rather than duplicating the behavior of `Match`, this PR inherits `Match` to `MatchWithCaptures` and `MatchWithNamedCaptures`. These subclasses are only instantiated when `with_captures` is invoked. (Thus, if `with_captures` is not invoked, the normal `Match` behavior applies without needing to be duplicated or manually invoked.)

- logic for creating a hash of named captures is pushed into the `ReliableMatchData` (it's only a concern of the matchdata object, after all. the alternative feels a bit to ask-don't-tell since we're mucking with the properties of matchdata rather than relying on it to give us a proper hash)