### PR TITLE
Improve failure message of #change matcher with block and #satisfy matcher by including the block snippet

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,9 @@ Enhancements:
 * Allow for scoped aliased and negated matchers--just call
   `alias_matcher` or `define_negated_matcher` from within an example
   group. (Markus Reiter, #974)
+* Improve failure message of `change` matcher with block by including the block
+  snippet instead of just describing it as `result` when Ripper is available.
+  (Yuji Nakayama, #987)
 
 Bug Fixes:
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,9 +7,9 @@ Enhancements:
 * Allow for scoped aliased and negated matchers--just call
   `alias_matcher` or `define_negated_matcher` from within an example
   group. (Markus Reiter, #974)
-* Improve failure message of `change` matcher with block by including the block
-  snippet instead of just describing it as `result` when Ripper is available.
-  (Yuji Nakayama, #987)
+* Improve failure message of `change` matcher with block and `satisfy` matcher
+  by including the block snippet instead of just describing it as `result` or
+  `block` when Ripper is available. (Yuji Nakayama, #987)
 
 Bug Fixes:
 

--- a/features/built_in_matchers/change.feature
+++ b/features/built_in_matchers/change.feature
@@ -26,6 +26,7 @@ Feature: `change` matcher
       end
       """
 
+  @skip-when-ripper-unsupported
   Scenario: expect change
     Given a file named "spec/example_spec.rb" with:
       """ruby
@@ -33,19 +34,20 @@ Feature: `change` matcher
 
       RSpec.describe Counter, "#increment" do
         it "should increment the count" do
-          expect { Counter.increment }.to change{Counter.count}.from(0).to(1)
+          expect { Counter.increment }.to change { Counter.count }.from(0).to(1)
         end
 
         # deliberate failure
         it "should increment the count by 2" do
-          expect { Counter.increment }.to change{Counter.count}.by(2)
+          expect { Counter.increment }.to change { Counter.count }.by(2)
         end
       end
       """
     When I run `rspec spec/example_spec.rb`
     Then the output should contain "1 failure"
-    Then the output should contain "expected result to have changed by 2, but was changed by 1"
+    Then the output should contain "expected `Counter.count` to have changed by 2, but was changed by 1"
 
+  @skip-when-ripper-unsupported
   Scenario: expect no change
     Given a file named "spec/example_spec.rb" with:
       """ruby
@@ -53,14 +55,14 @@ Feature: `change` matcher
 
       RSpec.describe Counter, "#increment" do
         it "should not increment the count by 1 (using not_to)" do
-          expect { Counter.increment }.not_to change{Counter.count}
+          expect { Counter.increment }.not_to change { Counter.count }
         end
 
         it "should not increment the count by 1 (using to_not)" do
-          expect { Counter.increment }.to_not change{Counter.count}
+          expect { Counter.increment }.to_not change { Counter.count }
         end
       end
       """
     When I run `rspec spec/example_spec.rb`
     Then the output should contain "2 failures"
-    Then the output should contain "expected result not to have changed, but did change from 1 to 2"
+    Then the output should contain "expected `Counter.count` not to have changed, but did change from 1 to 2"

--- a/features/built_in_matchers/satisfy.feature
+++ b/features/built_in_matchers/satisfy.feature
@@ -17,6 +17,7 @@ Feature: `satisfy` matcher
     end
     ```
 
+  @skip-when-ripper-unsupported
   Scenario: basic usage
     Given a file named "satisfy_matcher_spec.rb" with:
       """ruby
@@ -33,9 +34,8 @@ Feature: `satisfy` matcher
       """
     When I run `rspec satisfy_matcher_spec.rb`
     Then the output should contain all of these:
-      | 6 examples, 4 failures               |
-      | expected 10 not to satisfy block     |
-      | expected 10 to satisfy block         |
-      | expected 10 not to be greater than 5 |
-      | expected 10 to be greater than 15    |
-
+      | 6 examples, 4 failures                        |
+      | expected 10 not to satisfy expression `v > 5` |
+      | expected 10 to satisfy expression `v > 15`    |
+      | expected 10 not to be greater than 5          |
+      | expected 10 to be greater than 15             |

--- a/features/define_negated_matcher.feature
+++ b/features/define_negated_matcher.feature
@@ -3,6 +3,7 @@ Feature: Define negated matcher
   You can use `RSpec::Matchers.define_negated_matcher` to define a negated version of
   an existing matcher. This is particularly useful in composed matcher expressions.
 
+  @skip-when-ripper-unsupported
   Scenario: Composed negated matcher expression
     Given a file named "composed_negated_expression_spec.rb" with:
       """ruby
@@ -26,4 +27,4 @@ Feature: Define negated matcher
       | 2 examples, 1 failure                                                                                  |
       |  1) A negated matcher provides a good failure message based on the name                                |
       |     Failure/Error: expect { list.delete(1) }.to change { list }.to(an_array_excluding 5)               |
-      |       expected result to have changed to an array excluding 5, but is now [2, 3, 4, 5, 6, 7, 8, 9, 10] |
+      |       expected `list` to have changed to an array excluding 5, but is now [2, 3, 4, 5, 6, 7, 8, 9, 10] |

--- a/features/support/ruby_features.rb
+++ b/features/support/ruby_features.rb
@@ -27,3 +27,13 @@ Around "@skip-when-required-keyword-args-unsupported" do |scenario, block|
     warn "Skipping scenario #{scenario.title} because required keyword arguments are not supported"
   end
 end
+
+Around "@skip-when-ripper-unsupported" do |scenario, block|
+  require 'rspec/support/ruby_features'
+
+  if ::RSpec::Support::RubyFeatures.ripper_supported?
+    block.call
+  else
+    warn "Skipping scenario #{scenario.title} because Ripper is not supported"
+  end
+end

--- a/features/test_frameworks/minitest.feature
+++ b/features/test_frameworks/minitest.feature
@@ -72,13 +72,11 @@ Feature: Minitest integration
         end
 
         it 'passes a block expectation' do
-          x = 1
-          expect { x += 2 }.to change { x }.from(1).to(3)
+          expect { 1 / 0 }.to raise_error(ZeroDivisionError)
         end
 
         it 'fails a block expectation' do
-          x = 1
-          expect { x += 2 }.to change { x }.from(1).to(:wrong_value)
+          expect { 1 / 1 }.to raise_error(ZeroDivisionError)
         end
 
         it 'passes a negative expectation (using `not_to`)' do
@@ -108,6 +106,6 @@ Feature: Minitest integration
      When I run `ruby rspec_expectations_spec.rb`
      Then the output should contain "9 runs, 10 assertions, 5 failures, 0 errors"
       And the output should contain "expected `[1, 2].empty?` to return true, got false"
-      And the output should contain "expected result to have changed to :wrong_value, but is now 3"
+      And the output should contain "expected ZeroDivisionError but nothing was raised"
       And the output should contain "Got 2 failures from failure aggregation block"
       And the output should contain "Expected [1, 2] to be empty?"

--- a/lib/rspec/expectations.rb
+++ b/lib/rspec/expectations.rb
@@ -76,6 +76,7 @@ module RSpec
     class MultipleExpectationsNotMetError < ExpectationNotMetError
     end
 
-    autoload :FailureAggregator, "rspec/expectations/failure_aggregator"
+    autoload :BlockSnippetExtractor, "rspec/expectations/block_snippet_extractor"
+    autoload :FailureAggregator,     "rspec/expectations/failure_aggregator"
   end
 end

--- a/lib/rspec/expectations/block_snippet_extractor.rb
+++ b/lib/rspec/expectations/block_snippet_extractor.rb
@@ -1,0 +1,248 @@
+module RSpec
+  module Expectations
+    # @private
+    class BlockSnippetExtractor # rubocop:disable Style/ClassLength
+      # rubocop should properly handle `Struct.new {}` as an inner class definition.
+
+      attr_reader :proc, :method_name
+
+      def self.try_extracting_single_line_body_of(proc, method_name)
+        lines = new(proc, method_name).body_content_lines
+        return nil unless lines.count == 1
+        lines.first
+      rescue Error
+        nil
+      end
+
+      def initialize(proc, method_name)
+        @proc = proc
+        @method_name = method_name.to_s.freeze
+      end
+
+      # Ideally we should properly handle indentations of multiline snippet,
+      # but it's not implemented yet since because we use result of this method only when it's a
+      # single line and implementing the logic introduces additional complexity.
+      def body_content_lines
+        raw_body_lines.map(&:strip).reject(&:empty?)
+      end
+
+    private
+
+      def raw_body_lines
+        raw_body_snippet.split("\n")
+      end
+
+      def raw_body_snippet
+        block_token_extractor.body_tokens.map(&:string).join
+      end
+
+      def block_token_extractor
+        @block_token_extractor ||= BlockTokenExtractor.new(method_name, source, beginning_line_number)
+      end
+
+      if RSpec.respond_to?(:world)
+        def source
+          RSpec.world.source_from_file(file_path)
+        end
+      else
+        RSpec::Support.require_rspec_support 'source'
+        def source
+          @source ||= RSpec::Support::Source.from_file(file_path)
+        end
+      end
+
+      def file_path
+        proc.source_location.first
+      end
+
+      def beginning_line_number
+        proc.source_location.last
+      end
+
+      Error = Class.new(StandardError)
+      TargetNotFoundError = Class.new(Error)
+      AmbiguousTargetError = Class.new(Error)
+
+      # @private
+      # Performs extraction of block body snippet using tokens,
+      # which cannot be done with node information.
+      BlockTokenExtractor = Struct.new(:method_name, :source, :beginning_line_number) do
+        attr_reader :state, :body_tokens
+
+        def initialize(*)
+          super
+          parse!
+        end
+
+        private
+
+        def parse!
+          @state = :initial
+
+          catch(:finish) do
+            source.tokens.each do |token|
+              invoke_state_handler(token)
+            end
+            raise TargetNotFoundError, 'Could not find the target block'
+          end
+        end
+
+        def finish!
+          throw :finish
+        end
+
+        def invoke_state_handler(token)
+          __send__("#{state}_state", token)
+        end
+
+        def initial_state(token)
+          @state = :after_method_call if token.location == block_locator.method_call_location
+        end
+
+        def after_method_call_state(token)
+          @state = :after_opener if handle_opener_token(token)
+        end
+
+        def after_opener_state(token)
+          if handle_closer_token(token)
+            finish_or_find_next_block_if_incorrect!
+          elsif pipe_token?(token)
+            finalize_pending_tokens!
+            @state = :after_beginning_of_args
+          else
+            pending_tokens << token
+            handle_opener_token(token)
+            @state = :after_beginning_of_body unless token.type == :on_sp
+          end
+        end
+
+        def after_beginning_of_args_state(token)
+          @state = :after_beginning_of_body if pipe_token?(token)
+        end
+
+        def after_beginning_of_body_state(token)
+          if handle_closer_token(token)
+            finish_or_find_next_block_if_incorrect!
+          else
+            pending_tokens << token
+            handle_opener_token(token)
+          end
+        end
+
+        def pending_tokens
+          @pending_tokens ||= []
+        end
+
+        def finalize_pending_tokens!
+          pending_tokens.freeze.tap do
+            @pending_tokens = nil
+          end
+        end
+
+        def finish_or_find_next_block_if_incorrect!
+          body_tokens = finalize_pending_tokens!
+
+          if correct_block?(body_tokens)
+            @body_tokens = body_tokens
+            finish!
+          else
+            @state = :after_method_call
+          end
+        end
+
+        def handle_opener_token(token)
+          opener_token?(token).tap do |boolean|
+            opener_token_stack.push(token) if boolean
+          end
+        end
+
+        def opener_token?(token)
+          token.type == :on_lbrace || (token.type == :on_kw && token.string == 'do')
+        end
+
+        def handle_closer_token(token)
+          if opener_token_stack.last.closed_by?(token)
+            opener_token_stack.pop
+            opener_token_stack.empty?
+          else
+            false
+          end
+        end
+
+        def opener_token_stack
+          @opener_token_stack ||= []
+        end
+
+        def pipe_token?(token)
+          token.type == :on_op && token.string == '|'
+        end
+
+        def correct_block?(body_tokens)
+          return true if block_locator.body_content_locations.empty?
+          content_location = block_locator.body_content_locations.first
+          content_location.between?(body_tokens.first.location, body_tokens.last.location)
+        end
+
+        def block_locator
+          @block_locator ||= BlockLocator.new(method_name, source, beginning_line_number)
+        end
+      end
+
+      # @private
+      # Locates target block with node information (semantics), which tokens don't have.
+      BlockLocator = Struct.new(:method_name, :source, :beginning_line_number) do
+        def method_call_location
+          @method_call_location ||= method_ident_node.location
+        end
+
+        def body_content_locations
+          @body_content_locations ||= block_body_node.map(&:location).compact
+        end
+
+        private
+
+        def method_ident_node
+          method_call_node = block_wrapper_node.children.first
+          method_call_node.find do |node|
+            method_ident_node?(node)
+          end
+        end
+
+        def block_body_node
+          block_node = block_wrapper_node.children[1]
+          block_node.children.last
+        end
+
+        def block_wrapper_node
+          case candidate_block_wrapper_nodes.size
+          when 1
+            candidate_block_wrapper_nodes.first
+          when 0
+            raise TargetNotFoundError, 'Could not find the target block'
+          else
+            raise AmbiguousTargetError, "There're multiple blocks with the same name method call on the line"
+          end
+        end
+
+        def candidate_block_wrapper_nodes
+          @candidate_block_wrapper_nodes ||= candidate_method_ident_nodes.map do |method_ident_node|
+            block_wrapper_node = method_ident_node.each_ancestor.find { |node| node.type == :method_add_block }
+            next nil unless block_wrapper_node
+            method_call_node = block_wrapper_node.children.first
+            method_call_node.include?(method_ident_node) ? block_wrapper_node : nil
+          end.compact
+        end
+
+        def candidate_method_ident_nodes
+          source.nodes_by_line_number[beginning_line_number].select do |node|
+            method_ident_node?(node)
+          end
+        end
+
+        def method_ident_node?(node)
+          node.type == :@ident && node.args.first == method_name
+        end
+      end
+    end
+  end
+end

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -796,7 +796,7 @@ module RSpec
     # @example
     #   expect(5).to satisfy { |n| n > 3 }
     #   expect(5).to satisfy("be greater than 3") { |n| n > 3 }
-    def satisfy(description="satisfy block", &block)
+    def satisfy(description=nil, &block)
       BuiltIn::Satisfy.new(description, &block)
     end
     alias_matcher :an_object_satisfying, :satisfy

--- a/lib/rspec/matchers/built_in/satisfy.rb
+++ b/lib/rspec/matchers/built_in/satisfy.rb
@@ -5,10 +5,7 @@ module RSpec
       # Provides the implementation for `satisfy`.
       # Not intended to be instantiated directly.
       class Satisfy < BaseMatcher
-        # @private
-        attr_reader :description
-
-        def initialize(description="satisfy block", &block)
+        def initialize(description=nil, &block)
           @description = description
           @block = block
         end
@@ -18,6 +15,11 @@ module RSpec
           @block = block if block
           @actual = actual
           @block.call(actual)
+        end
+
+        # @private
+        def description
+          @description ||= "satisfy #{block_representation}"
         end
 
         # @api private
@@ -30,6 +32,27 @@ module RSpec
         # @return [String]
         def failure_message_when_negated
           "expected #{actual_formatted} not to #{description}"
+        end
+
+      private # rubocop:disable Lint/UselessAccessModifier
+
+        if RSpec::Support::RubyFeatures.ripper_supported?
+          def block_representation
+            if (block_snippet = extract_block_snippet)
+              "expression `#{block_snippet}`"
+            else
+              'block'
+            end
+          end
+
+          def extract_block_snippet
+            return nil unless @block
+            Expectations::BlockSnippetExtractor.try_extracting_single_line_body_of(@block, 'satisfy')
+          end
+        else
+          def block_representation
+            'block'
+          end
         end
       end
     end

--- a/spec/rspec/expectations/block_snippet_extractor_spec.rb
+++ b/spec/rspec/expectations/block_snippet_extractor_spec.rb
@@ -1,0 +1,296 @@
+require 'rspec/expectations/block_snippet_extractor'
+
+module RSpec::Expectations
+  RSpec.describe BlockSnippetExtractor, :if => RSpec::Support::RubyFeatures.ripper_supported? do
+    subject(:extractor) do
+      BlockSnippetExtractor.new(proc_object, 'target_method')
+    end
+
+    let(:proc_object) do
+      @proc_object
+    end
+
+    def target_method(*, &block)
+      @proc_object = block
+    end
+
+    def another_method(*)
+    end
+
+    before do
+      expression
+    end
+
+    describe '.try_extracting_single_line_body_of' do
+      subject(:try_extracting_single_line_body) do
+        BlockSnippetExtractor.try_extracting_single_line_body_of(proc_object, 'target_method')
+      end
+
+      context 'with a single line body block' do
+        let(:expression) do
+          target_method { 1.positive? }
+        end
+
+        it 'returns the body' do
+          expect(try_extracting_single_line_body).to eq('1.positive?')
+        end
+      end
+
+      context 'with a multiline body block' do
+        let(:expression) do
+          target_method do
+            1.positive?
+            2.negative?
+          end
+        end
+
+        it 'returns nil' do
+          expect(try_extracting_single_line_body).to be_nil
+        end
+      end
+
+      context 'when the block snippet cannot be extracted due to ambiguity' do
+        let(:expression) do
+          target_method { 1.positive? }; dummy_object.target_method { 2.negative? }
+        end
+
+        let(:dummy_object) do
+          double('dummy_object', :target_method => nil)
+        end
+
+        it 'returns nil' do
+          expect(try_extracting_single_line_body).to be_nil
+        end
+      end
+    end
+
+    describe '#body_content_lines' do
+      subject(:body_content_lines) do
+        extractor.body_content_lines
+      end
+
+      context 'with `target_method {}`' do
+        let(:expression) do
+          target_method {}
+        end
+
+        it 'returns empty lines' do
+          expect(body_content_lines).to eq([])
+        end
+      end
+
+      context 'with `target_method { body }`' do
+        let(:expression) do
+          target_method { 1.positive? }
+        end
+
+        it 'returns the body content lines' do
+          expect(body_content_lines).to eq(['1.positive?'])
+        end
+      end
+
+      context 'with `target_method do body end`' do
+        let(:expression) do
+          target_method do 1.positive? end
+        end
+
+        it 'returns the body content lines' do
+          expect(body_content_lines).to eq(['1.positive?'])
+        end
+      end
+
+      context 'with `target_method { |arg1, arg2| body }`' do
+        let(:expression) do
+          target_method { |arg1, arg2| 1.positive? }
+        end
+
+        it 'returns the body content lines' do
+          expect(body_content_lines).to eq(['1.positive?'])
+        end
+      end
+
+      context 'with `target_method(:arg1, :arg2) { body }`' do
+        let(:expression) do
+          target_method(:arg1, :arg2) { 1.positive? }
+        end
+
+        it 'returns the body content lines' do
+          expect(body_content_lines).to eq(['1.positive?'])
+        end
+      end
+
+      context 'with `target_method(:arg1,:arg2){|arg1,arg2|body}`' do
+        let(:expression) do
+          target_method(:arg1,:arg2){|arg1,arg2|1.positive?}
+        end
+
+        it 'returns the body content lines' do
+          expect(body_content_lines).to eq(['1.positive?'])
+        end
+      end
+
+      context 'with a multiline block containing a single line body' do
+        let(:expression) do
+          target_method do
+            1.positive?
+          end
+        end
+
+        it 'returns the body content lines' do
+          expect(body_content_lines).to eq(['1.positive?'])
+        end
+      end
+
+      context 'with a multiline body block' do
+        let(:expression) do
+          target_method do
+            1.positive?
+            2.negative?
+          end
+        end
+
+        it 'returns the body content lines' do
+          expect(body_content_lines).to eq([
+            '1.positive?',
+            '2.negative?'
+          ])
+        end
+      end
+
+      context 'with `target_method { { :key => "value" } }`' do
+        let(:expression) do
+          target_method { { :key => "value" } }
+        end
+
+        it 'does not confuse the hash curly with the block closer' do
+          expect(body_content_lines).to eq(['{ :key => "value" }'])
+        end
+      end
+
+      context 'with a do-end block containing another do-end block' do
+        let(:expression) do
+          target_method do
+            2.times do |index|
+              puts index
+            end
+          end
+        end
+
+        it 'does not confuse the inner `end` with the outer `end`' do
+          expect(body_content_lines).to eq([
+            '2.times do |index|',
+            'puts index',
+            'end'
+          ])
+        end
+      end
+
+      context "when there's another method invocation on the same line before the target" do
+        let(:expression) do
+          another_method { 2.negative? }; target_method { 1.positive? }
+        end
+
+        it 'correctly extracts the target snippet' do
+          expect(body_content_lines).to eq(['1.positive?'])
+        end
+      end
+
+      context "when there's another method invocation on the same line after the target" do
+        let(:expression) do
+          target_method { 1.positive? }; another_method { 2.negative? }
+        end
+
+        it 'correctly extracts the target snippet' do
+          expect(body_content_lines).to eq(['1.positive?'])
+        end
+      end
+
+      context "when there's another method invocation with the same name on the same line before the target" do
+        let(:expression) do
+          dummy_object.target_method { 2.negative? }; target_method { 1.positive? }
+        end
+
+        let(:dummy_object) do
+          double('dummy_object', :target_method => nil)
+        end
+
+        it 'raises AmbiguousTargetError' do
+          expect { body_content_lines }.to raise_error(BlockSnippetExtractor::AmbiguousTargetError)
+        end
+      end
+
+      context "when there's another method invocation with the same name on the same line after the target" do
+        let(:expression) do
+          target_method { 1.positive? }; dummy_object.target_method { 2.negative? }
+        end
+
+        let(:dummy_object) do
+          double('dummy_object', :target_method => nil)
+        end
+
+        it 'raises AmbiguousTargetError' do
+          expect { body_content_lines }.to raise_error(BlockSnippetExtractor::AmbiguousTargetError)
+        end
+      end
+
+      context "when there's another method invocation with the same name without block on the same line before the target" do
+        let(:expression) do
+          dummy_object.target_method; target_method { 1.positive? }
+        end
+
+        let(:dummy_object) do
+          double('dummy_object', :target_method => nil)
+        end
+
+        it 'correctly extracts the target snippet' do
+          expect(body_content_lines).to eq(['1.positive?'])
+        end
+      end
+
+      context "when there's another method invocation with the same name without block on the same line after the target" do
+        let(:expression) do
+          target_method { 1.positive? }; dummy_object.target_method
+        end
+
+        let(:dummy_object) do
+          double('dummy_object', :target_method => nil)
+        end
+
+        it 'correctly extracts the target snippet' do
+          expect(body_content_lines).to eq(['1.positive?'])
+        end
+      end
+
+      context 'when a hash is given as an argument' do
+        let(:expression) do
+          target_method({ :key => "value" }) { 1.positive? }
+        end
+
+        it 'correctly extracts the target snippet' do
+          expect(body_content_lines).to eq(['1.positive?'])
+        end
+      end
+
+      context 'when another method invocation with block is given as an argument' do
+        let(:expression) do
+          target_method(another_method { 2.negative? }) { 1.positive? }
+        end
+
+        it 'correctly extracts the target snippet' do
+          expect(body_content_lines).to eq(['1.positive?'])
+        end
+      end
+
+      context "when the block literal is described on different line with the method invocation" do
+        let(:expression) do
+          block = proc { 1.positive? }
+          target_method(&block)
+        end
+
+        it 'raises TargetNotFoundError' do
+          expect { body_content_lines }.to raise_error(BlockSnippetExtractor::TargetNotFoundError)
+        end
+      end
+    end
+  end
+end

--- a/spec/rspec/matchers/built_in/change_spec.rb
+++ b/spec/rspec/matchers/built_in/change_spec.rb
@@ -283,6 +283,14 @@ RSpec.describe "expect { ... }.to change { block }" do
         expect(matcher.description).to eq "change result"
       end
     end
+
+    context 'when used with an alias name' do
+      alias_matcher :modify, :change
+
+      pending 'can extract the block snippet' do
+        expect(modify { @instance.some_value }.description).to eq "modify `@instance.some_value`"
+      end
+    end
   end
 
   context 'in Ripper unsupported environment', :unless => RSpec::Support::RubyFeatures.ripper_supported? do

--- a/spec/rspec/matchers/built_in/change_spec.rb
+++ b/spec/rspec/matchers/built_in/change_spec.rb
@@ -2,6 +2,8 @@ class SomethingExpected
   attr_accessor :some_value
 end
 
+value_pattern = /(?:result|`.+?`)/
+
 RSpec.describe "expect { ... }.to change ..." do
   context "with a numeric value" do
     before(:example) do
@@ -76,7 +78,7 @@ RSpec.describe "expect { ... }.to change ..." do
           expect {
             set << 2
           }.to change { set }.from([1].to_set).to([2, 1, 3].to_set)
-        }.to fail_with("expected result to have changed to #{[2, 1, 3].to_set.inspect}, but is now #{[1, 2].to_set.inspect}")
+        }.to fail_with(/expected #{value_pattern} to have changed to #{Regexp.escape([2, 1, 3].to_set.inspect)}, but is now #{Regexp.escape([1, 2].to_set.inspect)}/)
       end
     end
   end
@@ -86,7 +88,7 @@ RSpec.describe "expect { ... }.to change ..." do
       expect {
         k = STDOUT
         expect { }.to change { k }
-      }.to fail_with(/expected result to have changed/)
+      }.to fail_with(/expected #{value_pattern} to have changed/)
     end
   end
 
@@ -120,7 +122,7 @@ RSpec.describe "expect { ... }.to change ..." do
     it "fails when a predicate on the actual fails" do
       expect do
         expect {@instance.some_value << 1}.to change { @instance.some_value }.to be_empty
-      end.to fail_with(/result to have changed to/)
+      end.to fail_with(/#{value_pattern} to have changed to/)
     end
 
     it "passes when a predicate on the actual passes" do
@@ -205,6 +207,10 @@ RSpec.describe "expect { ... }.to change ..." do
 end
 
 RSpec.describe "expect { ... }.to change(actual, message)" do
+  it "provides a #description with the block snippet" do
+    expect(change('instance', :some_value).description).to eq 'change #some_value'
+  end
+
   context "with a missing message" do
     it "fails with an ArgumentError" do
       expect do
@@ -244,7 +250,7 @@ RSpec.describe "expect { ... }.to change { block }" do
   it "fails when actual is not modified by the block" do
     expect do
       expect {}.to change{ @instance.some_value }
-    end.to fail_with("expected result to have changed, but is still 5")
+    end.to fail_with(/expected #{value_pattern} to have changed, but is still 5/)
   end
 
   it "warns if passed a block using do/end instead of {}" do
@@ -253,8 +259,36 @@ RSpec.describe "expect { ... }.to change { block }" do
     end.to raise_error(SyntaxError, /Block not received by the `change` matcher/)
   end
 
-  it "provides a #description" do
-    expect(change { @instance.some_value }.description).to eq "change result"
+  context 'in Ripper supported environment', :if => RSpec::Support::RubyFeatures.ripper_supported? do
+    context 'when the block body fits into a single line' do
+      it "provides a #description with the block snippet" do
+        expect(change { @instance.some_value }.description).to eq "change `@instance.some_value`"
+      end
+    end
+
+    context 'when the block body spans multiple lines' do
+      before do
+        def @instance.reload
+        end
+      end
+
+      let(:matcher) do
+        change {
+          @instance.reload
+          @instance.some_value
+        }
+      end
+
+      it "provides a #description with the block snippet" do
+        expect(matcher.description).to eq "change result"
+      end
+    end
+  end
+
+  context 'in Ripper unsupported environment', :unless => RSpec::Support::RubyFeatures.ripper_supported? do
+    it "provides a #description without the block snippet" do
+      expect(change { @instance.some_value }.description).to eq "change result"
+    end
   end
 end
 
@@ -271,7 +305,7 @@ RSpec.describe "expect { ... }.not_to change { block }" do
   it "fails when actual is not modified by the block" do
     expect do
       expect {@instance.some_value = 6}.not_to change { @instance.some_value }
-    end.to fail_with("expected result not to have changed, but did change from 5 to 6")
+    end.to fail_with(/expected #{value_pattern} not to have changed, but did change from 5 to 6/)
   end
 
   it "warns if passed a block using do/end instead of {}" do
@@ -308,14 +342,14 @@ RSpec.describe "expect { ... }.not_to change { }.from" do
       expect {
         k = 6
         expect { }.not_to change { k }.from(5)
-      }.to fail_with(/expected result to have initially been 5/)
+      }.to fail_with(/expected #{value_pattern} to have initially been 5/)
     end
 
     it 'fails when the value does change' do
       expect {
         k = 6
         expect { k += 1 }.not_to change { k }.from(5)
-      }.to fail_with(/expected result to have initially been 5/)
+      }.to fail_with(/expected #{value_pattern} to have initially been 5/)
     end
   end
 end
@@ -402,17 +436,25 @@ RSpec.describe "expect { ... }.to change { block }.by(expected)" do
   it "fails when the attribute is changed by unexpected amount" do
     expect do
       expect { @instance.some_value += 2 }.to change{@instance.some_value}.by(1)
-    end.to fail_with("expected result to have changed by 1, but was changed by 2")
+    end.to fail_with(/expected #{value_pattern} to have changed by 1, but was changed by 2/)
   end
 
   it "fails when the attribute is changed by unexpected amount in the opposite direction" do
     expect do
       expect { @instance.some_value -= 1 }.to change{@instance.some_value}.by(1)
-    end.to fail_with("expected result to have changed by 1, but was changed by -1")
+    end.to fail_with(/expected #{value_pattern} to have changed by 1, but was changed by -1/)
   end
 
-  it "provides a #description" do
-    expect(change { @instance.some_value }.by(3).description).to eq "change result by 3"
+  context 'in Ripper supported environment', :if => RSpec::Support::RubyFeatures.ripper_supported? do
+    it "provides a #description with the block snippet" do
+      expect(change { @instance.some_value }.by(3).description).to eq "change `@instance.some_value` by 3"
+    end
+  end
+
+  context 'in Ripper unsupported environment', :unless => RSpec::Support::RubyFeatures.ripper_supported? do
+    it "provides a #description without the block snippet" do
+      expect(change { @instance.some_value }.by(3).description).to eq "change result by 3"
+    end
   end
 end
 
@@ -458,11 +500,19 @@ RSpec.describe "expect { ... }.to change { block }.by_at_least(expected)" do
   it "fails when the attribute is changed by less than the unexpected amount" do
     expect do
       expect { @instance.some_value += 1 }.to change{@instance.some_value}.by_at_least(2)
-    end.to fail_with("expected result to have changed by at least 2, but was changed by 1")
+    end.to fail_with(/expected #{value_pattern} to have changed by at least 2, but was changed by 1/)
   end
 
-  it "provides a #description" do
-    expect(change { @instance.some_value }.by_at_least(3).description).to eq "change result by at least 3"
+  context 'in Ripper supported environment', :if => RSpec::Support::RubyFeatures.ripper_supported? do
+    it "provides a #description with the block snippet" do
+      expect(change { @instance.some_value }.by_at_least(3).description).to eq "change `@instance.some_value` by at least 3"
+    end
+  end
+
+  context 'in Ripper unsupported environment', :unless => RSpec::Support::RubyFeatures.ripper_supported? do
+    it "provides a #description without the block snippet" do
+      expect(change { @instance.some_value }.by_at_least(3).description).to eq "change result by at least 3"
+    end
   end
 end
 
@@ -508,11 +558,19 @@ RSpec.describe "expect { ... }.to change { block }.by_at_most(expected)" do
   it "fails when the attribute is changed by greater than the unexpected amount" do
     expect do
       expect { @instance.some_value += 2 }.to change{@instance.some_value}.by_at_most(1)
-    end.to fail_with("expected result to have changed by at most 1, but was changed by 2")
+    end.to fail_with(/expected #{value_pattern} to have changed by at most 1, but was changed by 2/)
   end
 
-  it "provides a #description" do
-    expect(change { @instance.some_value }.by_at_most(3).description).to eq "change result by at most 3"
+  context 'in Ripper supported environment', :if => RSpec::Support::RubyFeatures.ripper_supported? do
+    it "provides a #description with the block snippet" do
+      expect(change { @instance.some_value }.by_at_most(3).description).to eq "change `@instance.some_value` by at most 3"
+    end
+  end
+
+  context 'in Ripper unsupported environment', :unless => RSpec::Support::RubyFeatures.ripper_supported? do
+    it "provides a #description without the block snippet" do
+      expect(change { @instance.some_value }.by_at_most(3).description).to eq "change result by at most 3"
+    end
   end
 end
 
@@ -569,13 +627,25 @@ RSpec.describe "expect { ... }.to change { block }.from(old)" do
   it "fails when attribute does not match expected value before executing block" do
     expect do
       expect { @instance.some_value = "knot" }.to change{@instance.some_value}.from("cat")
-    end.to fail_with("expected result to have initially been \"cat\", but was \"string\"")
+    end.to fail_with(/expected #{value_pattern} to have initially been "cat", but was "string"/)
   end
 
   it "fails when attribute does not change" do
     expect do
       expect { }.to change { @instance.some_value }.from("string")
-    end.to fail_with('expected result to have changed from "string", but did not change')
+    end.to fail_with(/expected #{value_pattern} to have changed from "string", but did not change/)
+  end
+
+  context 'in Ripper supported environment', :if => RSpec::Support::RubyFeatures.ripper_supported? do
+    it "provides a #description with the block snippet" do
+      expect(change { @instance.some_value }.from(3).description).to eq "change `@instance.some_value` from 3"
+    end
+  end
+
+  context 'in Ripper unsupported environment', :unless => RSpec::Support::RubyFeatures.ripper_supported? do
+    it "provides a #description without the block snippet" do
+      expect(change { @instance.some_value }.from(3).description).to eq "change result from 3"
+    end
   end
 
   it "provides a #description" do
@@ -638,7 +708,7 @@ RSpec.describe "expect { ... }.to change { block }.to(new)" do
   it "fails when attribute does not match expected value after executing block" do
     expect do
       expect { @instance.some_value = "cat" }.to change{@instance.some_value}.from("string").to("dog")
-    end.to fail_with("expected result to have changed to \"dog\", but is now \"cat\"")
+    end.to fail_with(/expected #{value_pattern} to have changed to "dog", but is now "cat"/)
   end
 
   it "provides a #description" do
@@ -716,7 +786,7 @@ RSpec.describe "Composing a matcher with `change`" do
           expect { k += 1 }.to change { k }.
             from( a_value_within(0.1).of(0.7) ).
             to( a_value_within(0.1).of(1.5) )
-        }.to fail_with(/expected result to have initially been a value within 0.1 of 0.7, but was 0.51/)
+        }.to fail_with(/expected #{value_pattern} to have initially been a value within 0.1 of 0.7, but was 0.51/)
       end
 
       it 'fails with a clear message when the `to` does not match' do
@@ -725,7 +795,7 @@ RSpec.describe "Composing a matcher with `change`" do
           expect { k += 1 }.to change { k }.
             from( a_value_within(0.1).of(0.5) ).
             to( a_value_within(0.1).of(2.5) )
-        }.to fail_with(/expected result to have changed to a value within 0.1 of 2.5, but is now 1.51/)
+        }.to fail_with(/expected #{value_pattern} to have changed to a value within 0.1 of 2.5, but is now 1.51/)
       end
 
       it 'provides a description' do
@@ -750,7 +820,7 @@ RSpec.describe "Composing a matcher with `change`" do
           expect { k += 1 }.to change { k }.
             to( a_value_within(0.1).of(1.5) ).
             from( a_value_within(0.1).of(0.7) )
-        }.to fail_with(/expected result to have initially been a value within 0.1 of 0.7, but was 0.51/)
+        }.to fail_with(/expected #{value_pattern} to have initially been a value within 0.1 of 0.7, but was 0.51/)
       end
 
       it 'fails with a clear message when the `to` does not match' do
@@ -759,7 +829,7 @@ RSpec.describe "Composing a matcher with `change`" do
           expect { k += 1 }.to change { k }.
             to( a_value_within(0.1).of(2.5) ).
             from( a_value_within(0.1).of(0.5) )
-        }.to fail_with(/expected result to have changed to a value within 0.1 of 2.5, but is now 1.51/)
+        }.to fail_with(/expected #{value_pattern} to have changed to a value within 0.1 of 2.5, but is now 1.51/)
       end
 
       it 'provides a description' do
@@ -780,7 +850,7 @@ RSpec.describe "Composing a matcher with `change`" do
         expect {
           k = 0.5
           expect { k += 1.05 }.to change { k }.by( a_value_within(0.1).of(0.5) )
-        }.to fail_with(/expected result to have changed by a value within 0.1 of 0.5, but was changed by 1.05/)
+        }.to fail_with(/expected #{value_pattern} to have changed by a value within 0.1 of 0.5, but was changed by 1.05/)
       end
 
       it 'provides a description' do
@@ -801,7 +871,7 @@ RSpec.describe "Composing a matcher with `change`" do
       expect {
         k = 0.51
         expect { }.not_to change { k }.from( a_value_within(0.1).of(1.5) )
-      }.to fail_with(/expected result to have initially been a value within 0.1 of 1.5, but was 0.51/)
+      }.to fail_with(/expected #{value_pattern} to have initially been a value within 0.1 of 1.5, but was 0.51/)
     end
   end
 end

--- a/spec/rspec/matchers/built_in/change_spec.rb
+++ b/spec/rspec/matchers/built_in/change_spec.rb
@@ -2,7 +2,7 @@ class SomethingExpected
   attr_accessor :some_value
 end
 
-RSpec.describe "expect { ... }.to change(actual, message)" do
+RSpec.describe "expect { ... }.to change ..." do
   context "with a numeric value" do
     before(:example) do
       @instance = SomethingExpected.new
@@ -202,7 +202,9 @@ RSpec.describe "expect { ... }.to change(actual, message)" do
       end.to fail_with(/^expected #some_value to have changed, but is still/)
     end
   end
+end
 
+RSpec.describe "expect { ... }.to change(actual, message)" do
   context "with a missing message" do
     it "fails with an ArgumentError" do
       expect do
@@ -230,7 +232,6 @@ RSpec.describe "expect { ... }.not_to change(actual, message)" do
 end
 
 RSpec.describe "expect { ... }.to change { block }" do
-
   before(:example) do
     @instance = SomethingExpected.new
     @instance.some_value = 5
@@ -255,13 +256,6 @@ RSpec.describe "expect { ... }.to change { block }" do
   it "provides a #description" do
     expect(change { @instance.some_value }.description).to eq "change result"
   end
-
-  context "with an IO stream" do
-    it "passes when the stream does not change" do
-      k = STDOUT
-      expect { }.not_to change { k }
-    end
-  end
 end
 
 RSpec.describe "expect { ... }.not_to change { block }" do
@@ -285,8 +279,14 @@ RSpec.describe "expect { ... }.not_to change { block }" do
       expect {}.not_to change do; end
     end.to raise_error(SyntaxError, /Block not received by the `change` matcher/)
   end
-end
 
+  context "with an IO stream" do
+    it "passes when the stream does not change" do
+      k = STDOUT
+      expect { }.not_to change { k }
+    end
+  end
+end
 
 RSpec.describe "expect { ... }.not_to change { }.from" do
   context 'when the value starts at the from value' do
@@ -466,7 +466,6 @@ RSpec.describe "expect { ... }.to change { block }.by_at_least(expected)" do
   end
 end
 
-
 RSpec.describe "expect { ... }.to change(actual, message).by_at_most(expected)" do
   before(:example) do
     @instance = SomethingExpected.new
@@ -534,6 +533,7 @@ RSpec.describe "expect { ... }.to change(actual, message).from(old)" do
       end.to fail_with("expected #some_value to have initially been false, but was true")
     end
   end
+
   context "with non-boolean values" do
     before(:example) do
       @instance = SomethingExpected.new

--- a/spec/rspec/matchers/built_in/satisfy_spec.rb
+++ b/spec/rspec/matchers/built_in/satisfy_spec.rb
@@ -14,15 +14,34 @@ RSpec.describe "expect(...).to satisfy { block }" do
     end
   end
 
-  it "fails if block returns false" do
-    expect {
-      expect(false).to satisfy { |val| val }
-    }.to fail_with("expected false to satisfy block")
-    expect do
-      expect(false).to satisfy do |val|
-        val
+  context "when no custom description is provided" do
+    context 'in Ripper supported environment', :if => RSpec::Support::RubyFeatures.ripper_supported? do
+      it "fails with block snippet if block returns false" do
+        expect {
+          expect(false).to satisfy { |val| val }
+        }.to fail_with("expected false to satisfy expression `val`")
+
+        expect do
+          expect(false).to satisfy do |val|
+            val
+          end
+        end.to fail_with("expected false to satisfy expression `val`")
       end
-    end.to fail_with("expected false to satisfy block")
+    end
+
+    context 'in Ripper unsupported environment', :unless => RSpec::Support::RubyFeatures.ripper_supported? do
+      it "fails without block snippet if block returns false" do
+        expect {
+          expect(false).to satisfy { |val| val }
+        }.to fail_with("expected false to satisfy block")
+
+        expect do
+          expect(false).to satisfy do |val|
+            val
+          end
+        end.to fail_with("expected false to satisfy block")
+      end
+    end
   end
 
   context "when a custom description is provided" do
@@ -58,10 +77,22 @@ RSpec.describe "expect(...).not_to satisfy { block }" do
     end
   end
 
-  it "fails if block returns true" do
-    expect {
-      expect(true).not_to satisfy { |val| val }
-    }.to fail_with("expected true not to satisfy block")
+  context "when no custom description is provided" do
+    context 'in Ripper supported environment', :if => RSpec::Support::RubyFeatures.ripper_supported? do
+      it "fails with block snippet if block returns true" do
+        expect {
+          expect(true).not_to satisfy { |val| val }
+        }.to fail_with("expected true not to satisfy expression `val`")
+      end
+    end
+
+    context 'in Ripper unsupported environment', :unless => RSpec::Support::RubyFeatures.ripper_supported? do
+      it "fails without block snippet if block returns true" do
+        expect {
+          expect(true).not_to satisfy { |val| val }
+        }.to fail_with("expected true not to satisfy block")
+      end
+    end
   end
 
   context "when a custom description is provided" do


### PR DESCRIPTION
This closes #937.

This PR depends on https://github.com/rspec/rspec-core/pull/2420 and https://github.com/rspec/rspec-support/pull/315.