### PR TITLE
Call #to_hash only when object is not a Hash in RSpec::Matcher::BuiltIn::Include

### DIFF
--- a/lib/rspec/matchers/built_in/include.rb
+++ b/lib/rspec/matchers/built_in/include.rb
@@ -15,14 +15,14 @@ module RSpec
         # @api private
         # @return [Boolean]
         def matches?(actual)
-          actual = actual.to_hash if actual.respond_to?(:to_hash)
+          actual = actual.to_hash if convert_to_hash?(actual)
           perform_match(actual) { |v| v }
         end
 
         # @api private
         # @return [Boolean]
         def does_not_match?(actual)
-          actual = actual.to_hash if actual.respond_to?(:to_hash)
+          actual = actual.to_hash if convert_to_hash?(actual)
           perform_match(actual) { |v| !v }
         end
 
@@ -138,6 +138,10 @@ module RSpec
           expected.any? do |str|
             actual.include?(str) && lines.none? { |line| line == str }
           end
+        end
+
+        def convert_to_hash?(obj)
+          !(::Hash === obj) && obj.respond_to?(:to_hash)
         end
       end
     end


### PR DESCRIPTION
This PR should fix #1068.

With the change in #1012, `RSpec::Matchers::BuiltIn::Include` calls `#to_hash` to actual value. If actual value is a`ActiveSupport::HashWithIndifferentAccess`, `#to_hash` converts to ["a hash with string keys"](https://api.rubyonrails.org/classes/ActiveSupport/HashWithIndifferentAccess.html#method-i-to_hash). This behavior causes expectations like `expect(hsh).to include(:foo)` fail as reported in #1068.

This PR change to call `#to_hash` only when object is not a hash. Because `ActiveSupport::HashWithIndifferentAccess` inherits `Hash`, it will not call `#to_hash`, and `expect(hsh).to include(:foo)` should pass.