### PR TITLE
Fix rubocop issues in built_in matcher be.rb

### DIFF
--- a/lib/rspec/matchers/built_in/be.rb
+++ b/lib/rspec/matchers/built_in/be.rb
@@ -137,7 +137,8 @@ module RSpec
         include BeHelpers
 
         def initialize(operand, operator)
-          @expected, @operator = operand, operator
+          @expected = operand
+          @operator = operator
           @args = []
         end
 
@@ -151,13 +152,15 @@ module RSpec
         # @api private
         # @return [String]
         def failure_message
-          "expected: #{@operator} #{expected_formatted}\n     got: #{@operator.to_s.gsub(/./, ' ')} #{actual_formatted}"
+          "expected: #{@operator} #{expected_formatted}\n" \
+          "     got: #{@operator.to_s.gsub(/./, ' ')} #{actual_formatted}"
         end
 
         # @api private
         # @return [String]
         def failure_message_when_negated
-          message = "`expect(#{actual_formatted}).not_to be #{@operator} #{expected_formatted}`"
+          message = "`expect(#{actual_formatted}).not_to " \
+                    "be #{@operator} #{expected_formatted}`"
           if [:<, :>, :<=, :>=].include?(@operator)
             message + " not only FAILED, it is a bit confusing."
           else


### PR DESCRIPTION
Minor refactoring to fix rubocop issues:
- Removed parallel assignment
- Changes double quotes to single quotes where interpolation is not needed
- Shortened some longer lines