### PR TITLE
Fix diffing regression introduced by #916.

### DIFF
--- a/lib/rspec/matchers/built_in/include.rb
+++ b/lib/rspec/matchers/built_in/include.rb
@@ -51,8 +51,8 @@ module RSpec
         # @api private
         # @return [Array, Hash]
         def expected
-          if expecteds.all? { |item| item.is_a?(Hash) }
-            expecteds.inject(:merge)
+          if expecteds.one? && Hash === expecteds.first
+            expecteds.first
           else
             expecteds
           end

--- a/spec/rspec/matchers/built_in/include_spec.rb
+++ b/spec/rspec/matchers/built_in/include_spec.rb
@@ -184,6 +184,27 @@ RSpec.describe "#include matcher" do
           expect([1,2,3]).to include(5,1,6,2,4)
         }.to fail_matching("expected [1, 2, 3] to include 5, 6, and 4")
       end
+
+      it 'correctly diffs lists of hashes' do
+        allow(RSpec::Matchers.configuration).to receive(:color?).and_return(false)
+
+        expect {
+          expect([
+            { :number => 1 },
+            { :number => 2 },
+            { :number => 3 }
+          ]).to include(
+            { :number => 1 },
+            { :number => 0 },
+            { :number => 3 }
+          )
+        }.to fail_including(dedent(<<-END))
+          |Diff:
+          |@@ -1,2 +1,2 @@
+          |-[{:number=>1}, {:number=>0}, {:number=>3}]
+          |+[{:number=>1}, {:number=>2}, {:number=>3}]
+        END
+      end
     end
 
     context "for a hash target" do


### PR DESCRIPTION
We only want to return a single hash from `expected`
if only one hash was provided.  If multiple hashes
were provided we do not want to merge them for the
purposes of diffing.

Also, we tend to favor `klass === object` checks
over `object.is_a?(klass)` since `object` could
be any user object that defines `is_a?` however
(or does not define it at all), whereas monkey
patching `===` on a core type like `Hash` would
be far less common and we simply don't support that.

@JonRowe / @yujinakayama -- can you review this since you were involved in #916?