### PR TITLE
Don't use RSpec.configure to use the matcher DSL

### DIFF
--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -240,6 +240,7 @@ module RSpec
   #
   module Matchers
     extend ::RSpec::Matchers::DSL
+    include ::RSpec::Matchers::DSL
 
     # @!macro [attach] alias_matcher
     #   @!parse

--- a/lib/rspec/matchers/dsl.rb
+++ b/lib/rspec/matchers/dsl.rb
@@ -94,8 +94,6 @@ module RSpec
         # :nocov:
       end
 
-      RSpec.configure { |c| c.extend self } if RSpec.respond_to?(:configure)
-
       # Contains the methods that are available from within the
       # `RSpec::Matchers.define` DSL for creating custom matchers.
       module Macros


### PR DESCRIPTION
rspec-expectations shouldn't have knowledge of how to hook itself into rspec-core. rspec-core already includes the `RSpec::Matchers` module in example groups, so just including the module there (in addition to extending it) is enough to provide it to rspec-core, even if rspec-core hasn't been loaded yet and is loaded after rspec-expectations.

Fixes https://github.com/rspec/rspec/issues/122.