### PR TITLE
Remove rubocop on 1.9.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ end
 
 if RUBY_VERSION >= '1.9' && RUBY_VERSION <= '2.1'
   gem 'rubocop', "~> 0.23.0"
+  # The latest version (2.2.1) breaks on ruby 1.9.2
+  gem 'rainbow', "~> 2.1.0" if RUBY_VERSION == "1.9.2"
 end
 
 eval File.read('Gemfile-custom') if File.exist?('Gemfile-custom')

--- a/Gemfile
+++ b/Gemfile
@@ -34,10 +34,9 @@ platforms :rbx do
   gem 'rubysl'
 end
 
-if RUBY_VERSION >= '1.9' && RUBY_VERSION <= '2.1'
+if RUBY_VERSION >= '2' && RUBY_VERSION <= '2.1'
+  # todo upgrade rubocop and run on a recent version e.g. 2.3 or 2.4
   gem 'rubocop', "~> 0.23.0"
-  # The latest version (2.2.1) breaks on ruby 1.9.2
-  gem 'rainbow', "~> 2.1.0" if RUBY_VERSION == "1.9.2"
 end
 
 eval File.read('Gemfile-custom') if File.exist?('Gemfile-custom')


### PR DESCRIPTION
2.2.1 is broken on 1.9.2, its a dependency of Rubocop.