### PR TITLE
Always print compound failure messages multi-line.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,7 +12,8 @@ Enhancements:
   [match matcher](https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/match-matcher)
   which allows a user to specify expected captures when matching a regex
   against a string. (Sam Phippen, #848)
-
+* Always print compound failure messages in the multi-line form. Trying
+  to print it all on a single line didn't read very well. (Myron Marston, #859)
 
 Bug Fixes:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,6 @@ install:
   - gem install bundler
   - bundler --version
   - bundle install
-  - cinst ansicon
 
 test_script:
   - bundle exec rspec --backtrace

--- a/lib/rspec/matchers/built_in/compound.rb
+++ b/lib/rspec/matchers/built_in/compound.rb
@@ -24,7 +24,7 @@ module RSpec
         # @api private
         # @return [String]
         def description
-          singleline_message(matcher_1.description, matcher_2.description)
+          "#{matcher_1.description} #{conjunction} #{matcher_2.description}"
         end
 
         def supports_block_expectations?
@@ -84,30 +84,9 @@ module RSpec
         end
 
         def compound_failure_message
-          message_1 = matcher_1.failure_message
-          message_2 = matcher_2.failure_message
-
-          if multiline?(message_1) || multiline?(message_2)
-            multiline_message(message_1, message_2)
-          else
-            singleline_message(message_1, message_2)
-          end
-        end
-
-        def multiline_message(message_1, message_2)
-          [
-            indent_multiline_message(message_1.sub(/\n+\z/, '')),
-            "...#{conjunction}:",
-            indent_multiline_message(message_2.sub(/\A\n+/, ''))
-          ].join("\n\n")
-        end
-
-        def multiline?(message)
-          message.lines.count > 1
-        end
-
-        def singleline_message(message_1, message_2)
-          [message_1, conjunction, message_2].join(' ')
+          "#{indent_multiline_message(matcher_1.failure_message.sub(/\n+\z/, ''))}" \
+          "\n\n...#{conjunction}:" \
+          "\n\n#{indent_multiline_message(matcher_2.failure_message.sub(/\A\n+/, ''))}"
         end
 
         def matcher_1_matches?

--- a/spec/rspec/matchers/built_in/all_spec.rb
+++ b/spec/rspec/matchers/built_in/all_spec.rb
@@ -108,7 +108,11 @@ module RSpec::Matchers::BuiltIn
               |expected [3, 4, 7, 28] to all be between 2 and 5 (inclusive) or be between 6 and 9 (inclusive)
               |
               |   object at index 3 failed to match:
-              |      expected 28 to be between 2 and 5 (inclusive) or expected 28 to be between 6 and 9 (inclusive)
+              |         expected 28 to be between 2 and 5 (inclusive)
+              |
+              |      ...or:
+              |
+              |         expected 28 to be between 6 and 9 (inclusive)
             EOS
           end
         end
@@ -121,10 +125,18 @@ module RSpec::Matchers::BuiltIn
               |expected [3, 4, 27, 22] to all be between 2 and 5 (inclusive) or be between 6 and 9 (inclusive)
               |
               |   object at index 2 failed to match:
-              |      expected 27 to be between 2 and 5 (inclusive) or expected 27 to be between 6 and 9 (inclusive)
+              |         expected 27 to be between 2 and 5 (inclusive)
+              |
+              |      ...or:
+              |
+              |         expected 27 to be between 6 and 9 (inclusive)
               |
               |   object at index 3 failed to match:
-              |      expected 22 to be between 2 and 5 (inclusive) or expected 22 to be between 6 and 9 (inclusive)
+              |         expected 22 to be between 2 and 5 (inclusive)
+              |
+              |      ...or:
+              |
+              |         expected 22 to be between 6 and 9 (inclusive)
             EOS
           end
         end

--- a/spec/rspec/matchers/built_in/compound_spec.rb
+++ b/spec/rspec/matchers/built_in/compound_spec.rb
@@ -340,10 +340,16 @@ module RSpec::Matchers::BuiltIn
         end
 
         context "when both matchers have single-line failure messages" do
-          it 'fails with a single-line failure message' do
+          it 'still fails with a multi-line failure message because it reads better than keeping it on a single line' do
             expect {
               expect("foo").to start_with("a").and end_with("z")
-            }.to fail_with('expected "foo" to start with "a" and expected "foo" to end with "z"')
+            }.to fail_with(dedent <<-EOS)
+              |   expected "foo" to start with "a"
+              |
+              |...and:
+              |
+              |   expected "foo" to end with "z"
+            EOS
           end
         end
 
@@ -511,7 +517,11 @@ module RSpec::Matchers::BuiltIn
 
           it 'fails with a message containing diffs for both matcher' do
             expected_failure = dedent(<<-EOS)
-              |expected "baz\\nbug" to include "bar" and expected "baz\\nbug" to include "foo"
+              |   expected "baz\\nbug" to include "bar"
+              |
+              |...and:
+              |
+              |   expected "baz\\nbug" to include "foo"
               |Diff for (include "bar"):
               |@@ -1,2 +1,3 @@
               |-bar
@@ -530,7 +540,9 @@ module RSpec::Matchers::BuiltIn
                 |baz
                 |bug
               EOS
-            }.to fail_including(expected_failure)
+            }.to fail do |error|
+              expect(error.message).to include(expected_failure)
+            end
           end
         end
 
@@ -618,10 +630,16 @@ module RSpec::Matchers::BuiltIn
         end
 
         context "when both matchers have single-line failure messages" do
-          it 'fails with a single-line failure message' do
+          it 'still fails with a multi-line failure message because it reads better than keeping it on a single line' do
             expect {
               expect("foo").to start_with("a").or end_with("z")
-            }.to fail_with('expected "foo" to start with "a" or expected "foo" to end with "z"')
+            }.to fail_with(dedent <<-EOS)
+              |   expected "foo" to start with "a"
+              |
+              |...or:
+              |
+              |   expected "foo" to end with "z"
+            EOS
           end
         end
 
@@ -738,7 +756,11 @@ module RSpec::Matchers::BuiltIn
 
         it 'fails with a message containing diffs for both matcher' do
           expected_failure = dedent(<<-EOS)
-            |expected "baz\\nbug" to include "foo" or expected "baz\\nbug" to include "buzz"
+            |   expected "baz\\nbug" to include "foo"
+            |
+            |...or:
+            |
+            |   expected "baz\\nbug" to include "buzz"
             |Diff for (include "foo"):
             |@@ -1,2 +1,3 @@
             |-foo
@@ -787,7 +809,15 @@ module RSpec::Matchers::BuiltIn
         matcher = include("bar").and include("buzz").or include("foo")
 
         expected_failure = dedent(<<-EOS)
-          |expected "bug\\nsquash" to include "bar" and expected "bug\\nsquash" to include "buzz" or expected "bug\\nsquash" to include "foo"
+          |   expected "bug\\nsquash" to include "bar"
+          |
+          |...and:
+          |
+          |      expected "bug\\nsquash" to include "buzz"
+          |
+          |   ...or:
+          |
+          |      expected "bug\\nsquash" to include "foo"
           |Diff for (include "bar"):
           |@@ -1,2 +1,3 @@
           |-bar
@@ -812,7 +842,9 @@ module RSpec::Matchers::BuiltIn
             |bug
             |squash
           EOS
-        }.to fail_including(expected_failure)
+        }.to fail do |error|
+          expect(error.message).to include(expected_failure)
+        end
       end
 
       it 'fails with a complete message' do


### PR DESCRIPTION
They are harder to read when put on a single line.

Closes #747.