### PR TITLE
Reduce allocations

### DIFF
--- a/lib/rspec/expectations/fail_with.rb
+++ b/lib/rspec/expectations/fail_with.rb
@@ -4,7 +4,7 @@ module RSpec
       # @private
       def differ
         RSpec::Support::Differ.new(
-          :object_preparer => self,
+          :object_preparer => DifferObjectPreparer,
           :color => RSpec::Matchers.configuration.color?
         )
       end
@@ -27,7 +27,10 @@ module RSpec
         RSpec::Support.notify_failure(RSpec::Expectations::ExpectationNotMetError.new message)
       end
 
-      def call(object)
+    end
+
+    module DifferObjectPreparer
+      def self.call(object)
         RSpec::Matchers::Composable.surface_descriptions_in(object)
       end
     end

--- a/lib/rspec/expectations/fail_with.rb
+++ b/lib/rspec/expectations/fail_with.rb
@@ -4,7 +4,7 @@ module RSpec
       # @private
       def differ
         RSpec::Support::Differ.new(
-          :object_preparer => lambda { |object| RSpec::Matchers::Composable.surface_descriptions_in(object) },
+          :object_preparer => self,
           :color => RSpec::Matchers.configuration.color?
         )
       end
@@ -25,6 +25,10 @@ module RSpec
         message = ::RSpec::Matchers::ExpectedsForMultipleDiffs.from(expected).message_with_diff(message, differ, actual)
 
         RSpec::Support.notify_failure(RSpec::Expectations::ExpectationNotMetError.new message)
+      end
+
+      def call(object)
+        RSpec::Matchers::Composable.surface_descriptions_in(object)
       end
     end
   end

--- a/lib/rspec/matchers/english_phrasing.rb
+++ b/lib/rspec/matchers/english_phrasing.rb
@@ -7,7 +7,7 @@ module RSpec
       #     split_words(:banana_creme_pie) #=> "banana creme pie"
       #
       def self.split_words(sym)
-        sym.to_s.gsub(/_/, ' ')
+        sym.to_s.tr('_', ' ')
       end
 
       # @note The returned string has a leading space except

--- a/lib/rspec/matchers/expecteds_for_multiple_diffs.rb
+++ b/lib/rspec/matchers/expecteds_for_multiple_diffs.rb
@@ -64,8 +64,8 @@ module RSpec
       def diffs(differ, actual)
         @expected_list.inject("") do |output, (expected, diff_label)|
           diff = differ.diff(actual, expected)
-          output << diff_label << diff << "\n".freeze unless /\A[[:space:]]*\z/ === diff
-          output
+          next output if /\A[[:space:]]*\z/ === diff
+          output << diff_label << diff << "\n".freeze
         end.tap(&:rstrip!)
       end
     end

--- a/lib/rspec/matchers/expecteds_for_multiple_diffs.rb
+++ b/lib/rspec/matchers/expecteds_for_multiple_diffs.rb
@@ -62,11 +62,11 @@ module RSpec
       end
 
       def diffs(differ, actual)
-        @expected_list.map do |(expected, diff_label)|
+        @expected_list.inject("") do |output, (expected, diff_label)|
           diff = differ.diff(actual, expected)
-          next if diff.strip.empty?
-          "#{diff_label}#{diff}"
-        end.compact.join("\n")
+          output << diff_label << diff << "\n".freeze unless /\A[[:space:]]*\z/ === diff
+          output
+        end.tap(&:rstrip!)
       end
     end
   end

--- a/spec/rspec/expectations/fail_with_spec.rb
+++ b/spec/rspec/expectations/fail_with_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe RSpec::Expectations, "#fail_with with matchers" do
       |@@ -1,2 +1,2 @@
       |-["poo", "car"]
       |+[(a string matching /foo/), (a string matching /bar/)]
-      |
     EOS
 
     expect {

--- a/spec/rspec/matchers/dsl_spec.rb
+++ b/spec/rspec/matchers/dsl_spec.rb
@@ -439,7 +439,7 @@ module RSpec::Matchers::DSL
         diff = e.message.sub(/\A.*Diff:/m, "Diff:").gsub(/^\s*/,'')
       end
 
-      expect(diff).to eq "Diff:\n@@ -1,3 +1,3 @@\n-line1\n+LINE1\nline2\n"
+      expect(diff).to eq "Diff:\n@@ -1,3 +1,3 @@\n-line1\n+LINE1\nline2"
     end
 
     it 'does not confuse the diffability of different matchers' do


### PR DESCRIPTION
I and @k3rni have profiled rspec-expectations' test suite for memory allocations using `allocation_stats`. The results are at http://danieljanus.pl/rspec-allocations.txt. Most are non-trivial to change, but we did find some (not much) low-hanging fruit. This is a PR for #766.

Specific changes are documented in individual commit messages.