### PR TITLE
Handle sudden subject hash change

### DIFF
--- a/lib/rspec/matchers/built_in/change.rb
+++ b/lib/rspec/matchers/built_in/change.rb
@@ -373,6 +373,7 @@ module RSpec
           event_proc.call
 
           @actual_after = evaluate_value_proc
+          @actual_hash = @actual_after.hash
           true
         end
 
@@ -387,8 +388,9 @@ module RSpec
           #
           # Note that it is not sufficient to only check the hashes; it is
           # possible for two values to be unequal (and of different classes)
-          # but to return the same hash value.
-          @actual_before != @actual_after || @before_hash != @actual_after.hash
+          # but to return the same hash value. Also, some objects may change
+          # their hash after being compared with `==`/`!=`.
+          @actual_before != @actual_after || @before_hash != @actual_hash
         end
 
         def actual_delta

--- a/spec/rspec/matchers/built_in/change_spec.rb
+++ b/spec/rspec/matchers/built_in/change_spec.rb
@@ -101,6 +101,20 @@ RSpec.describe "expect { ... }.to change ..." do
     }.to change { obj.x }
   end
 
+  it 'does not detect changes in an object that updates its hash upon comparison' do
+    obj = Class.new do
+      def ==(another)
+        @hash = rand # (^ °=°)^ #
+        self.object_id == another.object_id
+      end
+      def hash
+        @hash ||= super
+      end
+    end.new
+
+    expect { }.not_to change { obj }
+  end
+
   context "with nil value" do
     before(:example) do
       @instance = SomethingExpected.new


### PR DESCRIPTION
#1034 introduced a hash comparison in addition to equality comparison, and it broke the following examples (using `rspec-rails`):

    it { expect { 'noop' }.not_to change { country.reload.cities } }

a workaround to that was to use the `.to_a` on the relation:

    it { expect { 'noop' }.not_to change { country.reload.cities.to_a } }

and the underlying problem is with the objects that are changing their hash during the comparison.


[Notable example](https://github.com/rails/rails/blob/788eb51df3007d94b266965433b0be88a23b84c5/activerecord/lib/active_record/associations/collection_proxy.rb#L959):

    def ==(other)
      load_target == other
    end


The problem is originally described [here](https://github.com/rspec/rspec-expectations/issues/1030#issuecomment-450823945), and the proposed solution was to raise the question against Rails team to fix the `CollectionProxy#hash` behaviour, but I believe this wouldn't work for the following reasons:

1. The issue is specific to RSpec, while Rails comes with its own testing framework that does the assertions using `==`, and is not affected by the problem in question.

2. Fixing the issue would require to either:
 - stick to the original hash that the object was assigned that breaks the 'dynamic hashcode value depending on the contents of the object itself' that mutable Ruby objects seem to adhere to
 - pre-load the relation that may be a huge performance hit


*The change swaps conditions in a way that the hashcode of the objects being compared is not yet updated by the other sneaky condition.*


This might also fix the issue described in #1070