### PR TITLE
Raise warning when matching raise_error(StandardError) without a message

### DIFF
--- a/lib/rspec/matchers/built_in/raise_error.rb
+++ b/lib/rspec/matchers/built_in/raise_error.rb
@@ -12,7 +12,7 @@ module RSpec
         def initialize(expected_error_or_message=nil, expected_message=nil, &block)
           @block = block
           @actual_error = nil
-          @warn_about_bare_error = expected_error_or_message.nil?
+          @warn_about_bare_error = expected_error_or_message.nil? || expected_error_or_message == StandardError && expected_message.nil?
 
           case expected_error_or_message
           when nil

--- a/spec/rspec/matchers/built_in/raise_error_spec.rb
+++ b/spec/rspec/matchers/built_in/raise_error_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe "expect { ... }.to raise_error" do
     expect { raise }.to raise_error
   end
 
+  it "issues a warning when used with StandardError without a message" do
+    expect_warning_with_call_site __FILE__, __LINE__+1, /without providing a specific error/
+    expect { raise StandardError.new }.to raise_error(StandardError)
+  end
+
+  it "does not issue a warning when used with StandardError with a message" do
+    expect_no_warnings
+    expect { raise StandardError.new("message") }.to raise_error(StandardError, "message")
+  end
+
   it 'issues a warning that includes the current error when used without an error class or message' do
     expect_warning_with_call_site __FILE__, __LINE__+1, /Actual error raised was #<StandardError: boom>/
     expect { raise StandardError.new, 'boom'}.to raise_error
@@ -99,9 +109,10 @@ RSpec.describe "expect { ... }.to raise_error" do
   end
 
   it "passes if an error class is expected and an instance of that class is thrown" do
-    s = StandardError.new :bees
+    CustomErrorClass = Class.new(StandardError)
+    s = CustomErrorClass.new :bees
 
-    expect { raise s }.to raise_error(StandardError)
+    expect { raise s }.to raise_error(CustomErrorClass)
   end
 
   it "fails if nothing is raised" do


### PR DESCRIPTION
Same as raise_error, raise_error(StandardError) is prone to catch
NoMethodError, NameError, ArgumentError, mistakenly allowing tests to
pass without even executing wanted codepath.