### PR TITLE
Handle unexpected Index / KeyError when looking up match results

### DIFF
--- a/lib/rspec/matchers/built_in/compound.rb
+++ b/lib/rspec/matchers/built_in/compound.rb
@@ -154,7 +154,12 @@ module RSpec
           end
 
           def matcher_matches?(matcher)
-            @match_results.fetch(matcher)
+            @match_results.fetch(matcher) do
+              raise ArgumentError, "Your #{matcher.description} has no match " \
+               "results, this can occur when an unexpected call stack or " \
+               "local jump occurs. Prehaps one of your matchers needs to " \
+               "declare `expects_call_stack_jump?` as `true`?"
+            end
           end
 
         private

--- a/spec/rspec/matchers/composable_spec.rb
+++ b/spec/rspec/matchers/composable_spec.rb
@@ -95,6 +95,28 @@ module RSpec
           expect(with_matchers_cloned([stdout]).first).to equal(stdout)
         end
       end
+
+      describe "when an unexpected call stack jump occurs" do
+        RSpec::Matchers.define :cause_call_stack_jump do
+          supports_block_expectations
+
+          match do |block|
+            begin
+              block.call
+              false
+            rescue Exception
+              true
+            end
+          end
+        end
+
+        it "issue a warning suggesting `expects_call_stack_jump?` has been improperly declared" do
+          expect {
+            x = 0
+            expect { x += 1; exit }.to change { x }.and cause_call_stack_jump
+          }.to raise_error(/no match results, [\.\w\s]+ declare `expects_call_stack_jump\?`/)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
When an unexpected local jump (and probably some other conditions) happens in some composed matchers, this result in an unexpected KeyError.

Fixes #1074 