### PR TITLE
Minor refactors to line lengths and rubocop issues

### DIFF
--- a/benchmarks/gsub_vs_tr_single_character.rb
+++ b/benchmarks/gsub_vs_tr_single_character.rb
@@ -1,0 +1,28 @@
+require 'benchmark/ips'
+
+Benchmark.ips do |x|
+  y = '1_2_3_4_5_6_7_8_9_10'
+
+  x.report('gsub') do |_times|
+    y.gsub('_', ' ')
+  end
+
+  x.report('tr') do |_times|
+    y.tr('_', ' ')
+  end
+
+  x.compare!
+end
+
+__END__
+
+Calculating -------------------------------------
+                gsub    29.483k i/100ms
+                  tr    79.170k i/100ms
+-------------------------------------------------
+                gsub     10.420B (±23.7%) i/s -     31.106B
+                  tr     78.139B (±20.6%) i/s -    129.289B
+
+Comparison:
+                  tr: 78139428607.9 i/s
+                gsub: 10419757735.7 i/s - 7.50x slower

--- a/lib/rspec/matchers/built_in/change.rb
+++ b/lib/rspec/matchers/built_in/change.rb
@@ -58,13 +58,15 @@ module RSpec
         # @api private
         # @return [String]
         def failure_message
-          "expected #{@change_details.message} to have changed, but #{positive_failure_reason}"
+          "expected #{@change_details.message} to have changed, " \
+          "but #{positive_failure_reason}"
         end
 
         # @api private
         # @return [String]
         def failure_message_when_negated
-          "expected #{@change_details.message} not to have changed, but #{negative_failure_reason}"
+          "expected #{@change_details.message} not to have changed, " \
+          "but #{negative_failure_reason}"
         end
 
         # @api private
@@ -96,7 +98,8 @@ module RSpec
 
         def negative_failure_reason
           return "was not given a block" unless Proc === @event_proc
-          "did change from #{description_of @change_details.actual_before} to #{description_of @change_details.actual_after}"
+          "did change from #{description_of @change_details.actual_before} " \
+          "to #{description_of @change_details.actual_after}"
         end
       end
 
@@ -112,7 +115,9 @@ module RSpec
 
         # @private
         def failure_message
-          "expected #{@change_details.message} to have changed #{@relativity.to_s.gsub("_", " ")} #{description_of @expected_delta}, but #{failure_reason}"
+          "expected #{@change_details.message} to have changed " \
+          "#{@relativity.to_s.tr('_', ' ')} " \
+          "#{description_of @expected_delta}, but #{failure_reason}"
         end
 
         # @private
@@ -125,12 +130,14 @@ module RSpec
 
         # @private
         def does_not_match?(_event_proc)
-          raise NotImplementedError, "`expect { }.not_to change { }.#{@relativity}()` is not supported"
+          raise NotImplementedError, "`expect { }.not_to change " \
+            "{ }.#{@relativity}()` is not supported"
         end
 
         # @private
         def description
-          "change #{@change_details.message} #{@relativity.to_s.gsub("_", " ")} #{description_of @expected_delta}"
+          "change #{@change_details.message} " \
+          "#{@relativity.to_s.tr('_', ' ')} #{description_of @expected_delta}"
         end
 
         # @private
@@ -195,23 +202,31 @@ module RSpec
         end
 
         def before_value_failure
-          "expected #{@change_details.message} to have initially been #{description_of @expected_before}, but was #{description_of @change_details.actual_before}"
+          "expected #{@change_details.message} " \
+          "to have initially been #{description_of @expected_before}, " \
+          "but was #{description_of @change_details.actual_before}"
         end
 
         def after_value_failure
-          "expected #{@change_details.message} to have changed to #{description_of @expected_after}, but is now #{description_of @change_details.actual_after}"
+          "expected #{@change_details.message} " \
+          "to have changed to #{description_of @expected_after}, " \
+          "but is now #{description_of @change_details.actual_after}"
         end
 
         def did_not_change_failure
-          "expected #{@change_details.message} to have changed #{change_description}, but did not change"
+          "expected #{@change_details.message} " \
+          "to have changed #{change_description}, but did not change"
         end
 
         def did_change_failure
-          "expected #{@change_details.message} not to have changed, but did change from #{description_of @change_details.actual_before} to #{description_of @change_details.actual_after}"
+          "expected #{@change_details.message} not to have changed, but " \
+          "did change from #{description_of @change_details.actual_before} " \
+          "to #{description_of @change_details.actual_after}"
         end
 
         def not_given_a_block_failure
-          "expected #{@change_details.message} to have changed #{change_description}, but was not given a block"
+          "expected #{@change_details.message} to have changed " \
+          "#{change_description}, but was not given a block"
         end
       end
 
@@ -235,7 +250,8 @@ module RSpec
         # @private
         def does_not_match?(event_proc)
           if @description_suffix
-            raise NotImplementedError, "`expect { }.not_to change { }.to()` is not supported"
+            raise NotImplementedError, "`expect { }.not_to change { }.to()` " \
+              "is not supported"
           end
 
           @event_proc = event_proc
@@ -277,7 +293,8 @@ module RSpec
 
         # @private
         def does_not_match?(_event_proc)
-          raise NotImplementedError, "`expect { }.not_to change { }.to()` is not supported"
+          raise NotImplementedError, "`expect { }.not_to change { }.to()` " \
+            "is not supported"
         end
 
       private


### PR DESCRIPTION
* Shortened strings spanning more than 80 characters
* Replaced double quotes to single quotes inside string interpolation per rubocop
* Replaced `gsub` with `tr` in string interpolation for the performance gain of 1-1 replacements