### PR TITLE
Fix tests for 951 + rdoc first word needs to match the variable

### DIFF
--- a/lib/rspec/expectations/configuration.rb
+++ b/lib/rspec/expectations/configuration.rb
@@ -56,6 +56,19 @@ module RSpec
         end
       end
 
+      # Configures the maximum character length that RSpec will print while
+      # formatting an object
+      # @param [Fixnum] the length to format to
+      # @example
+      #   RSpec.configure do |rspec|
+      #     rspec.expect_with :rspec do |c|
+      #       c.max_formatted_output_length = 200
+      #     end
+      #   end
+      def max_formatted_output_length=(length)
+        RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length = length
+      end
+
       # The list of configured syntaxes.
       # @return [Array<Symbol>] the list of configured syntaxes.
       # @example

--- a/lib/rspec/expectations/configuration.rb
+++ b/lib/rspec/expectations/configuration.rb
@@ -58,7 +58,7 @@ module RSpec
 
       # Configures the maximum character length that RSpec will print while
       # formatting an object
-      # @param [Fixnum] the length to format to
+      # @param [Fixnum] length the number of characters to limit the formatted output to
       # @example
       #   RSpec.configure do |rspec|
       #     rspec.expect_with :rspec do |c|

--- a/spec/rspec/expectations/configuration_spec.rb
+++ b/spec/rspec/expectations/configuration_spec.rb
@@ -87,6 +87,20 @@ module RSpec
         end
       end
 
+      describe "#max_formatted_output_length=" do
+        let(:object_with_large_inspect_string) { Struct.new(:value).new("a"*300) }
+
+        it "sets the maximum object formatter length" do
+          config.max_formatted_output_length = 10
+          expect(RSpec::Support::ObjectFormatter.format(object_with_large_inspect_string)).to eq("#<stru...aaa\">")
+        end
+
+        it "formats the entire object when set to nil" do
+          config.max_formatted_output_length = nil
+          expect(RSpec::Support::ObjectFormatter.format(object_with_large_inspect_string)).to eq(object_with_large_inspect_string.inspect)
+        end
+      end
+
       describe "#warn_about_potential_false_positives?" do
         it "is true by default" do
           expect(config.warn_about_potential_false_positives?).to be true

--- a/spec/rspec/expectations/configuration_spec.rb
+++ b/spec/rspec/expectations/configuration_spec.rb
@@ -88,6 +88,14 @@ module RSpec
       end
 
       describe "#max_formatted_output_length=" do
+        before do
+          @orig_max_formatted_output_length = RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length
+        end
+
+        after do
+          config.max_formatted_output_length = @orig_max_formatted_output_length
+        end
+
         let(:object_with_large_inspect_string) { Struct.new(:value).new("a"*300) }
 
         it "sets the maximum object formatter length" do


### PR DESCRIPTION
Tests were leaking config changes.

It should fix #951