### PR TITLE
Add chained matchers example to raise_error

### DIFF
--- a/features/built_in_matchers/raise_error.feature
+++ b/features/built_in_matchers/raise_error.feature
@@ -138,7 +138,7 @@ Feature: `raise_error` matcher
       RSpec.describe "composing matchers" do
         it "raises StandardError" do
           expect { raise StandardError, "my message" }.
-            to raise_error(an_instance_of(StandardError).and having_attributes(message: "my message"))
+            to raise_error(an_instance_of(StandardError).and having_attributes({message: "my message"}))
         end
       end
       """

--- a/features/built_in_matchers/raise_error.feature
+++ b/features/built_in_matchers/raise_error.feature
@@ -26,6 +26,7 @@ Feature: `raise_error` matcher
     expect { raise "oops" }.to raise_error(/op/)
     expect { raise "oops" }.to raise_error(RuntimeError, "oops")
     expect { raise "oops" }.to raise_error(RuntimeError, /op/)
+    expect { raise "oops" }.to raise_error(an_instance_of(RuntimeError).and have_attributes(message: "oops"))
     ```
 
   Scenario: expect any error
@@ -125,6 +126,19 @@ Feature: `raise_error` matcher
           expect { Object.new.foo }.to raise_error { |error|
             expect(error).to be_a(NameError)
           }
+        end
+      end
+      """
+      When I run `rspec example_spec`
+      Then the example should pass
+      
+  Scenario: set expectations on error object with chained matchers
+    Given a file named "example_spec" with:
+      """
+      RSpec.describe "composing matchers" do
+        it "raises StandardError" do
+          expect { raise StandardError, "my message" }.to 
+            raise_error(an_instance_of(StandardError).and have_attributes(message: "my message"))
         end
       end
       """

--- a/features/built_in_matchers/raise_error.feature
+++ b/features/built_in_matchers/raise_error.feature
@@ -137,8 +137,8 @@ Feature: `raise_error` matcher
       """
       RSpec.describe "composing matchers" do
         it "raises StandardError" do
-          expect { raise StandardError, "my message" }.to
-            raise_error(an_instance_of(StandardError).and having_attributes(message: "my message"))
+          expect { raise StandardError, "my message" }.
+            to raise_error(an_instance_of(StandardError).and having_attributes(message: "my message"))
         end
       end
       """

--- a/features/built_in_matchers/raise_error.feature
+++ b/features/built_in_matchers/raise_error.feature
@@ -138,7 +138,7 @@ Feature: `raise_error` matcher
       RSpec.describe "composing matchers" do
         it "raises StandardError" do
           expect { raise StandardError, "my message" }.
-            to raise_error(an_instance_of(StandardError).and having_attributes({message: "my message"}))
+            to raise_error(an_instance_of(StandardError).and having_attributes({"message" => "my message"}))
         end
       end
       """

--- a/features/built_in_matchers/raise_error.feature
+++ b/features/built_in_matchers/raise_error.feature
@@ -131,13 +131,13 @@ Feature: `raise_error` matcher
       """
       When I run `rspec example_spec`
       Then the example should pass
-      
+
   Scenario: set expectations on error object with chained matchers
     Given a file named "example_spec" with:
       """
       RSpec.describe "composing matchers" do
         it "raises StandardError" do
-          expect { raise StandardError, "my message" }.to 
+          expect { raise StandardError, "my message" }.to
             raise_error(an_instance_of(StandardError).and have_attributes(message: "my message"))
         end
       end

--- a/features/built_in_matchers/raise_error.feature
+++ b/features/built_in_matchers/raise_error.feature
@@ -26,7 +26,7 @@ Feature: `raise_error` matcher
     expect { raise "oops" }.to raise_error(/op/)
     expect { raise "oops" }.to raise_error(RuntimeError, "oops")
     expect { raise "oops" }.to raise_error(RuntimeError, /op/)
-    expect { raise "oops" }.to raise_error(an_instance_of(RuntimeError).and have_attributes(message: "oops"))
+    expect { raise "oops" }.to raise_error(an_instance_of(RuntimeError).and having_attributes(message: "oops"))
     ```
 
   Scenario: expect any error
@@ -138,7 +138,7 @@ Feature: `raise_error` matcher
       RSpec.describe "composing matchers" do
         it "raises StandardError" do
           expect { raise StandardError, "my message" }.to
-            raise_error(an_instance_of(StandardError).and have_attributes(message: "my message"))
+            raise_error(an_instance_of(StandardError).and having_attributes(message: "my message"))
         end
       end
       """


### PR DESCRIPTION
Being new to rspec, it wasn't clear that I could pass composed matchers to 'raise_error'.  This commit adds an example of a chained matcher being passed to 'raise_error'. This is useful for testing custom attributes on an error while still satisfying the one 'expect' statement per test case enforced by rubocop-rspec. 

See https://github.com/rubocop-hq/rubocop-rspec/issues/379 for more details.