### PR TITLE
Use `hash` for `change` matcher to handle deeply nested objects.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,11 @@
 
 * Improve failure message of `change(receiver, :message)` by including the
   receiver as `SomeClass#some_message`. (Tomohiro Hashidate, #1005)
+* Improve `change` matcher so that it can correctly detect changes in
+  deeply nested mutable objects (such as arrays-of-hashes-of-arrays).
+  The improved logic uses the before/after `hash` value to see if the
+  object has been mutated, rather than shallow duping the object.
+  (Myron Marston, #1034)
 
 ### 3.7.0 / 2017-10-17
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.6.0...v3.7.0)

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -480,7 +480,10 @@ module RSpec
     # == Notes
     #
     # Evaluates `receiver.message` or `block` before and after it
-    # evaluates the block passed to `expect`.
+    # evaluates the block passed to `expect`. If the value is the same
+    # object, its before/after `hash` value is used to see if it has changed.
+    # Therefore, your object needs to properly implement `hash` to work correctly
+    # with this matcher.
     #
     # `expect( ... ).not_to change` supports the form that specifies `from`
     # (which specifies what you expect the starting, unchanged value to be)

--- a/lib/rspec/matchers/built_in/change.rb
+++ b/lib/rspec/matchers/built_in/change.rb
@@ -331,7 +331,7 @@ module RSpec
       # etc, which are derived from the `before` value may not be accurate if
       # they are lazily computed as needed. We must pre-compute them before
       # applying the change in the `expect` block. To ensure that all `change`
-      # matchers do that properly, we do not expeose the `actual_before` value.
+      # matchers do that properly, we do not expose the `actual_before` value.
       # Instead, matchers must pass a block to `perform_change`, which yields
       # the `actual_before` value before applying the change.
       class ChangeDetails
@@ -377,16 +377,18 @@ module RSpec
         end
 
         def changed?
-          if @actual_before.__id__ == @actual_after.__id__
-            # The same object was returned both before and after; to see if
-            # it changed we have to check the hash value since `x == x` for
-            # all objects, regardless of how the object was mutated.
-            @before_hash != @actual_after.hash
-          else
-            # We do not want to use the hash in the general case as objects of
-            # different classes can return the same hash value.
-            @actual_before != @actual_after
-          end
+          # Consider it changed if either:
+          #
+          # - The before/after values are unequal
+          # - The before/after values have different hash values
+          #
+          # The latter case specifically handles the case when the value proc
+          # returns the exact same object, but it has been mutated.
+          #
+          # Note that it is not sufficient to only check the hashes; it is
+          # possible for two values to be unequal (and of different classes)
+          # but to return the same hash value.
+          @actual_before != @actual_after || @before_hash != @actual_after.hash
         end
 
         def actual_delta

--- a/spec/rspec/matchers/built_in/change_spec.rb
+++ b/spec/rspec/matchers/built_in/change_spec.rb
@@ -109,6 +109,58 @@ RSpec.describe "expect { ... }.to change ..." do
     end
   end
 
+  context "with a deeply nested object graph" do
+    it "passes when a leaf is changed" do
+      data = [{ :a => [1, 2] }]
+      expect { data[0][:a] << 3 }.to change { data }
+    end
+
+    it 'fails when no part of it is changed' do
+      data = [{ :a => [1, 2] }]
+      failure_msg = /expected #{value_pattern} to have changed, but is still #{regexp_inspect data}/
+
+      expect {
+        expect { data.to_s }.to change { data }
+      }.to fail_with(failure_msg)
+    end
+
+    it "passes when correctly specifying the exact mutation of a leaf" do
+      data = [{ :a => [1, 2] }]
+
+      expect { data[0][:a] << 3 }.to change { data }.
+          from([{ :a => [1, 2] }]).
+          to([{ :a => [1, 2, 3] }])
+    end
+
+    it "fails when wrongly specifying the `from` value" do
+      data = [{ :a => [1, 2] }]
+      expected_initial = [{ :a => [1] }]
+      failure_msg = /expected #{value_pattern} to have initially been #{regexp_inspect expected_initial}, but was #{regexp_inspect data}/
+
+      expect {
+        expect { data[0][:a] << 3 }.to change { data }.
+            from(expected_initial).
+            to([{ :a => [1, 2, 3] }])
+      }.to fail_with(failure_msg)
+    end
+
+    it "fails when wrongly specifying the `to` value" do
+      data = [{ :a => [1, 2] }]
+      expected_final = [{ :a => [1] }]
+      failure_msg = /expected #{value_pattern} to have changed to #{regexp_inspect expected_final}, but is now #{regexp_inspect [{ :a => [1, 2, 3] }]}/
+
+      expect {
+        expect { data[0][:a] << 3 }.to change { data }.
+            from([{ :a => [1, 2] }]).
+            to(expected_final)
+      }.to fail_with(failure_msg)
+    end
+
+    def regexp_inspect(object)
+      Regexp.escape(object.inspect)
+    end
+  end
+
   context "with an array" do
     before(:example) do
       @instance = SomethingExpected.new
@@ -190,6 +242,10 @@ RSpec.describe "expect { ... }.to change ..." do
 
         def ==(other)
           elements == other.elements
+        end
+
+        def hash
+          elements.hash
         end
       end.new
     end
@@ -366,6 +422,34 @@ RSpec.describe "expect { ... }.not_to change { block }" do
     it "passes when the stream does not change" do
       k = STDOUT
       expect { }.not_to change { k }
+    end
+  end
+
+  context "with a deeply nested object graph" do
+    it "passes when the object is changed" do
+      data = [{ :a => [1, 2] }]
+      expect { data.to_s }.not_to change { data }
+    end
+
+    it 'fails when part of it is changed' do
+      data = [{ :a => [1, 2] }]
+      failure_msg = /expected #{value_pattern} not to have changed, but did change from #{regexp_inspect data} to #{regexp_inspect [{:a=>[1, 2, 3]}]}/
+
+      expect {
+        expect { data[0][:a] << 3 }.not_to change { data }
+      }.to fail_with(failure_msg)
+    end
+
+    it "passes when correctly specifying the exact mutation of a leaf" do
+      data = [{ :a => [1, 2] }]
+
+      expect { data[0][:a] << 3 }.to change { data }.
+          from([{ :a => [1, 2] }]).
+          to([{ :a => [1, 2, 3] }])
+    end
+
+    def regexp_inspect(object)
+      Regexp.escape(object.inspect)
     end
   end
 end

--- a/spec/rspec/matchers/built_in/change_spec.rb
+++ b/spec/rspec/matchers/built_in/change_spec.rb
@@ -92,6 +92,15 @@ RSpec.describe "expect { ... }.to change ..." do
     end
   end
 
+  it 'correctly detects a change that both mutates and replaces an object' do
+    obj = Struct.new(:x).new([])
+
+    expect {
+      obj.x << 1 # mutate it
+      obj.x = [1] # replace it
+    }.to change { obj.x }
+  end
+
   context "with nil value" do
     before(:example) do
       @instance = SomethingExpected.new


### PR DESCRIPTION
Fixes #1030.