### PR TITLE
Correct grammar errors

### DIFF
--- a/.rubocop_rspec_base.yml
+++ b/.rubocop_rspec_base.yml
@@ -89,7 +89,7 @@ PercentLiteralDelimiters:
     '%x': ()      # a shell command as a string
 
 # We have too many special cases where we allow generator methods or prefer a
-# prefixed predicate due to it's improved readability.
+# prefixed predicate due to its improved readability.
 PredicateName:
   Enabled: false
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -92,7 +92,7 @@ Bug Fixes:
 
 * Fix failure message from dynamic predicate matchers when the object
   does not respond to the predicate so that it is inspected rather
-  than relying upon it's `to_s` -- that way for `nil`, `"nil"` is
+  than relying upon its `to_s` -- that way for `nil`, `"nil"` is
   printed rather than an empty string. (Myron Marston, #841)
 * Fix SystemStackError raised when diffing an Enumerable object
   whose `#each` includes the object itself. (Yuji Nakayama, #857)

--- a/lib/rspec/matchers/dsl.rb
+++ b/lib/rspec/matchers/dsl.rb
@@ -266,7 +266,7 @@ module RSpec
         #
         # This compiles the user block into an actual method, allowing
         # them to use normal method constructs like `return`
-        # (e.g. for a early guard statement), while allowing us to define
+        # (e.g. for an early guard statement), while allowing us to define
         # an override that can provide the wrapped handling
         # (e.g. assigning `@actual`, rescueing errors, etc) and
         # can `super` to the user's definition.

--- a/spec/rspec/matchers/built_in/raise_error_spec.rb
+++ b/spec/rspec/matchers/built_in/raise_error_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "expect { ... }.to raise_error" do
     expect { raise StandardError.new, 'boom'}.to raise_error
   end
 
-  it 'issues a warning that does not include current error when its not present' do
+  it "issues a warning that does not include current error when it's not present" do
     expect(::Kernel).to receive(:warn) do |message|
       ex = /Actual error raised was/
       expect(message).not_to match ex


### PR DESCRIPTION
This corrects both "a" vs "an" and "its" vs "it's" grammar errors.