### PR TITLE
Support block snippet extraction with aliased matchers

### DIFF
--- a/lib/rspec/matchers/built_in/base_matcher.rb
+++ b/lib/rspec/matchers/built_in/base_matcher.rb
@@ -22,6 +22,9 @@ module RSpec
         # @private
         attr_reader :actual, :expected, :rescued_exception
 
+        # @private
+        attr_writer :matcher_name
+
         def initialize(expected=UNDEFINED)
           @expected = expected unless UNDEFINED.equal?(expected)
         end
@@ -93,6 +96,15 @@ module RSpec
         # @private
         def self.matcher_name
           @matcher_name ||= underscore(name.split('::').last)
+        end
+
+        # @private
+        def matcher_name
+          if defined?(@matcher_name)
+            @matcher_name
+          else
+            self.class.matcher_name
+          end
         end
 
         # @private

--- a/lib/rspec/matchers/built_in/satisfy.rb
+++ b/lib/rspec/matchers/built_in/satisfy.rb
@@ -47,7 +47,7 @@ module RSpec
 
           def extract_block_snippet
             return nil unless @block
-            Expectations::BlockSnippetExtractor.try_extracting_single_line_body_of(@block, 'satisfy')
+            Expectations::BlockSnippetExtractor.try_extracting_single_line_body_of(@block, matcher_name)
           end
         else
           def block_representation

--- a/lib/rspec/matchers/dsl.rb
+++ b/lib/rspec/matchers/dsl.rb
@@ -35,6 +35,7 @@ module RSpec
 
         define_method(new_name) do |*args, &block|
           matcher = __send__(old_name, *args, &block)
+          matcher.matcher_name = new_name if matcher.respond_to?(:matcher_name=)
           klass.new(matcher, description_override)
         end
       end

--- a/spec/rspec/matchers/built_in/change_spec.rb
+++ b/spec/rspec/matchers/built_in/change_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe "expect { ... }.to change { block }" do
     context 'when used with an alias name' do
       alias_matcher :modify, :change
 
-      pending 'can extract the block snippet' do
+      it 'can extract the block snippet' do
         expect(modify { @instance.some_value }.description).to eq "modify `@instance.some_value`"
       end
     end

--- a/spec/rspec/matchers/built_in/satisfy_spec.rb
+++ b/spec/rspec/matchers/built_in/satisfy_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe "expect(...).to satisfy { block }" do
           end
         end.to fail_with("expected false to satisfy expression `val`")
       end
+
+      context 'when used with an alias name' do
+        alias_matcher :fulfill, :satisfy
+
+        it 'can extract the block snippet' do
+          expect {
+            expect(false).to fulfill { |val| val }
+          }.to fail_with("expected false to fulfill expression `val`")
+        end
+      end
     end
 
     context 'in Ripper unsupported environment', :unless => RSpec::Support::RubyFeatures.ripper_supported? do


### PR DESCRIPTION
Follow-up to https://github.com/rspec/rspec-expectations/pull/987.

The interface is not smart but we cannot pass matcher name to the constructor with the current matcher protocol.