### PR TITLE
Support checking `initialize` when checking `respond_to(:new)`

### DIFF
--- a/lib/rspec/matchers/built_in/respond_to.rb
+++ b/lib/rspec/matchers/built_in/respond_to.rb
@@ -125,9 +125,18 @@ module RSpec
 
           return true if expectation.empty?
 
-          signature = Support::MethodSignature.new(Support.method_handle_for(actual, name))
+          Support::StrictSignatureVerifier.new(method_signature_for(actual, name)).
+            with_expectation(expectation).valid?
+        end
 
-          Support::StrictSignatureVerifier.new(signature).with_expectation(expectation).valid?
+        def method_signature_for(actual, name)
+          method_handle = Support.method_handle_for(actual, name)
+
+          if name == :new && method_handle.owner === ::Class && ::Class === actual
+            Support::MethodSignature.new(actual.instance_method(:initialize))
+          else
+            Support::MethodSignature.new(method_handle)
+          end
         end
 
         def with_arity


### PR DESCRIPTION
Following on from #1071 when we're checking the arity of a method for `respond_to` and the method being checked is a standard library `new` method, then we should actually check the method signature for the instance method `initialize`. This is similar to what we do in `rspec-mocks` for verifying doubles.

/cc @myronmarston as you wrote the inspiration!