### PR TITLE
Upgrade rubocop, motivated by CVE.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
-inherit_from: .rubocop_rspec_base.yml
+inherit_from:
+  - .rubocop_rspec_base.yml
 
 # Over time we'd like to get this down, but this is what we're at now.
 LineLength:
@@ -7,3 +8,36 @@ LineLength:
 # We have some situations where we need to use `raise ExceptionClass.new(argument)`.
 Style/RaiseArgs:
   Enabled: false
+
+Metrics/AbcSize:
+  Max: 26
+
+# Offense count: 2
+# Configuration parameters: CountComments, ExcludedMethods.
+Metrics/BlockLength:
+  Max: 96
+
+# Offense count: 1
+# Configuration parameters: CountComments.
+Metrics/ModuleLength:
+  Max: 236
+
+# Offense count: 4
+Metrics/PerceivedComplexity:
+  Max: 14
+
+AccessModifierIndentation:
+  Exclude:
+    - 'lib/rspec/expectations/syntax.rb' # Too much diff to fix
+
+# Offense count: 6
+Lint/IneffectiveAccessModifier:
+  Exclude:
+    - 'lib/rspec/matchers.rb'
+    - 'lib/rspec/matchers/built_in/compound.rb'
+    - 'lib/rspec/matchers/expecteds_for_multiple_diffs.rb'
+    - 'lib/rspec/matchers/generated_descriptions.rb'
+
+Lint/InheritException:
+  Exclude:
+    - 'lib/rspec/expectations.rb'

--- a/.rubocop_rspec_base.yml
+++ b/.rubocop_rspec_base.yml
@@ -5,7 +5,7 @@
 # can customize by inheriting this file and overriding particular settings.
 
 AccessModifierIndentation:
-  EnforcedStyle: outdent
+  Enabled: false
 
 # "Use alias_method instead of alias"
 # We're fine with `alias`.
@@ -50,9 +50,6 @@ DoubleNegation:
 EachWithObject:
   Enabled: false
 
-Encoding:
-  EnforcedStyle: when_needed
-
 FormatString:
   EnforcedStyle: percent
 
@@ -73,7 +70,7 @@ MethodLength:
   Max: 15
 
 # Who cares what we call the argument for binary operator methods?
-OpMethod:
+BinaryOperatorParameterName:
   Enabled: false
 
 PercentLiteralDelimiters:
@@ -98,9 +95,6 @@ PredicateName:
 Proc:
   Enabled: false
 
-RedundantReturn:
-  AllowMultipleReturnValues: true
-
 # Exceptions should be rescued with `Support::AllExceptionsExceptOnesWeMustNotRescue`
 RescueException:
   Enabled: true
@@ -121,10 +115,196 @@ StringLiterals:
 Style/SpecialGlobalVars:
   Enabled: false
 
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
   Enabled: false
 
 TrivialAccessors:
   AllowDSLWriters: true
   AllowPredicates: true
   ExactNameMatch: true
+
+Style/ParallelAssignment:
+  Enabled: false
+
+Layout/EmptyLineBetweenDefs:
+  Enabled: false
+
+Layout/FirstParameterIndentation:
+  Enabled: false
+
+Naming/ConstantName:
+  Enabled: false
+
+Style/ClassCheck:
+  Enabled: false
+
+Style/ConditionalAssignment:
+  Enabled: false
+
+Style/EmptyMethod:
+  Enabled: false
+
+Style/FormatStringToken:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/IdenticalConditionalBranches:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/IfUnlessModifierOfIfUnless:
+  Enabled: false
+
+Style/MethodMissing:
+  Enabled: false
+
+Style/MixinUsage:
+  Enabled: false
+
+Style/MultipleComparison:
+  Enabled: false
+
+Style/MutableConstant:
+  Enabled: false
+
+Style/NestedModifier:
+  Enabled: false
+
+Style/NestedParenthesizedCalls:
+  Enabled: false
+
+Style/NumericPredicate:
+  Enabled: false
+
+Style/RedundantParentheses:
+  Enabled: false
+
+Style/StringLiteralsInInterpolation:
+  Enabled: false
+
+Style/SymbolArray:
+  Enabled: false
+
+Style/SymbolProc:
+  Enabled: false
+
+Style/YodaCondition:
+  Enabled: false
+
+Style/ZeroLengthPredicate:
+  Enabled: false
+
+Layout/ClosingParenthesisIndentation:
+  Enabled: false
+
+Layout/ExtraSpacing:
+  Enabled: false
+
+Layout/MultilineMethodCallBraceLayout:
+  Enabled: false
+
+Layout/MultilineMethodCallIndentation:
+  Enabled: false
+
+Layout/MultilineOperationIndentation:
+  Enabled: false
+
+Layout/SpaceAroundBlockParameters:
+  Enabled: false
+
+Layout/SpaceAroundOperators:
+  Enabled: false
+
+Layout/SpaceBeforeComma:
+  Enabled: false
+
+Style/BlockDelimiters:
+  Enabled: false
+
+Style/EmptyCaseCondition:
+  Enabled: false
+
+Style/MultilineIfModifier:
+  Enabled: false
+
+Style/RescueStandardError:
+  Enabled: false
+
+Style/StderrPuts:
+  Enabled: false
+
+Style/TernaryParentheses:
+  Enabled: false
+
+# This could likely be enabled, but it had a false positive on rspec-mocks
+# (suggested change was not behaviour preserving) so I don't trust it.
+Performance/HashEachMethods:
+  Enabled: false
+
+Naming/HeredocDelimiterNaming:
+  Enabled: false
+
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+
+Layout/IndentArray:
+  Enabled: false
+
+Layout/IndentAssignment:
+  Enabled: false
+
+Layout/IndentHeredoc:
+  Enabled: false
+
+Layout/SpaceInsidePercentLiteralDelimiters:
+  Enabled: false
+
+Style/EmptyElse:
+  Enabled: false
+
+Style/IfInsideElse:
+  Enabled: false
+
+Style/RedundantReturn:
+  Enabled: false
+
+Style/StructInheritance:
+  Enabled: false
+
+Naming/VariableNumber:
+  Enabled: false
+
+Layout/SpaceInsideStringInterpolation:
+  Enabled: false
+
+Style/DateTime:
+  Enabled: false
+
+Style/ParenthesesAroundCondition:
+  Enabled: false
+
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: false
+
+Lint/ImplicitStringConcatenation:
+  Enabled: false
+
+Lint/NestedMethodDefinition:
+  Enabled: false
+
+Style/RegexpLiteral:
+  Enabled: false
+
+Style/TrailingUnderscoreVariable:
+  Enabled: false
+
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: false
+

--- a/Gemfile
+++ b/Gemfile
@@ -39,9 +39,8 @@ platforms :rbx do
   gem 'rubysl'
 end
 
-if RUBY_VERSION >= '2' && RUBY_VERSION <= '2.1'
-  # todo upgrade rubocop and run on a recent version e.g. 2.3 or 2.4
-  gem 'rubocop', "~> 0.23.0"
+if RUBY_VERSION >= '2.4' && RUBY_ENGINE == 'ruby'
+  gem 'rubocop', "~> 0.52.1"
 end
 
 eval File.read('Gemfile-custom') if File.exist?('Gemfile-custom')

--- a/lib/rspec/expectations/block_snippet_extractor.rb
+++ b/lib/rspec/expectations/block_snippet_extractor.rb
@@ -1,7 +1,7 @@
 module RSpec
   module Expectations
     # @private
-    class BlockSnippetExtractor # rubocop:disable Style/ClassLength
+    class BlockSnippetExtractor # rubocop:disable Metrics/ClassLength
       # rubocop should properly handle `Struct.new {}` as an inner class definition.
 
       attr_reader :proc, :method_name

--- a/lib/rspec/matchers/built_in/compound.rb
+++ b/lib/rspec/matchers/built_in/compound.rb
@@ -3,7 +3,6 @@ module RSpec
     module BuiltIn
       # @api private
       # Base class for `and` and `or` compound matchers.
-      # rubocop:disable ClassLength
       class Compound < BaseMatcher
         # @private
         attr_reader :matcher_1, :matcher_2, :evaluator

--- a/lib/rspec/matchers/built_in/contain_exactly.rb
+++ b/lib/rspec/matchers/built_in/contain_exactly.rb
@@ -89,7 +89,7 @@ module RSpec
           elsif actual.respond_to?(:to_a) && !to_a_disallowed?(actual)
             @actual = actual.to_a
           else
-            return false
+            false
           end
         end
 

--- a/lib/rspec/matchers/built_in/has.rb
+++ b/lib/rspec/matchers/built_in/has.rb
@@ -77,7 +77,7 @@ module RSpec
         end
 
         def method_description
-          @method_name.to_s.gsub('_', ' ')
+          @method_name.to_s.tr('_', ' ')
         end
 
         def args_description

--- a/lib/rspec/matchers/built_in/respond_to.rb
+++ b/lib/rspec/matchers/built_in/respond_to.rb
@@ -151,7 +151,7 @@ module RSpec
                      @expected_keywords.map(&:inspect).join(' and ')
                    else
                      "#{@expected_keywords[0...-1].map(&:inspect).join(', ')}, and #{@expected_keywords.last.inspect}"
-          end
+                   end
 
           "keyword#{@expected_keywords.count == 1 ? '' : 's'} #{kw_str}"
         end

--- a/lib/rspec/matchers/built_in/satisfy.rb
+++ b/lib/rspec/matchers/built_in/satisfy.rb
@@ -34,7 +34,7 @@ module RSpec
           "expected #{actual_formatted} not to #{description}"
         end
 
-      private # rubocop:disable Lint/UselessAccessModifier
+      private
 
         if RSpec::Support::RubyFeatures.ripper_supported?
           def block_representation

--- a/lib/rspec/matchers/english_phrasing.rb
+++ b/lib/rspec/matchers/english_phrasing.rb
@@ -44,14 +44,14 @@ module RSpec
         # So it appears that `Array` can trigger that (e.g. by calling `to_a` on the passed object?)
         # So here we replace `Kernel#Array` with our own warning-free implementation for 1.8.7.
         # @private
-        # rubocop:disable Style/MethodName
+        # rubocop:disable Naming/MethodName
         def self.Array(obj)
           case obj
           when Array then obj
           else [obj]
           end
         end
-        # rubocop:enable Style/MethodName
+        # rubocop:enable Naming/MethodName
       end
     end
   end

--- a/lib/rspec/matchers/generated_descriptions.rb
+++ b/lib/rspec/matchers/generated_descriptions.rb
@@ -21,8 +21,6 @@ module RSpec
       "#{last_expectation_handler.verb} #{last_description}"
     end
 
-  private
-
     # @private
     def self.last_description
       last_matcher.respond_to?(:description) ? last_matcher.description : <<-MESSAGE

--- a/script/functions.sh
+++ b/script/functions.sh
@@ -180,7 +180,7 @@ function check_documentation_coverage {
 
 function check_style_and_lint {
   echo "bin/rubocop lib"
-  bin/rubocop lib
+  eval "(unset RUBYOPT; exec bin/rubocop lib)"
 }
 
 function run_all_spec_suites {


### PR DESCRIPTION
Defaulted most new things to off, though tried to keep performance and linters.

Note that `.rubocop_rspec_base` doesn't 100% match up with `rspec-dev` because I was adding to it as we went along. Once these are all merged I'm planning to ensure they're all consistent.