### PR TITLE
Only call to_hash when actual object does not respond to include?

### DIFF
--- a/lib/rspec/matchers/built_in/include.rb
+++ b/lib/rspec/matchers/built_in/include.rb
@@ -141,7 +141,7 @@ module RSpec
         end
 
         def convert_to_hash?(obj)
-          !(::Hash === obj) && obj.respond_to?(:to_hash)
+          !obj.respond_to?(:include?) && obj.respond_to?(:to_hash)
         end
       end
     end

--- a/spec/rspec/matchers/built_in/include_spec.rb
+++ b/spec/rspec/matchers/built_in/include_spec.rb
@@ -128,6 +128,14 @@ RSpec.describe "#include matcher" do
       end
     end
 
+    context "for an arbitrary object that responds to `include?` and `to_hash`" do
+      it "delegates to `include?`" do
+        container = double("Container", :include? => true, :to_hash => {"foo" => "bar"})
+        expect(container).to receive(:include?).with("foo").and_return(true)
+        expect(container).to include("foo")
+      end
+    end
+
     context "for a string target" do
       it "passes if target includes expected" do
         expect("abc").to include("a")


### PR DESCRIPTION
According to the docs for the built-in include matcher, if an object responds to `#include?` that method will be called. Currently, if an object implements `#to_hash`, the `#include?` method on the returned `Hash` is called instead (unless the object is already a Hash).

This change in behavior was introduced in https://github.com/rspec/rspec-expectations/commit/a0c39589979befc8279c2d4f78579a504d7dfcff.