### PR TITLE
Fix windows build.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,10 @@ if RUBY_VERSION < '2.0.0' || RUBY_ENGINE == 'java'
   gem 'json', '< 2.0.0' # is a dependency of simplecov
 end
 
+if RUBY_VERSION < '2.0.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)
+  gem 'ffi', '< 1.9.15' # allow ffi to be installed on older rubies on windows
+end
+
 platforms :jruby do
   gem "jruby-openssl"
 end


### PR DESCRIPTION
Pin ffi on 1.8 and 1.9 on windows due to a change in required Rubies for ffi.