### PR TITLE
Use clearer variable names in documentation (features).

### DIFF
--- a/features/syntax_configuration.feature
+++ b/features/syntax_configuration.feature
@@ -50,8 +50,8 @@ Feature: Syntax Configuration
     Given a file named "spec/spec_helper.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.expect_with :rspec do |c|
-          c.syntax = :expect
+        config.expect_with :rspec do |expectations|
+          expectations.syntax = :expect
         end
       end
       """
@@ -64,11 +64,11 @@ Feature: Syntax Configuration
     Given a file named "spec/spec_helper.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.expect_with :rspec do |c|
-          c.syntax = :should
+        config.expect_with :rspec do |expectations|
+          expectations.syntax = :should
         end
-        config.mock_with :rspec do |c|
-          c.syntax = :should
+        config.mock_with :rspec do |mocks|
+          mocks.syntax = :should
         end
       end
       """
@@ -81,8 +81,8 @@ Feature: Syntax Configuration
     Given a file named "spec/spec_helper.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.expect_with :rspec do |c|
-          c.syntax = [:should, :expect]
+        config.expect_with :rspec do |expectations|
+          expectations.syntax = [:should, :expect]
         end
       end
       """


### PR DESCRIPTION
Many times I have looked at, or copy-pasted, the stanza from https://relishapp.com/rspec/rspec-expectations/v/3-6/docs/syntax-configuration which goes:

```ruby
RSpec.configure do |config|
  config.expect_with :rspec do |c|
    c.syntax = :expect
  end
end
```

This is unsatisfying, because of the two nested blocks perhaps, but even more so because of the variable `c`. Does it stand for "configuration"? If so, how is it different from `config`? I didn't really think of fixing this until I saw https://relishapp.com/rspec/rspec-mocks/v/3-6/docs/old-syntax which names the analogous variables `mocks` instead of `c`. And so epiphany struck: not only is `expectations` a better name than `c` (just in general), but it also helps with another confusion: the need to set expect syntax both for `expect_with` and `mock_with` (if you want both). It makes the whole stanza look more like "I am configuring rspec-expectations" and less like "here is some random rspec line noise which I copy-paste to do the thing".