### PR TITLE
Fix NoMethodError raised with &:symbol proc in #change and #satisfy

### DIFF
--- a/lib/rspec/expectations/block_snippet_extractor.rb
+++ b/lib/rspec/expectations/block_snippet_extractor.rb
@@ -52,11 +52,15 @@ module RSpec
       end
 
       def file_path
-        proc.source_location.first
+        source_location.first
       end
 
       def beginning_line_number
-        proc.source_location.last
+        source_location.last
+      end
+
+      def source_location
+        proc.source_location || raise(TargetNotFoundError, 'Could not find the target block')
       end
 
       Error = Class.new(StandardError)

--- a/lib/rspec/expectations/block_snippet_extractor.rb
+++ b/lib/rspec/expectations/block_snippet_extractor.rb
@@ -42,11 +42,13 @@ module RSpec
 
       if RSpec.respond_to?(:world)
         def source
+          raise TargetNotFoundError unless File.exist?(file_path)
           RSpec.world.source_from_file(file_path)
         end
       else
         RSpec::Support.require_rspec_support 'source'
         def source
+          raise TargetNotFoundError unless File.exist?(file_path)
           @source ||= RSpec::Support::Source.from_file(file_path)
         end
       end

--- a/lib/rspec/expectations/block_snippet_extractor.rb
+++ b/lib/rspec/expectations/block_snippet_extractor.rb
@@ -87,7 +87,6 @@ module RSpec
             source.tokens.each do |token|
               invoke_state_handler(token)
             end
-            raise TargetNotFoundError, 'Could not find the target block'
           end
         end
 

--- a/lib/rspec/expectations/block_snippet_extractor.rb
+++ b/lib/rspec/expectations/block_snippet_extractor.rb
@@ -60,7 +60,7 @@ module RSpec
       end
 
       def source_location
-        proc.source_location || raise(TargetNotFoundError, 'Could not find the target block')
+        proc.source_location || raise(TargetNotFoundError)
       end
 
       Error = Class.new(StandardError)
@@ -221,9 +221,9 @@ module RSpec
           when 1
             candidate_block_wrapper_nodes.first
           when 0
-            raise TargetNotFoundError, 'Could not find the target block'
+            raise TargetNotFoundError
           else
-            raise AmbiguousTargetError, "There're multiple blocks with the same name method call on the line"
+            raise AmbiguousTargetError
           end
         end
 

--- a/spec/rspec/expectations/block_snippet_extractor_spec.rb
+++ b/spec/rspec/expectations/block_snippet_extractor_spec.rb
@@ -291,6 +291,16 @@ module RSpec::Expectations
           expect { body_content_lines }.to raise_error(BlockSnippetExtractor::TargetNotFoundError)
         end
       end
+
+      context 'with &:symbol syntax' do
+        let(:expression) do
+          target_method(&:positive?)
+        end
+
+        it 'raises TargetNotFoundError' do
+          expect { body_content_lines }.to raise_error(BlockSnippetExtractor::TargetNotFoundError)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Ref: https://github.com/rspec/rspec-expectations/issues/989