### PR TITLE
Fix include matcher so that it provides a valid diff for hashes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@ Enhancements:
 Bug Fixes:
 
 * Allow `should` deprecation check to work on `BasicObject`s. (James Coleman, #898)
+* Fix `include` matcher so that it provides a valid diff for hashes. (Yuji Nakayama, #916)
 
 ### 3.5.0.beta1 / 2016-02-06
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.4.0...v3.5.0.beta1)

--- a/lib/rspec/matchers/built_in/include.rb
+++ b/lib/rspec/matchers/built_in/include.rb
@@ -5,8 +5,11 @@ module RSpec
       # Provides the implementation for `include`.
       # Not intended to be instantiated directly.
       class Include < BaseMatcher
-        def initialize(*expected)
-          @expected = expected
+        # @private
+        attr_reader :expecteds
+
+        def initialize(*expecteds)
+          @expecteds = expecteds
         end
 
         # @api private
@@ -24,7 +27,7 @@ module RSpec
         # @api private
         # @return [String]
         def description
-          improve_hash_formatting("include#{readable_list_of(expected)}")
+          improve_hash_formatting("include#{readable_list_of(expecteds)}")
         end
 
         # @api private
@@ -43,6 +46,16 @@ module RSpec
         # @return [Boolean]
         def diffable?
           !diff_would_wrongly_highlight_matched_item?
+        end
+
+        # @api private
+        # @return [Array, Hash]
+        def expected
+          if expecteds.all? { |item| item.is_a?(Hash) }
+            expecteds.inject(:merge)
+          else
+            expecteds
+          end
         end
 
       private
@@ -73,7 +86,7 @@ module RSpec
         def excluded_from_actual
           return [] unless @actual.respond_to?(:include?)
 
-          expected.inject([]) do |memo, expected_item|
+          expecteds.inject([]) do |memo, expected_item|
             if comparing_hash_to_a_subset?(expected_item)
               expected_item.each do |(key, value)|
                 memo << { key => value } unless yield actual_hash_includes?(key, value)

--- a/spec/rspec/matchers/built_in/include_spec.rb
+++ b/spec/rspec/matchers/built_in/include_spec.rb
@@ -108,6 +108,20 @@ RSpec.describe "#include matcher" do
         expect(hash).to include(hash)
       end
 
+      it 'provides a valid diff' do
+        allow(RSpec::Matchers.configuration).to receive(:color?).and_return(false)
+
+        expect {
+          expect(:foo => 1, :bar => 2).to include(:foo => 1, :bar => 3)
+        }.to fail_including(dedent(<<-END))
+          |Diff:
+          |@@ -1,3 +1,3 @@
+          |-:bar => 3,
+          |+:bar => 2,
+          | :foo => 1,
+        END
+      end
+
       context 'that overrides #send' do
         it 'still works' do
           array = [1, 2]


### PR DESCRIPTION
This fixes #887.