### PR TITLE
Allow raising on false positives

### DIFF
--- a/lib/rspec/expectations/configuration.rb
+++ b/lib/rspec/expectations/configuration.rb
@@ -22,6 +22,7 @@ module RSpec
       FALSE_POSITIVE_BEHAVIOURS =
         {
           :warn    => lambda { |message| RSpec.warning message },
+          :raise   => lambda { |message| raise ArgumentError, message },
           :nothing => lambda { |_| true },
         }
 
@@ -162,7 +163,7 @@ module RSpec
       # Configures what RSpec will do about matcher use which will
       # potentially cause false positives in tests.
       #
-      # @param [Symbol] behavior can be set to :warn or :nothing
+      # @param [Symbol] behavior can be set to :warn, :raise or :nothing
       def on_potential_false_positives=(behavior)
         unless FALSE_POSITIVE_BEHAVIOURS.key?(behavior)
           raise ArgumentError, "Supported values are: #{FALSE_POSITIVE_BEHAVIOURS.keys}"

--- a/lib/rspec/expectations/configuration.rb
+++ b/lib/rspec/expectations/configuration.rb
@@ -151,19 +151,35 @@ module RSpec
       # @param [Boolean] boolean
       def warn_about_potential_false_positives=(boolean)
         if boolean
-          @on_potential_false_positives = :warn
+          self.on_potential_false_positives = :warn
         elsif warn_about_potential_false_positives?
-          @on_potential_false_positives = :nothing
+          self.on_potential_false_positives = :nothing
         else
           # no-op, handler is something else
         end
       end
+      #
+      # Configures what RSpec will do about matcher use which will
+      # potentially cause false positives in tests.
+      #
+      # @param [Symbol] behavior can be set to :warn or :nothing
+      def on_potential_false_positives=(behavior)
+        unless FALSE_POSITIVE_BEHAVIOURS.key?(behavior)
+          raise ArgumentError, "Supported values are: #{FALSE_POSITIVE_BEHAVIOURS.keys}"
+        end
+        @on_potential_false_positives = behavior
+      end
+
+      # Indicates what RSpec will do about matcher use which will
+      # potentially cause false positives in tests, generally you want to
+      # avoid such scenarios so this defaults to `true`.
+      attr_reader :on_potential_false_positives
 
       # Indicates whether RSpec will warn about matcher use which will
       # potentially cause false positives in tests, generally you want to
       # avoid such scenarios so this defaults to `true`.
       def warn_about_potential_false_positives?
-        @on_potential_false_positives == :warn
+        on_potential_false_positives == :warn
       end
 
       # @private

--- a/lib/rspec/expectations/configuration.rb
+++ b/lib/rspec/expectations/configuration.rb
@@ -18,8 +18,15 @@ module RSpec
     #
     #   RSpec::Expectations.configuration
     class Configuration
+      # @private
+      FALSE_POSITIVE_BEHAVIOURS =
+        {
+          :warn    => lambda { |message| RSpec.warning message },
+          :nothing => lambda { |_| true },
+        }
+
       def initialize
-        @warn_about_potential_false_positives = true
+        @on_potential_false_positives = :warn
       end
 
       # Configures the supported syntax.
@@ -141,14 +148,27 @@ module RSpec
       # Configures whether RSpec will warn about matcher use which will
       # potentially cause false positives in tests.
       #
-      # @param value [Boolean]
-      attr_writer :warn_about_potential_false_positives
+      # @param [Boolean] boolean
+      def warn_about_potential_false_positives=(boolean)
+        if boolean
+          @on_potential_false_positives = :warn
+        elsif warn_about_potential_false_positives?
+          @on_potential_false_positives = :nothing
+        else
+          # no-op, handler is something else
+        end
+      end
 
       # Indicates whether RSpec will warn about matcher use which will
       # potentially cause false positives in tests, generally you want to
       # avoid such scenarios so this defaults to `true`.
       def warn_about_potential_false_positives?
-        @warn_about_potential_false_positives
+        @on_potential_false_positives == :warn
+      end
+
+      # @private
+      def false_positives_handler
+        FALSE_POSITIVE_BEHAVIOURS.fetch(@on_potential_false_positives)
       end
     end
 

--- a/lib/rspec/matchers/built_in/raise_error.rb
+++ b/lib/rspec/matchers/built_in/raise_error.rb
@@ -162,8 +162,8 @@ module RSpec
                          "#{warning}"\
                          "Instead consider providing a specific error class or message. " \
                          "This message can be suppressed by setting: " \
-                         "`RSpec::Expectations.configuration.warn_about_potential_false" \
-                         "_positives = false`")
+                         "`RSpec::Expectations.configuration.on_potential_false" \
+                         "_positives = :nothing`")
         end
 
         def warn_about_negative_false_positive(expression)
@@ -174,8 +174,8 @@ module RSpec
                          "may not even get reached. Instead consider using " \
                          "`expect {}.not_to raise_error` or `expect { }.to raise_error" \
                          "(DifferentSpecificErrorClass)`. This message can be suppressed by " \
-                         "setting: `RSpec::Expectations.configuration.warn_about_potential_false" \
-                         "_positives = false`")
+                         "setting: `RSpec::Expectations.configuration.on_potential_false" \
+                         "_positives = :nothing`")
         end
 
         def expected_error

--- a/spec/rspec/expectations/configuration_spec.rb
+++ b/spec/rspec/expectations/configuration_spec.rb
@@ -119,6 +119,11 @@ module RSpec
           config.on_potential_false_positives = :warn
           expect(config.on_potential_false_positives).to eq :warn
         end
+
+        it 'can be set to :raise' do
+          config.on_potential_false_positives = :raise
+          expect(config.on_potential_false_positives).to eq :raise
+        end
       end
 
       shared_examples "configuring the expectation syntax" do

--- a/spec/rspec/expectations/configuration_spec.rb
+++ b/spec/rspec/expectations/configuration_spec.rb
@@ -104,6 +104,23 @@ module RSpec
         end
       end
 
+      describe '#on_potential_false_positives' do
+        it 'is set to :warn by default' do
+          expect(config.on_potential_false_positives).to eq :warn
+        end
+
+        it 'can be set to :nothing' do
+          config.on_potential_false_positives = :nothing
+          expect(config.on_potential_false_positives).to eq :nothing
+        end
+
+        it 'can be set back to :warn' do
+          config.on_potential_false_positives = :nothing
+          config.on_potential_false_positives = :warn
+          expect(config.on_potential_false_positives).to eq :warn
+        end
+      end
+
       shared_examples "configuring the expectation syntax" do
         before do
           @orig_syntax = RSpec::Matchers.configuration.syntax

--- a/spec/rspec/matchers/built_in/raise_error_spec.rb
+++ b/spec/rspec/matchers/built_in/raise_error_spec.rb
@@ -29,6 +29,16 @@ RSpec.describe "expect { ... }.to raise_error" do
     }.to fail_with("expected Exception but nothing was raised")
   end
 
+  it "raises an exception when configured to do so" do
+    begin
+      RSpec::Expectations.configuration.on_potential_false_positives = :raise
+      expect_no_warnings
+      expect { expect { '' }.to raise_error }.to raise_error ArgumentError
+    ensure
+      RSpec::Expectations.configuration.on_potential_false_positives = :warn
+    end
+  end
+
   it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
     RSpec::Expectations.configuration.warn_about_potential_false_positives = false
     expect_no_warnings

--- a/spec/rspec/matchers/built_in/raise_error_spec.rb
+++ b/spec/rspec/matchers/built_in/raise_error_spec.rb
@@ -35,6 +35,12 @@ RSpec.describe "expect { ... }.to raise_error" do
     expect { raise }.to raise_error
   end
 
+  it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
+    RSpec::Expectations.configuration.on_potential_false_positives = :nothing
+    expect_no_warnings
+    expect { raise }.to raise_error
+  end
+
   it 'does not issue a warning when an exception class is specified (even if it is just `Exception`)' do
     expect_no_warnings
     expect { raise "error" }.to raise_error Exception


### PR DESCRIPTION
Change our `warn_about_false_positives` behaviour to also allow raising on false positives, for those that like an even stricter behaviour. (we allow this with deprecations so why not!)

Closes #888 