### PR TITLE
Pin ffi on RBX / 1.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,8 @@ end
 
 if RUBY_VERSION < '2.0.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)
   gem 'ffi', '< 1.9.15' # allow ffi to be installed on older rubies on windows
+elsif RUBY_VERSION < '1.9'
+  gem 'ffi', '< 1.9.19' # ffi dropped Ruby 1.8 support in 1.9.19
 end
 
 platforms :jruby do


### PR DESCRIPTION
FFI changed their minimum supported ruby version, so we'll have to pin it.

See https://travis-ci.org/rspec/rspec-expectations/jobs/354893396