### PR TITLE
Include current error message in raise_error warning

### DIFF
--- a/lib/rspec/matchers/built_in/raise_error.rb
+++ b/lib/rspec/matchers/built_in/raise_error.rb
@@ -46,7 +46,6 @@ module RSpec
           @eval_block = false
           @eval_block_passed = false
 
-          warn_about_bare_error if warning_about_bare_error && !negative_expectation
           return false unless Proc === given_proc
 
           begin
@@ -59,6 +58,7 @@ module RSpec
             end
           end
 
+          warn_about_bare_error if warning_about_bare_error && !negative_expectation
           eval_block if !negative_expectation && ready_to_eval_block?
 
           expectation_matched?
@@ -160,6 +160,7 @@ module RSpec
                         "will match when Ruby raises a `NoMethodError`, `NameError` or " \
                         "`ArgumentError`, potentially allowing the expectation to pass " \
                         "without even executing the method you are intending to call. " \
+                        "Actual error raised was #{description_of(@actual_error)}. "\
                         "Instead consider providing a specific error class or message. " \
                         "This message can be supressed by setting: " \
                         "`RSpec::Expectations.configuration.warn_about_potential_false_positives = false`")

--- a/lib/rspec/matchers/built_in/raise_error.rb
+++ b/lib/rspec/matchers/built_in/raise_error.rb
@@ -160,7 +160,7 @@ module RSpec
                         "will match when Ruby raises a `NoMethodError`, `NameError` or " \
                         "`ArgumentError`, potentially allowing the expectation to pass " \
                         "without even executing the method you are intending to call. " \
-                        "Actual error raised was #{description_of(@actual_error)}. "\
+                        "#{warning}"\
                         "Instead consider providing a specific error class or message. " \
                         "This message can be supressed by setting: " \
                         "`RSpec::Expectations.configuration.warn_about_potential_false_positives = false`")
@@ -214,6 +214,11 @@ module RSpec
         def raise_message_already_set
           raise "`expect { }.to raise_error(message).with_message(message)` is not valid. " \
                 'The matcher only allows the expected message to be specified once'
+        end
+
+        def warning
+          warning = "Actual error raised was #{description_of(@actual_error)}. "
+          warning if @actual_error
         end
       end
       # rubocop:enable RescueException

--- a/spec/rspec/matchers/built_in/raise_error_spec.rb
+++ b/spec/rspec/matchers/built_in/raise_error_spec.rb
@@ -18,6 +18,17 @@ RSpec.describe "expect { ... }.to raise_error" do
     expect { raise StandardError.new, 'boom'}.to raise_error
   end
 
+  it 'issues a warning that does not include current error when its not present' do
+    expect(::Kernel).to receive(:warn) do |message|
+      ex = /Actual error raised was/
+      expect(message).not_to match ex
+    end
+
+    expect {
+      expect{ '' }.to(raise_error)
+    }.to fail_with("expected Exception but nothing was raised")
+  end
+
   it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
     RSpec::Expectations.configuration.warn_about_potential_false_positives = false
     expect_no_warnings

--- a/spec/rspec/matchers/built_in/raise_error_spec.rb
+++ b/spec/rspec/matchers/built_in/raise_error_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe "expect { ... }.to raise_error" do
     expect { raise }.to raise_error
   end
 
+  it 'issues a warning that includes the current error when used without an error class or message' do
+    expect_warning_with_call_site __FILE__, __LINE__+1, /Actual error raised was #<StandardError: boom>/
+    expect { raise StandardError.new, 'boom'}.to raise_error
+  end
+
   it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
     RSpec::Expectations.configuration.warn_about_potential_false_positives = false
     expect_no_warnings


### PR DESCRIPTION
Fix for issue #822

https://github.com/rspec/rspec-expectations/issues/822

When the raise_error() matcher triggers a warning it does not include
the cause of the actual error. This commit changes the warning message
to include the actual error that was raised.

I've moved setting the warning message `RaiseError#warn_about_bare_error`
further down in `RaiseError##matches` because the warning message needs
an instance variable to be set in order to display the current error.