### PR TITLE
Fix nested `all` repeated failure message

### DIFF
--- a/lib/rspec/matchers/built_in/all.rb
+++ b/lib/rspec/matchers/built_in/all.rb
@@ -73,6 +73,7 @@ module RSpec
 
         def initialize_copy(other)
           @matcher = @matcher.clone
+          @failed_objects = @failed_objects.clone
           super
         end
 

--- a/spec/rspec/matchers/built_in/all_spec.rb
+++ b/spec/rspec/matchers/built_in/all_spec.rb
@@ -143,6 +143,23 @@ module RSpec::Matchers::BuiltIn
       end
     end
 
+    context 'when composed in another matcher' do
+      it 'returns the indexes of the failed objects only' do
+        expect {
+          expect([[false], [true]]).to all( all( be(true) ) )
+        }.to fail_with(dedent <<-EOS)
+          |expected [[false], [true]] to all all equal true
+          |
+          |   object at index 0 failed to match:
+          |      expected [false] to all equal true
+          |
+          |         object at index 0 failed to match:
+          |            expected true
+          |                 got false
+          EOS
+      end
+    end
+
     shared_examples "making a copy" do |copy_method|
       context "when making a copy via `#{copy_method}`" do
 


### PR DESCRIPTION
`RSpec::Matchers::BuiltIn::All` keeps track of which objects failed at
which index of the actual value in a `@failed_objects` hash. The matcher
considers a match successful if `@failed_objects` is empty. When the
matcher is composed inside another matcher, the matcher gets cloned
before matching against each item in the actual collection.  The
`@failed_objects` hash doesn't itself get cloned, resulting in each
cloned matcher having a reference to the same hash. This means that once
a matcher (or one of its clones) fails – populating `@failed_objects` –,
each of its clones will fail matching regardless of whether it matched
or not, as each clone's `@failed_objects` reference is not empty. This
leads to behavior like the following, where we see the first failure
(expecting `false` to be `true`) repeated twice.

```
expect([[true], [false]]).to all(all(be(false)))

RSpec::Expectations::ExpectationNotMetError: expected [[true], [false]] to all all equal false

   object at index 0 failed to match:
      expected [true] to all equal false

         object at index 0 failed to match:
            expected false
                 got true

   object at index 1 failed to match:
      expected [false] to all equal false

         object at index 0 failed to match:
            expected false
                 got true
```

The solution here is to clone the `@failed_objects` hash when the
matcher itself is cloned. So long as the matcher itself is cloned
immediately after construction (while `@failed_objects` is empty)
– which is what actually happens – we avoid this bug.

Alternative solutions include:

* calling `@failed_objects.clear` at the start of each `matches?` call
* lazily defining `@failed_objects` (i.e. outside of the constructor) so
  that when the matcher is cloned, `@failed_objects` isn't defined yet
  and so cannot have shared references to it

However, the pattern already exists where, when the matcher is cloned,
its 'submatcher' (composed matcher) is cloned. Cloning `@failed_objects`
at this time follows the same pattern.