### PR TITLE
Replace "should" with "is expected to" in Generated Descriptions

### DIFF
--- a/features/custom_matchers/define_block_matcher.feature
+++ b/features/custom_matchers/define_block_matcher.feature
@@ -68,7 +68,7 @@ Feature: define a matcher supporting block expectations
       """
       Failures:
 
-        1) a custom block matcher should support blocks with errors
+        1) a custom block matcher is expected to support blocks with errors
            Failure/Error: expect(true).to eq false
 
              expected: false

--- a/features/custom_matchers/define_matcher.feature
+++ b/features/custom_matchers/define_matcher.feature
@@ -36,8 +36,8 @@ Feature: Define a custom matcher
     When I run `rspec ./matcher_with_default_message_spec.rb --format documentation`
     Then the exit status should not be 0
 
-    And the output should contain "should be a multiple of 3"
-    And the output should contain "should not be a multiple of 4"
+    And the output should contain "is expected to be a multiple of 3"
+    And the output should contain "is expected not to be a multiple of 4"
     And the output should contain "Failure/Error: it { is_expected.to be_a_multiple_of(4) }"
     And the output should contain "Failure/Error: it { is_expected.not_to be_a_multiple_of(3) }"
 
@@ -118,8 +118,8 @@ Feature: Define a custom matcher
     When I run `rspec ./matcher_overriding_description_spec.rb --format documentation`
     Then the exit status should be 0
     And the stdout should contain "2 examples, 0 failures"
-    And the stdout should contain "should be multiple of 3"
-    And the stdout should contain "should not be multiple of 4"
+    And the stdout should contain "is expected to be multiple of 3"
+    And the stdout should contain "is expected not to be multiple of 4"
 
   Scenario: With no args
     Given a file named "matcher_with_no_args_spec.rb" with:
@@ -143,7 +143,7 @@ Feature: Define a custom matcher
     When I run `rspec ./matcher_with_no_args_spec.rb --format documentation`
     Then the exit status should be 0
     And the stdout should contain "1 example, 0 failures"
-    And the stdout should contain "should have 7 fingers"
+    And the stdout should contain "is expected to have 7 fingers"
 
   Scenario: With multiple args
     Given a file named "matcher_with_multiple_args_spec.rb" with:
@@ -163,7 +163,7 @@ Feature: Define a custom matcher
     When I run `rspec ./matcher_with_multiple_args_spec.rb --format documentation`
     Then the exit status should be 0
     And the stdout should contain "1 example, 0 failures"
-    And the stdout should contain "should be the sum of 1, 2, 3, and 4"
+    And the stdout should contain "is expected to be the sum of 1, 2, 3, and 4"
 
   Scenario: With a block arg
     Given a file named "matcher_with_block_arg_spec.rb" with:
@@ -185,7 +185,7 @@ Feature: Define a custom matcher
     When I run `rspec ./matcher_with_block_arg_spec.rb --format documentation`
     Then the exit status should be 0
     And the stdout should contain "1 example, 0 failures"
-    And the stdout should contain "should be lazily equal to 10"
+    And the stdout should contain "is expected to be lazily equal to 10"
 
   Scenario: With helper methods
     Given a file named "matcher_with_internal_helper_spec.rb" with:

--- a/features/custom_matchers/define_matcher_with_fluent_interface.feature
+++ b/features/custom_matchers/define_matcher_with_fluent_interface.feature
@@ -21,7 +21,7 @@ Feature: define matcher with fluent interface
       """
     When I run `rspec between_spec.rb --format documentation`
     Then the output should contain "1 example, 0 failures"
-    And  the output should contain "should be bigger than 4"
+    And  the output should contain "is expected to be bigger than 4"
 
   Scenario: chained setter
     Given a file named "between_spec.rb" with:
@@ -40,7 +40,7 @@ Feature: define matcher with fluent interface
       """
     When I run `rspec between_spec.rb --format documentation`
     Then the output should contain "1 example, 0 failures"
-    And  the output should contain "should be bigger than 4"
+    And  the output should contain "is expected to be bigger than 4"
 
     Scenario: include_chain_clauses_in_custom_matcher_descriptions configured to true, and chained method with argument
       Given a file named "between_spec.rb" with:
@@ -67,4 +67,4 @@ Feature: define matcher with fluent interface
         """
       When I run `rspec between_spec.rb --format documentation`
       Then the output should contain "1 example, 0 failures"
-      And  the output should contain "should be bigger than 4 and smaller than 6"
+      And  the output should contain "is expected to be bigger than 4 and smaller than 6"

--- a/features/implicit_docstrings.feature
+++ b/features/implicit_docstrings.feature
@@ -23,9 +23,9 @@ Feature: implicit docstrings
 
     When I run `rspec ./implicit_docstrings_spec.rb -fdoc`
 
-    Then the output should contain "should be < 5"
-    And the output should contain "should include 2"
-    And the output should contain "should respond to #size"
+    Then the output should contain "is expected to be < 5"
+    And the output should contain "is expected to include 2"
+    And the output should contain "is expected to respond to #size"
 
   Scenario: run failing examples
     Given a file named "failing_implicit_docstrings_spec.rb" with:
@@ -45,7 +45,7 @@ Feature: implicit docstrings
 
     When I run `rspec ./failing_implicit_docstrings_spec.rb -fdoc`
 
-    Then the output should contain "should equal 2"
-    And the output should contain "should be > 5"
-    And the output should contain "should include 4"
-    And the output should contain "should not respond to #size"
+    Then the output should contain "is expected to equal 2"
+    And the output should contain "is expected to be > 5"
+    And the output should contain "is expected to include 4"
+    And the output should contain "is expected not to respond to #size"

--- a/lib/rspec/expectations/handler.rb
+++ b/lib/rspec/expectations/handler.rb
@@ -52,7 +52,7 @@ module RSpec
       end
 
       def self.verb
-        "should"
+        'is expected to'
       end
 
       def self.should_method
@@ -82,7 +82,7 @@ module RSpec
       end
 
       def self.verb
-        "should not"
+        'is expected not to'
       end
 
       def self.should_method

--- a/spec/rspec/matchers/description_generation_spec.rb
+++ b/spec/rspec/matchers/description_generation_spec.rb
@@ -1,56 +1,56 @@
-RSpec.describe "Matchers should be able to generate their own descriptions" do
+RSpec.describe 'a matcher is expected to be able to have its description generated' do
   after(:example) do
     RSpec::Matchers.clear_generated_description
   end
 
   example "expect(...).to eq expected" do
     expect("this").to eq "this"
-    expect(RSpec::Matchers.generated_description).to eq "should eq \"this\""
+    expect(RSpec::Matchers.generated_description).to eq "is expected to eq \"this\""
   end
 
   example "expect(...).to not eq expected" do
     expect("this").not_to eq "that"
-    expect(RSpec::Matchers.generated_description).to eq "should not eq \"that\""
+    expect(RSpec::Matchers.generated_description).to eq "is expected not to eq \"that\""
   end
 
   example "expect(...).to be empty (arbitrary predicate)" do
     expect([]).to be_empty
-    expect(RSpec::Matchers.generated_description).to eq "should be empty"
+    expect(RSpec::Matchers.generated_description).to eq "is expected to be empty"
   end
 
   example "expect(...).to not be empty (arbitrary predicate)" do
     expect([1]).not_to be_empty
-    expect(RSpec::Matchers.generated_description).to eq "should not be empty"
+    expect(RSpec::Matchers.generated_description).to eq "is expected not to be empty"
   end
 
   example "expect(...).to be truthy" do
     expect(true).to be_truthy
-    expect(RSpec::Matchers.generated_description).to eq "should be truthy"
+    expect(RSpec::Matchers.generated_description).to eq "is expected to be truthy"
   end
 
   example "expect(...).to be falsey" do
     expect(false).to be_falsey
-    expect(RSpec::Matchers.generated_description).to eq "should be falsey"
+    expect(RSpec::Matchers.generated_description).to eq "is expected to be falsey"
   end
 
   example "expect(...).to be nil" do
     expect(nil).to be_nil
-    expect(RSpec::Matchers.generated_description).to eq "should be nil"
+    expect(RSpec::Matchers.generated_description).to eq "is expected to be nil"
   end
 
   example "expect(...).to be > n" do
     expect(5).to be > 3
-    expect(RSpec::Matchers.generated_description).to eq "should be > 3"
+    expect(RSpec::Matchers.generated_description).to eq "is expected to be > 3"
   end
 
   example "expect(...).to be between min and max" do
     expect(10).to be_between(0, 10)
-    expect(RSpec::Matchers.generated_description).to eq "should be between 0 and 10 (inclusive)"
+    expect(RSpec::Matchers.generated_description).to eq "is expected to be between 0 and 10 (inclusive)"
   end
 
   example "expect(...).to be exclusively between min and max" do
     expect(9).to be_between(0, 10).exclusive
-    expect(RSpec::Matchers.generated_description).to eq "should be between 0 and 10 (exclusive)"
+    expect(RSpec::Matchers.generated_description).to eq "is expected to be between 0 and 10 (exclusive)"
   end
 
   example "expect(...).to be predicate arg1, arg2 and arg3" do
@@ -61,33 +61,33 @@ RSpec.describe "Matchers should be able to generate their own descriptions" do
       end
     end
     expect(Child.new).to be_a_child_of(Parent, Object)
-    expect(RSpec::Matchers.generated_description).to eq "should be a child of Parent and Object"
+    expect(RSpec::Matchers.generated_description).to eq "is expected to be a child of Parent and Object"
   end
 
   example "expect(...).to equal" do
     expected = "expected"
     expect(expected).to equal(expected)
-    expect(RSpec::Matchers.generated_description).to eq "should equal \"expected\""
+    expect(RSpec::Matchers.generated_description).to eq "is expected to equal \"expected\""
   end
 
   example "expect(...).not_to equal" do
     expect(5).not_to equal(37)
-    expect(RSpec::Matchers.generated_description).to eq "should not equal 37"
+    expect(RSpec::Matchers.generated_description).to eq "is expected not to equal 37"
   end
 
   example "expect(...).to eql" do
     expect("string").to eql("string")
-    expect(RSpec::Matchers.generated_description).to eq "should eql \"string\""
+    expect(RSpec::Matchers.generated_description).to eq "is expected to eql \"string\""
   end
 
   example "expect(...).not_to eql" do
     expect("a").not_to eql(:a)
-    expect(RSpec::Matchers.generated_description).to eq "should not eql :a"
+    expect(RSpec::Matchers.generated_description).to eq "is expected not to eql :a"
   end
 
   example "expect(...).to have_key" do
     expect({:a => "a"}).to have_key(:a)
-    expect(RSpec::Matchers.generated_description).to eq "should have key :a"
+    expect(RSpec::Matchers.generated_description).to eq "is expected to have key :a"
   end
 
   example "expect(...).to have_some_method" do
@@ -95,7 +95,7 @@ RSpec.describe "Matchers should be able to generate their own descriptions" do
     def object.has_eyes_closed?; true; end
 
     expect(object).to have_eyes_closed
-    expect(RSpec::Matchers.generated_description).to eq 'should have eyes closed'
+    expect(RSpec::Matchers.generated_description).to eq 'is expected to have eyes closed'
   end
 
   example "expect(...).to have_some_method(args*)" do
@@ -103,18 +103,18 @@ RSpec.describe "Matchers should be able to generate their own descriptions" do
     def object.has_taste_for?(*args); true; end
 
     expect(object).to have_taste_for("wine", "cheese")
-    expect(RSpec::Matchers.generated_description).to eq 'should have taste for "wine", "cheese"'
+    expect(RSpec::Matchers.generated_description).to eq 'is expected to have taste for "wine", "cheese"'
   end
 
   example "expect(...).to include(x)" do
     expect([1,2,3]).to include(3)
-    expect(RSpec::Matchers.generated_description).to eq "should include 3"
+    expect(RSpec::Matchers.generated_description).to eq "is expected to include 3"
   end
 
   example "expect(...).to include(x) when x responds to description but is not a matcher" do
     obj = double(:description => "description", :inspect => "inspect")
     expect([obj]).to include(obj)
-    expect(RSpec::Matchers.generated_description).to eq "should include inspect"
+    expect(RSpec::Matchers.generated_description).to eq "is expected to include inspect"
   end
 
   example "expect(...).to include(x) when x responds to description and is a matcher" do
@@ -122,57 +122,57 @@ RSpec.describe "Matchers should be able to generate their own descriptions" do
                      :matches?                   => true,
                      :failure_message => "")
     expect([matcher]).to include(matcher)
-    expect(RSpec::Matchers.generated_description).to eq "should include (description)"
+    expect(RSpec::Matchers.generated_description).to eq "is expected to include (description)"
   end
 
   example "expect(array).to contain_exactly(1, 2, 3)" do
     expect([1,2,3]).to contain_exactly(1, 2, 3)
-    expect(RSpec::Matchers.generated_description).to eq "should contain exactly 1, 2, and 3"
+    expect(RSpec::Matchers.generated_description).to eq "is expected to contain exactly 1, 2, and 3"
   end
 
   example "expect(...).to match" do
     expect("this string").to match(/this string/)
-    expect(RSpec::Matchers.generated_description).to eq "should match /this string/"
+    expect(RSpec::Matchers.generated_description).to eq "is expected to match /this string/"
   end
 
   example "expect(...).to raise_error" do
     expect { raise 'foo' }.to raise_error Exception
-    expect(RSpec::Matchers.generated_description).to eq "should raise Exception"
+    expect(RSpec::Matchers.generated_description).to eq "is expected to raise Exception"
   end
 
   example "expect(...).to raise_error with class" do
     expect { raise }.to raise_error(RuntimeError)
-    expect(RSpec::Matchers.generated_description).to eq "should raise RuntimeError"
+    expect(RSpec::Matchers.generated_description).to eq "is expected to raise RuntimeError"
   end
 
   example "expect(...).to raise_error with class and message" do
     expect { raise "there was an error" }.to raise_error(RuntimeError, "there was an error")
-    expect(RSpec::Matchers.generated_description).to eq "should raise RuntimeError with \"there was an error\""
+    expect(RSpec::Matchers.generated_description).to eq "is expected to raise RuntimeError with \"there was an error\""
   end
 
   example "expect(...).to respond_to" do
     expect([]).to respond_to(:insert)
-    expect(RSpec::Matchers.generated_description).to eq "should respond to #insert"
+    expect(RSpec::Matchers.generated_description).to eq "is expected to respond to #insert"
   end
 
   example "expect(...).to throw symbol" do
     expect { throw :what_a_mess }.to throw_symbol
-    expect(RSpec::Matchers.generated_description).to eq "should throw a Symbol"
+    expect(RSpec::Matchers.generated_description).to eq "is expected to throw a Symbol"
   end
 
   example "expect(...).to throw symbol (with named symbol)" do
     expect { throw :what_a_mess }.to throw_symbol(:what_a_mess)
-    expect(RSpec::Matchers.generated_description).to eq "should throw :what_a_mess"
+    expect(RSpec::Matchers.generated_description).to eq "is expected to throw :what_a_mess"
   end
 
   example "expect(...).to matcher_that_delegates_to_an_internal_expectation" do
     expect(1).to matcher_that_delegates_to_an_internal_expectation
-    expect(RSpec::Matchers.generated_description).to eq "should matcher that delegates to an internal expectation"
+    expect(RSpec::Matchers.generated_description).to eq "is expected to matcher that delegates to an internal expectation"
   end
 
   example "expect(...).not_to matcher_that_delegates_to_an_internal_expectation" do
     expect(1).not_to matcher_that_delegates_to_an_internal_expectation
-    expect(RSpec::Matchers.generated_description).to eq "should not matcher that delegates to an internal expectation"
+    expect(RSpec::Matchers.generated_description).to eq "is expected not to matcher that delegates to an internal expectation"
   end
 
   RSpec::Matchers.define :matcher_that_delegates_to_an_internal_expectation do


### PR DESCRIPTION
#### Context

> [In version 2.11 `expect` method was introduced which is now the recommended way to define expectations on an object.](https://github.com/rspec/rspec-expectations/blob/955d603421fa50e739662983f8dc09b88ccaf731/Should.md#should-and-should_not-syntax) 

When `expect` is used without a description, "should" is used in the description that is generated.

#### Change

 - 473dc26 describes the change that we would like to see in the world
 - bfbc2b9 is my naive attempt to fix this

