### PR TITLE
Improve predicate matcher message for `be_something?`

### DIFF
--- a/lib/rspec/matchers/built_in/be.rb
+++ b/lib/rspec/matchers/built_in/be.rb
@@ -278,6 +278,8 @@ module RSpec
             msg << " or perhaps you meant `be true` or `be_truthy`"
           elsif predicate == :false?
             msg << " or perhaps you meant `be false` or `be_falsey`"
+          elsif predicate.to_s.end_with?('??')
+            msg << " or perhaps you meant `be_#{@expected[0..-2]}`(without question suffix)"
           end
 
           msg

--- a/lib/rspec/matchers/built_in/has.rb
+++ b/lib/rspec/matchers/built_in/has.rb
@@ -91,10 +91,13 @@ module RSpec
         end
 
         def validity_message
+          msg = "expected #{@actual} to respond to `#{predicate}`"
           if private_predicate?
-            "expected #{@actual} to respond to `#{predicate}` but `#{predicate}` is a private method"
+            msg << " but `#{predicate}` is a private method"
+          elsif @method_name.to_s.end_with?('?')
+            msg << " or perhaps you meant `#{@method_name.to_s[0..-2]}`(without question suffix)"
           elsif !predicate_exists?
-            "expected #{@actual} to respond to `#{predicate}`"
+            msg
           end
         end
       end

--- a/spec/rspec/matchers/built_in/be_spec.rb
+++ b/spec/rspec/matchers/built_in/be_spec.rb
@@ -158,6 +158,13 @@ RSpec.describe "expect(...).to be_predicate" do
       expect(actual).to be_false
     }.not_to raise_error
   end
+
+  it "indicates droping a question when using `be_something?`" do
+    actual = double("actual")
+    expect {
+      expect(actual).to be_something?
+    }.to fail_with(/or perhaps you meant `be_something`\(without question suffix\)/)
+  end
 end
 
 RSpec.describe "expect(...).not_to be_predicate" do

--- a/spec/rspec/matchers/built_in/has_spec.rb
+++ b/spec/rspec/matchers/built_in/has_spec.rb
@@ -84,6 +84,12 @@ RSpec.describe "expect(...).to have_sym(*args)" do
     }.to fail_including('to respond to `has_key?`')
   end
 
+  it "fails if target does not respond to #has_sym??" do
+    expect {
+      expect(Object.new).to have_key?(:a)
+    }.to fail_including('or perhaps you meant `have_key`(without question suffix)')
+  end
+
   it "reraises an exception thrown in #has_sym?(*args)" do
     o = Object.new
     def o.has_sym?(*args)


### PR DESCRIPTION
I sometimes write `expect(actual).to be_something?` by mistake. Actually, `expect(actual).to be_something` is correct (without the question suffix).

Currently, RSpec tells me about this mistake, but the message is not easy to understand.

```
expected actual to respond to `something?`
```

By this change, RSpec tells me about this mistake with more descriptive message.

```
expected actual to respond to `something?` or perhaps you meant `be_something`(without question suffix)
```