### PR TITLE
Change the `warn_about_negative_false_positive` message

### DIFF
--- a/lib/rspec/matchers/built_in/raise_error.rb
+++ b/lib/rspec/matchers/built_in/raise_error.rb
@@ -172,7 +172,7 @@ module RSpec
                          "including those raised by Ruby (e.g. NoMethodError, NameError " \
                          "and ArgumentError), meaning the code you are intending to test " \
                          "may not even get reached. Instead consider using " \
-                         "`expect {}.not_to raise_error` or `expect { }.to raise_error" \
+                         "`expect { }.not_to raise_error` or `expect { }.to raise_error" \
                          "(DifferentSpecificErrorClass)`. This message can be suppressed by " \
                          "setting: `RSpec::Expectations.configuration.on_potential_false" \
                          "_positives = :nothing`")


### PR DESCRIPTION
This PR put a blank for a sense of unity as a whole warning message.