### PR TITLE
Raise an error when a block is passed to the BeWithin matcher

### DIFF
--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -410,6 +410,7 @@ module RSpec
     #   expect(result).to     be_within(0.5).of(3.0)
     #   expect(result).not_to be_within(0.5).of(3.0)
     def be_within(delta)
+      raise ArgumentError, "The RSpec BeWithin matcher does not take a block" if block_given?
       BuiltIn::BeWithin.new(delta)
     end
     alias_matcher :a_value_within, :be_within

--- a/spec/rspec/matchers/built_in/be_within_spec.rb
+++ b/spec/rspec/matchers/built_in/be_within_spec.rb
@@ -66,6 +66,12 @@ module RSpec
           expect(nil).to be_within(0.1).of(0)
         }.to fail_with("expected nil to be within 0.1 of 0, but it could not be treated as a numeric value")
       end
+
+      it "raises an error if a block is passed" do
+        expect {
+          within("test") { }
+        }.to raise_error(ArgumentError, /does not take a block/)
+      end
     end
 
     RSpec.describe "expect(actual).to be_within(delta).percent_of(expected)" do


### PR DESCRIPTION
The BeWithin matcher is aliased as `within`, which collides with Capybaras `within` scoping method when used together.  This wouldn't really be an issue if errors occurred, however since Capybaras `within` scopes a passed block and the BeWithin matcher just ignores the passed block it can lead to tests silently passing when they haven't actually done anything.  This PR makes the BeWithin matcher raise an ArgumentError when passed a block so the collision becomes known to users.