### PR TITLE
use be truthy in be matcher

### DIFF
--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -341,7 +341,7 @@ module RSpec
     # (e.g. be_empty), letting you choose the prefix that best suits the
     # predicate.
     def be(*args)
-      args.empty? ? Matchers::BuiltIn::Be.new : equal(*args)
+      args.empty? ? be_truthy : equal(*args)
     end
     alias_matcher :a_value, :be, :klass => AliasedMatcherWithOperatorSupport
 


### PR DESCRIPTION
I noticed that there was some code duplication here and that it would make more sense for be to explicitly call `be_truthy` instead of returning the underlying object that `be_truthy` returns.

Should I also update the docs to mention that you can do `to be` instead of `to be_truthy`?