### PR TITLE
yield_with_args: match immediately

### DIFF
--- a/lib/rspec/matchers/built_in/yield.rb
+++ b/lib/rspec/matchers/built_in/yield.rb
@@ -276,14 +276,15 @@ module RSpec
 
         # @private
         def matches?(block)
-          args_matched_when_yielded = true
+          @args_matched_when_yielded = true
           @probe = YieldProbe.new(block) do
             @actual = @probe.single_yield_args
-            args_matched_when_yielded &&= args_currently_match?
+            @actual_formatted = actual_formatted
+            @args_matched_when_yielded &&= args_currently_match?
           end
           return false unless @probe.has_block?
           @probe.probe
-          @probe.yielded_once?(:yield_with_args) && args_matched_when_yielded
+          @probe.yielded_once?(:yield_with_args) && @args_matched_when_yielded
         end
 
         # @private
@@ -328,10 +329,10 @@ module RSpec
         def negative_failure_reason
           if !@probe.has_block?
             'was not a block'
-          elsif all_args_match?
+          elsif @args_matched_when_yielded && !@expected.empty?
             'yielded with expected arguments' \
               "\nexpected not: #{surface_descriptions_in(@expected).inspect}" \
-              "\n         got: #{actual_formatted}"
+              "\n         got: #{@actual_formatted}"
           else
             'did'
           end
@@ -346,7 +347,7 @@ module RSpec
           unless (match = all_args_match?)
             @positive_args_failure = 'yielded with unexpected arguments' \
               "\nexpected: #{surface_descriptions_in(@expected).inspect}" \
-              "\n     got: #{actual_formatted}"
+              "\n     got: #{@actual_formatted}"
           end
 
           match

--- a/lib/rspec/matchers/built_in/yield.rb
+++ b/lib/rspec/matchers/built_in/yield.rb
@@ -417,7 +417,7 @@ module RSpec
         end
 
         def called_expected_number_of_times?
-          @total_calls == @expected.count
+          @total_calls == @expected.size
         end
 
         def args_matched_when_yielded?

--- a/lib/rspec/matchers/built_in/yield.rb
+++ b/lib/rspec/matchers/built_in/yield.rb
@@ -21,7 +21,7 @@ module RSpec
 
         def initialize(block, &callback)
           @block = block
-          @callback = callback || proc {}
+          @callback = callback || Proc.new {}
           @used = false
           self.num_yields = 0
           self.yielded_args = []

--- a/lib/rspec/matchers/built_in/yield.rb
+++ b/lib/rspec/matchers/built_in/yield.rb
@@ -21,7 +21,7 @@ module RSpec
 
         def initialize(block, &callback)
           @block = block
-          @callback = callback
+          @callback = callback || proc {}
           @used = false
           self.num_yields = 0
           self.yielded_args = []

--- a/lib/rspec/matchers/built_in/yield.rb
+++ b/lib/rspec/matchers/built_in/yield.rb
@@ -35,10 +35,11 @@ module RSpec
           @used = true
 
           probe = self
+          callback = @callback
           Proc.new do |*args|
             probe.num_yields += 1
             probe.yielded_args << args
-            @callback.call(*args)
+            callback.call(*args)
             nil # to indicate the block does not return a meaningful value
           end
         end

--- a/lib/rspec/matchers/built_in/yield.rb
+++ b/lib/rspec/matchers/built_in/yield.rb
@@ -368,10 +368,12 @@ module RSpec
 
         # @private
         def matches?(block)
+          @actual_formatted = []
           args_matched_when_yielded = true
           yield_count = 0
 
           @probe = YieldProbe.probe(block) do |args|
+            @actual_formatted << RSpec::Support::ObjectFormatter.format(args)
             args_matched_when_yielded &&= values_match?(@expected[yield_count], args)
             yield_count += 1
           end
@@ -418,7 +420,7 @@ module RSpec
 
           'yielded with unexpected arguments' \
           "\nexpected: #{surface_descriptions_in(@expected).inspect}" \
-          "\n     got: #{actual_formatted}"
+          "\n     got: [#{@actual_formatted.join(", ")}]"
         end
 
         def negative_failure_reason
@@ -426,7 +428,7 @@ module RSpec
 
           'yielded with expected arguments' \
           "\nexpected not: #{surface_descriptions_in(@expected).inspect}" \
-          "\n         got: #{actual_formatted}"
+          "\n         got: [#{@actual_formatted.join(", ")}]"
         end
       end
     end

--- a/lib/rspec/matchers/built_in/yield.rb
+++ b/lib/rspec/matchers/built_in/yield.rb
@@ -408,12 +408,6 @@ module RSpec
 
       private
 
-        def next_expected
-          value = @expected[@total_calls]
-          @total_calls += 1
-          value
-        end
-
         def expected_arg_description
           @expected.map { |e| description_of e }.join(', ')
         end

--- a/lib/rspec/matchers/built_in/yield.rb
+++ b/lib/rspec/matchers/built_in/yield.rb
@@ -277,7 +277,7 @@ module RSpec
             check_args_match
           end
           return false unless @probe.has_block?
-          @probe.yielded_once?(:yield_with_args) && args_matched?
+          @probe.yielded_once?(:yield_with_args) && args_matched_when_yielded?
         end
 
         # @private
@@ -331,15 +331,15 @@ module RSpec
           end
         end
 
-        def args_matched?
-          @args_matched
+        def args_matched_when_yielded?
+          @args_matched_when_yielded
         end
 
         def check_args_match
-          @args_matched = args_match?
+          @args_matched_when_yielded = args_currently_match?
         end
 
-        def args_match?
+        def args_currently_match?
           if @expected.empty? # expect {...}.to yield_with_args
             @positive_args_failure = 'yielded with no arguments' if @actual.empty?
             return !@actual.empty?

--- a/spec/rspec/matchers/built_in/yield_spec.rb
+++ b/spec/rspec/matchers/built_in/yield_spec.rb
@@ -700,7 +700,7 @@ RSpec.describe "yield_successive_args matcher" do
       expect { |b|
         %w[ barn food ].each do |val|
           _yield_with_args(val, &b)
-          val.clear
+          val.delete!(val)
         end
       }.not_to yield_successive_args(a_string_matching(/foo/), a_string_matching(/bar/))
     end

--- a/spec/rspec/matchers/built_in/yield_spec.rb
+++ b/spec/rspec/matchers/built_in/yield_spec.rb
@@ -548,7 +548,7 @@ RSpec.describe "yield_successive_args matcher" do
 
   it_behaves_like "an RSpec matcher",
       :valid_value => lambda { |b| [1, 2].each(&b) },
-      :invalid_value => lambda { |b| _dont_yield(&b) } do
+      :invalid_value => lambda { |b| [3, 4].each(&b) } do
     let(:matcher) { yield_successive_args(1, 2) }
   end
 

--- a/spec/rspec/matchers/built_in/yield_spec.rb
+++ b/spec/rspec/matchers/built_in/yield_spec.rb
@@ -697,12 +697,18 @@ RSpec.describe "yield_successive_args matcher" do
     end
 
     it 'fails when the successively yielded args match the matchers (at yield time only)' do
-      expect { |b|
-        %w[ barn food ].each do |val|
-          _yield_with_args(val, &b)
-          val.sub!(/.+/, '')
-        end
-      }.not_to yield_successive_args(a_string_matching(/foo/), a_string_matching(/bar/))
+      expect {
+        expect { |b|
+          %w[ food barn ].each do |val|
+            _yield_with_args(val, &b)
+            val.sub!(/.+/, '')
+          end
+        }.not_to yield_successive_args(a_string_matching(/foo/), a_string_matching(/bar/))
+      }.to fail_with(dedent <<-EOS)
+        |expected given block not to yield successively with arguments, but yielded with expected arguments
+        |expected not: [(a string matching /foo/), (a string matching /bar/)]
+        |         got: ["", ""]
+      EOS
     end
   end
 

--- a/spec/rspec/matchers/built_in/yield_spec.rb
+++ b/spec/rspec/matchers/built_in/yield_spec.rb
@@ -700,7 +700,7 @@ RSpec.describe "yield_successive_args matcher" do
       expect { |b|
         %w[ barn food ].each do |val|
           _yield_with_args(val, &b)
-          val.delete!(val)
+          val.sub!(/.+/, '')
         end
       }.not_to yield_successive_args(a_string_matching(/foo/), a_string_matching(/bar/))
     end

--- a/spec/rspec/matchers/built_in/yield_spec.rb
+++ b/spec/rspec/matchers/built_in/yield_spec.rb
@@ -309,6 +309,14 @@ RSpec.describe "yield_with_args matcher" do
       expect { |b| _yield_with_args(1, &b) }.to yield_with_args
     end
 
+    it 'passes if the matchers match at yield time only' do
+      expect { |b|
+        val = []
+        _yield_with_args(val, &b)
+        val << 1
+      }.to yield_with_args(be_empty)
+    end
+
     it 'fails if the block does not yield' do
       expect {
         expect { |b| _dont_yield(&b) }.to yield_with_args
@@ -319,6 +327,16 @@ RSpec.describe "yield_with_args matcher" do
       expect {
         expect { |b| _yield_with_no_args(&b) }.to yield_with_args
       }.to fail_with(/expected given block to yield with arguments, but yielded with no arguments/)
+    end
+
+    it 'fails if the matchers match at return time only' do
+      expect {
+        expect { |b|
+          val = [1]
+          _yield_with_args(val, &b)
+          val.clear
+        }.to yield_with_args(be_empty)
+      }.to fail_with(/but yielded with unexpected arguments/)
     end
 
     it 'raises an error if it yields multiple times' do
@@ -335,12 +353,30 @@ RSpec.describe "yield_with_args matcher" do
       }.to fail_with(/expected given block not to yield with arguments, but did/)
     end
 
+    it 'fails if the matchers match at yield time only' do
+      expect {
+        expect { |b|
+          val = []
+          _yield_with_args(val, &b)
+          val << 1
+        }.not_to yield_with_args(be_empty)
+      }.to fail_with(/expected given block not to yield with arguments, but did/)
+    end
+
     it 'passes if the block does not yield' do
       expect { |b| _dont_yield(&b) }.not_to yield_with_args
     end
 
     it 'passes if the block yields with no arguments' do
       expect { |b| _yield_with_no_args(&b) }.not_to yield_with_args
+    end
+
+    it 'passes if the matchers match at return time only' do
+      expect { |b|
+        val = [1]
+        _yield_with_args(val, &b)
+        val.clear
+      }.not_to yield_with_args(be_empty)
     end
 
     it 'fails if the expect block does not accept an argument', :if => (RUBY_VERSION.to_f > 1.8) do

--- a/spec/rspec/matchers/built_in/yield_spec.rb
+++ b/spec/rspec/matchers/built_in/yield_spec.rb
@@ -336,7 +336,11 @@ RSpec.describe "yield_with_args matcher" do
           _yield_with_args(val, &b)
           val.clear
         }.to yield_with_args(be_empty)
-      }.to fail_with(/but yielded with unexpected arguments/)
+      }.to fail_with(dedent <<-EOS)
+        |expected given block to yield with arguments, but yielded with unexpected arguments
+        |expected: [(be empty)]
+        |     got: [[1]]
+      EOS
     end
 
     it 'raises an error if it yields multiple times' do
@@ -360,7 +364,11 @@ RSpec.describe "yield_with_args matcher" do
           _yield_with_args(val, &b)
           val << 1
         }.not_to yield_with_args(be_empty)
-      }.to fail_with(/expected given block not to yield with arguments, but did/)
+      }.to fail_with(dedent <<-EOS)
+        |expected given block not to yield with arguments, but yielded with expected arguments
+        |expected not: [(be empty)]
+        |         got: [[]]
+      EOS
     end
 
     it 'passes if the block does not yield' do

--- a/spec/rspec/matchers/built_in/yield_spec.rb
+++ b/spec/rspec/matchers/built_in/yield_spec.rb
@@ -581,7 +581,7 @@ RSpec.describe "yield_successive_args matcher" do
       }.to fail_with(/but yielded with unexpected arguments/)
     end
 
-    it 'fails if the matched at return time only' do
+    it 'fails if matched at return time only' do
       expect {
         expect { |b|
           [ [:a, 1], [:b, 2] ].each do |eventual|

--- a/spec/rspec/matchers/built_in/yield_spec.rb
+++ b/spec/rspec/matchers/built_in/yield_spec.rb
@@ -668,13 +668,13 @@ RSpec.describe "yield_successive_args matcher" do
   end
 
   describe "expect {...}.not_to yield_successive_args(matcher, matcher)" do
-    it 'passes when the successively yielded args match the matchers' do
+    it 'passes when the successively yielded args do not match the matchers' do
       expect { |b|
         %w[ barn food ].each(&b)
       }.not_to yield_successive_args(a_string_matching(/foo/), a_string_matching(/bar/))
     end
 
-    it 'passes when the successively yielded args match the matchers at yield time only' do
+    it 'passes when the successively yielded args do not match the matchers (at yield time only)' do
       expect { |b|
         %w[ barn food ].each do |eventual|
           initial = String.new
@@ -684,7 +684,7 @@ RSpec.describe "yield_successive_args matcher" do
       }.not_to yield_successive_args(a_string_matching(/foo/), a_string_matching(/bar/))
     end
 
-    it 'fails when the successively yielded args do not match the matchers' do
+    it 'fails when the successively yielded args match the matchers' do
       expect {
         expect { |b|
           %w[ food barn ].each(&b)
@@ -696,7 +696,7 @@ RSpec.describe "yield_successive_args matcher" do
       EOS
     end
 
-    it 'fails when the successively yielded args match the matchers at return time only' do
+    it 'fails when the successively yielded args match the matchers (at yield time only)' do
       expect { |b|
         %w[ barn food ].each do |val|
           _yield_with_args(val, &b)

--- a/spec/rspec/matchers/built_in/yield_spec.rb
+++ b/spec/rspec/matchers/built_in/yield_spec.rb
@@ -598,7 +598,11 @@ RSpec.describe "yield_successive_args matcher" do
             initial.concat(eventual)
           end
         }.to yield_successive_args([:a, 1], [:b, 2])
-      }.to fail_with(/but yielded with unexpected arguments/)
+      }.to fail_with(dedent <<-EOS)
+        |expected given block to yield successively with arguments, but yielded with unexpected arguments
+        |expected: [[:a, 1], [:b, 2]]
+        |     got: [[], []]
+      EOS
     end
   end
 
@@ -715,7 +719,7 @@ RSpec.describe "yield_successive_args matcher" do
       }.to fail_with(dedent <<-EOS)
         |expected given block not to yield successively with arguments, but yielded with expected arguments
         |expected not: [(a string matching /foo/), (a string matching /bar/)]
-        |         got: ["", ""]
+        |         got: ["food", "barn"]
       EOS
     end
   end

--- a/spec/rspec/matchers/built_in/yield_spec.rb
+++ b/spec/rspec/matchers/built_in/yield_spec.rb
@@ -676,7 +676,7 @@ RSpec.describe "yield_successive_args matcher" do
 
     it 'passes when the successively yielded args do not match the matchers (at yield time only)' do
       expect { |b|
-        %w[ barn food ].each do |eventual|
+        %w[ food barn ].each do |eventual|
           initial = String.new
           _yield_with_args(initial, &b)
           initial << eventual


### PR DESCRIPTION
This change makes `yield_with_args(matcher)` evaluate the matcher as soon as the arguments are yielded, rather than after the block has run.

I'll demonstrate the problem this solves with an example using Rails's `ActiveRecord::Relation.create`. This method takes a block. It constructs a record object, yields it, saves the record in the database, then returns it.

I'd like to be able to write a test like this:

```ruby
it "yields the record before saving" do
  expect { |b| Dog.create(&b) }.to yield_with_args(be_new_record)
end

it "returns the saved record" do
  expect(Dog.create).not_to be_new_record
end
```

Currently, this doesn't work. The `be_new_record` matcher is only evaluated _after_ the block is finished executing, which means that the record has already been saved and so no longer matches the matcher.

This is a very quick patch to demonstrate the problem and show an example of how it might be fixed. I'm happy to clean it up, write some tests, and adapt it based on any feedback you may have for me, but I wanted to get an indication of whether the patch was likely to be accepted before I worked on it any further.

Thanks!