### PR TITLE
Update Should.md to suggest is_expected in one-liners

### DIFF
--- a/Should.md
+++ b/Should.md
@@ -43,6 +43,14 @@ describe User do
 end
 ```
 
+It can also be expressed with the `is_expected` syntax:
+
+```ruby
+describe User do
+  it { is_expected.to validate_presence_of :email }
+end
+```
+
 ### Using either `expect` or `should` or both
 
 By default, both `expect` and `should` syntaxes are available. In the future,


### PR DESCRIPTION
### Description
This change updates `Should.md` to include a description about `is_expected` as suggested in #994. 

### Affected section
<img width="915" alt="screen shot 2018-06-06 at 2 12 31 pm" src="https://user-images.githubusercontent.com/2517299/41019996-c0789f7c-6993-11e8-9147-1cfcb3b96ffe.png">
