### PR TITLE
Remove parallel assignment and break up string that was too long. 

### DIFF
--- a/lib/rspec/matchers/built_in/raise_error.rb
+++ b/lib/rspec/matchers/built_in/raise_error.rb
@@ -16,11 +16,14 @@ module RSpec
 
           case expected_error_or_message
           when nil
-            @expected_error, @expected_message = Exception, expected_message
+            @expected_error = Exception
+            @expected_message = expected_message
           when String
-            @expected_error, @expected_message = Exception, expected_error_or_message
+            @expected_error = Exception
+            @expected_message = expected_error_or_message
           else
-            @expected_error, @expected_message = expected_error_or_message, expected_message
+            @expected_error = expected_error_or_message
+            @expected_message = expected_message
           end
         end
 
@@ -208,7 +211,8 @@ module RSpec
         end
 
         def raise_message_already_set
-          raise "`expect { }.to raise_error(message).with_message(message)` is not valid. The matcher only allows the expected message to be specified once"
+          raise "`expect { }.to raise_error(message).with_message(message)` is not valid. " \
+                'The matcher only allows the expected message to be specified once'
         end
       end
       # rubocop:enable RescueException


### PR DESCRIPTION
Made some minor refactors as stated below. 

* Removed parallel assignment in initialize. IMO makes it easier to read as well
* Break up string from one to two lines as length was very long
* Only 2 rubocop issues remain `matches?` and `warn_for_false_positives`