### PR TITLE
Fix SystemStackError raised when diffing a recursive Enumerable object

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,8 @@ Bug Fixes:
   does not respond to the predicate so that it is inspected rather
   than relying upon it's `to_s` -- that way for `nil`, `"nil"` is
   printed rather than an empty string. (Myron Marston, #841)
+* Fix SystemStackError raised when diffing an Enumerable object
+  whose `#each` includes the object itself. (Yuji Nakayama, #857)
 
 ### 3.3.1 / 2015-07-15
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.3.0...v3.3.1)

--- a/spec/rspec/matchers/composable_spec.rb
+++ b/spec/rspec/matchers/composable_spec.rb
@@ -20,6 +20,14 @@ module RSpec
         }.to fail_with(infinite_range.inspect)
       end
 
+      it "does not blow up when surfacing descriptions from an Enumerable object whose #each includes the object itself" do
+        array = ['something']
+        array << array
+        expect {
+          expect(1).to matcher_using_surface_descriptions_in(array)
+        }.to fail_with(array.to_s)
+      end
+
       it "does not enumerate normal ranges" do
         range = 1..3
         expect {


### PR DESCRIPTION
This patch fixes SystemStackError raised when diffing an Enumerable object whose `#each` includes the object itself:

```ruby
array = ['something']
array << array
expect(array).to eq([])
```

```
     Failure/Error:
       expect(array).to eq([])
     SystemStackError:
       stack level too deep
```