### PR TITLE
Add ability for raise_error to create expectations on error attributes

### DIFF
--- a/features/built_in_matchers/raise_error.feature
+++ b/features/built_in_matchers/raise_error.feature
@@ -26,7 +26,11 @@ Feature: `raise_error` matcher
     expect { raise "oops" }.to raise_error(/op/)
     expect { raise "oops" }.to raise_error(RuntimeError, "oops")
     expect { raise "oops" }.to raise_error(RuntimeError, /op/)
+    expect { raise SystemExit.new(1, 'oops') } to raise_error(SystemExit).with_attributes(status: 1, message: 'oops')
+    expect { raise SystemExit.new(1, 'oops') } to raise_error(SystemExit).with_attributes(status: 1, message: /op/)
     ```
+
+  with_attributes uses the have_attributes matcher internally.  See the have_attributes matcher documentation for more details.
 
   Scenario: expect any error
     Given a file named "example_spec" with:
@@ -137,6 +141,34 @@ Feature: `raise_error` matcher
       RSpec.describe "#to_s" do
         it "does not raise" do
           expect { Object.new.to_s }.not_to raise_error
+        end
+      end
+      """
+    When I run `rspec example_spec`
+    Then the example should pass
+
+  Scenario: matching error attributes with `with_attributes`
+    Given a file named "spec/test_spec.rb" with:
+      """ruby
+      RSpec.describe 'raise_error matcher' do
+        specify do
+          expect { raise SystemExit.new(1, 'File not found') }.to(
+            raise_error(SystemExit).with_attributes(message: 'File not found', status: 1)
+          )
+        end
+      end
+      """
+    When I run `rspec spec/test_spec.rb`
+    Then the example should pass
+
+  Scenario: fuzzy matching error attributes with `with_attributes`
+    Given a file named "example_spec" with:
+      """ruby
+      RSpec.describe 'raise_error matcher' do
+        specify do
+          expect { raise RuntimeError, 'ERROR: File not found' }.to(
+            raise_error(RuntimeError).with_attributes(message: /not found/i)
+          )
         end
       end
       """


### PR DESCRIPTION
I could not find an easy way to to define an expectation for an error that has multiple attributes (like `SystemExit`.  Please let me know if I missed something.

This change adds a `with_attributes` chain to the `raise_error` matcher (like the existing `with_message` chain).

Internally, `with_attributes` uses the `have_attributes` matcher, so all functionality of that matcher is exposed with `with_attributes`.

Here is how it works:

```Ruby
expect { raise SystemExit.new(1, 'File not found') }.to(
  raise_error(SystemExit).with_attributes(message: 'File not found', status: 1)
)
```

or

```Ruby
expect { raise SystemExit.new(1, 'FILE NOT FOUND') }.to(
  raise_error(SystemExit).with_attributes(message: /not found/i, status: 1..255)
)
```

This change does not change any existing functionality.

I have followed all the directions and the checklist from https://github.com/rspec/rspec-expectations/blob/master/DEVELOPMENT.md