### PR TITLE
Stop block matchers from swallowing nested expectations

### DIFF
--- a/features/custom_matchers/define_block_matcher.feature
+++ b/features/custom_matchers/define_block_matcher.feature
@@ -42,3 +42,37 @@ Feature: define a matcher supporting block expectations
       """
     When I run `rspec ./block_matcher_spec.rb`
     Then the example should pass
+
+  Scenario: define a block matcher using shortcut
+    Given a file named "block_matcher_spec.rb" with:
+      """ruby
+      RSpec::Matchers.define :support_blocks_with_errors do
+        match(:notify_expectation_failures => true) do |actual|
+          actual.call
+          true
+        end
+
+        supports_block_expectations
+      end
+
+      RSpec.describe "a custom block matcher" do
+        specify do
+          expect {
+            expect(true).to eq false
+          }.to support_blocks_with_errors
+        end
+      end
+      """
+    When I run `rspec ./block_matcher_spec.rb`
+    Then it should fail with:
+      """
+      Failures:
+
+        1) a custom block matcher should support blocks with errors
+           Failure/Error: expect(true).to eq false
+
+             expected: false
+                  got: true
+
+             (compared using ==)
+      """

--- a/spec/rspec/matchers/dsl_spec.rb
+++ b/spec/rspec/matchers/dsl_spec.rb
@@ -870,6 +870,20 @@ module RSpec::Matchers::DSL
         expect(3).to matcher
         expect { 3 }.to matcher
       end
+
+      it 'will not swallow expectation errors from blocks when told to' do
+        matcher = new_matcher(:foo) do
+          match(:notify_expectation_failures => true) do |actual|
+            actual.call
+            true
+          end
+          supports_block_expectations
+        end
+
+        expect {
+          expect { raise RSpec::Expectations::ExpectationNotMetError.new('original') }.to matcher
+        }.to raise_error(RSpec::Expectations::ExpectationNotMetError, /original/)
+      end
     end
 
     context "#new" do


### PR DESCRIPTION
This is an attempt at a solution for #890 , by wrapping actual "value" blocks in another closure, we should be able to captures any expectation errors internally before re-raising them, which in turn should allow us to maintain existing block behaviour but also raise nested expectations correctly from the matcher.

Thoughts? @myronmarston 