### PR TITLE
Add doc to inform that max_formatted_output_length can be set to nil

### DIFF
--- a/lib/rspec/expectations/configuration.rb
+++ b/lib/rspec/expectations/configuration.rb
@@ -57,8 +57,9 @@ module RSpec
       end
 
       # Configures the maximum character length that RSpec will print while
-      # formatting an object
-      # @param [Fixnum] length the number of characters to limit the formatted output to
+      # formatting an object. You can set length to nil to prevent RSpec from
+      # doing truncation.
+      # @param [Fixnum] length the number of characters to limit the formatted output to.
       # @example
       #   RSpec.configure do |rspec|
       #     rspec.expect_with :rspec do |c|


### PR DESCRIPTION
See : https://github.com/rspec/rspec-expectations/pull/1056#discussion_r184113835