### PR TITLE
reword MatchWithCaptures description

### DIFF
--- a/lib/rspec/matchers/built_in/match.rb
+++ b/lib/rspec/matchers/built_in/match.rb
@@ -14,7 +14,7 @@ module RSpec
         # @return [String]
         def description
           if @expected_captures && @expected.match(actual)
-            "match with string #{@expected} have captures #{surface_descriptions_in(@expected_captures).inspect}"
+            "match #{surface_descriptions_in(expected).inspect} with captures #{surface_descriptions_in(@expected_captures).inspect}"
           else
             "match #{surface_descriptions_in(expected).inspect}"
           end


### PR DESCRIPTION
The description for failed captures should read just like the normal 'match' description, but with the addition of the captures clause.

We shouldn't specify that either expected or actual is a string (since either could be a string).
We shouldn't use rely on to_s but rather inspec, that way the expected is printed in a consistent fashion for both the captures and non-captures cases.