### PR TITLE
Fix deprecation check for `should` with BasicObject.

### DIFF
--- a/lib/rspec/expectations/syntax.rb
+++ b/lib/rspec/expectations/syntax.rb
@@ -41,12 +41,12 @@ module RSpec
 
         syntax_host.module_exec do
           def should(matcher=nil, message=nil, &block)
-            ::RSpec::Expectations::Syntax.warn_about_should_unless_configured(__method__)
+            ::RSpec::Expectations::Syntax.warn_about_should_unless_configured(::Kernel.__method__)
             ::RSpec::Expectations::PositiveExpectationHandler.handle_matcher(self, matcher, message, &block)
           end
 
           def should_not(matcher=nil, message=nil, &block)
-            ::RSpec::Expectations::Syntax.warn_about_should_unless_configured(__method__)
+            ::RSpec::Expectations::Syntax.warn_about_should_unless_configured(::Kernel.__method__)
             ::RSpec::Expectations::NegativeExpectationHandler.handle_matcher(self, matcher, message, &block)
           end
         end

--- a/spec/rspec/expectations/extensions/kernel_spec.rb
+++ b/spec/rspec/expectations/extensions/kernel_spec.rb
@@ -43,6 +43,16 @@ RSpec.describe Object, "#should" do
     it 'works properly on BasicObject-subclassed proxy objects' do
       expect(proxy_class.new(Object.new)).to be_proxied
     end
+
+    it 'does not break the deprecation check on BasicObject-subclassed proxy objects' do
+      begin
+        should_enabled = RSpec::Expectations::Syntax.should_enabled?
+        RSpec::Expectations::Syntax.enable_should unless should_enabled
+        proxy_class.new(BasicObject.new).should be_proxied
+      ensure
+        RSpec::Expectations::Syntax.disable_should if should_enabled
+      end
+    end
   end
 end
 


### PR DESCRIPTION
The deprecation check uses `__method__` which is a Kernel method
that is not available on BasicObject. We can call it directly on
Kernel instead so that we avoid any `method_missing` chains that
may attempt to dispatch it to BasicObject.