### PR TITLE
Update yard to 0.9.12, motivated by CVE.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ branch = File.read(File.expand_path("../maintenance-branch", __FILE__)).chomp
 end
 
 gem 'coderay' # for syntax highlighting
-gem 'yard', '0.8.7.4', :require => false
+gem 'yard', '~> 0.9.12', :require => false
 
 ### deps for rdoc.info
 group :documentation do

--- a/lib/rspec/expectations/minitest_integration.rb
+++ b/lib/rspec/expectations/minitest_integration.rb
@@ -53,6 +53,6 @@ module RSpec
   module Expectations
     remove_const :ExpectationNotMetError
     # Exception raised when an expectation fails.
-    ExpectationNotMetError = ::Minitest::Assertion
+    const_set :ExpectationNotMetError, ::Minitest::Assertion
   end
 end

--- a/lib/rspec/expectations/syntax.rb
+++ b/lib/rspec/expectations/syntax.rb
@@ -106,7 +106,7 @@ if defined?(BasicObject)
   # that this syntax does not always play nice with delegate/proxy objects.
   # We recommend you use the non-monkeypatching `:expect` syntax instead.
   class BasicObject
-    # @method should
+    # @method should(matcher, message)
     # Passes if `matcher` returns true.  Available on every `Object`.
     # @example
     #   actual.should eq expected
@@ -118,7 +118,7 @@ if defined?(BasicObject)
     # @note This is only available when you have enabled the `:should` syntax.
     # @see RSpec::Matchers
 
-    # @method should_not
+    # @method should_not(matcher, message)
     # Passes if `matcher` returns false.  Available on every `Object`.
     # @example
     #   actual.should_not eq expected

--- a/lib/rspec/matchers/built_in/contain_exactly.rb
+++ b/lib/rspec/matchers/built_in/contain_exactly.rb
@@ -176,6 +176,7 @@ module RSpec
         #
         # @private
         class PairingsMaximizer
+          # @private
           Solution = Struct.new(:unmatched_expected_indexes,     :unmatched_actual_indexes,
                                 :indeterminate_expected_indexes, :indeterminate_actual_indexes) do
             def worse_than?(other)

--- a/lib/rspec/matchers/composable.rb
+++ b/lib/rspec/matchers/composable.rb
@@ -156,10 +156,12 @@ module RSpec
       # Wraps an item in order to surface its `description` via `inspect`.
       # @api private
       DescribableItem = Struct.new(:item) do
+        # Inspectable version of the item description
         def inspect
           "(#{item.description})"
         end
 
+        # A pretty printed version of the item description.
         def pretty_print(pp)
           pp.text "(#{item.description})"
         end

--- a/lib/rspec/matchers/generated_descriptions.rb
+++ b/lib/rspec/matchers/generated_descriptions.rb
@@ -23,6 +23,7 @@ module RSpec
 
   private
 
+    # @private
     def self.last_description
       last_matcher.respond_to?(:description) ? last_matcher.description : <<-MESSAGE
 When you call a matcher in an example without a String, like this:


### PR DESCRIPTION
* Added @private tag for nested class (no longer inherits).
* Included full method definition in generated should/should_not docs.
* Used const_set for constant redefinition, since using = confuses YARD.
* Added short descriptions to methods that are @api private. Could
  probably just @private the lot but didn't want to make that decision
  here.