### PR TITLE
Update Aruba to version 0.14.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,10 @@ if RUBY_VERSION < '2.2.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|min
   gem "childprocess", "< 1.0.0"
 end
 
+if RUBY_VERSION < '1.9.2'
+  gem 'contracts', '~> 0.15.0' # is a dependency of aruba
+end
+
 platforms :jruby do
   if RUBY_VERSION < '1.9.0'
     # Pin jruby-openssl on older J Ruby

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -10,7 +10,7 @@ Then /^the output should contain all of these:$/ do |table|
     if RUBY_VERSION == '1.8.7' && string =~ /\{.+=>.+\}/
       warn "Skipping checking #{string} on 1.8.7 because hash ordering is not consistent"
     else
-      assert_partial_output(string, all_output)
+      expect(all_output).to include_output_string string
     end
   end
 end

--- a/features/support/disallow_certain_apis.rb
+++ b/features/support/disallow_certain_apis.rb
@@ -4,7 +4,7 @@
 if defined?(Cucumber)
   require 'shellwords'
   Before('~@allow-disallowed-api') do
-    set_env('SPEC_OPTS', "-r#{Shellwords.escape(__FILE__)}")
+    set_environment_variable('SPEC_OPTS', "-r#{Shellwords.escape(__FILE__)}")
   end
 else
   module DisallowOneLinerShould

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,21 +1,21 @@
 require 'aruba/cucumber'
 
-Before do
+Aruba.configure do |config|
   if RUBY_PLATFORM =~ /java/ || defined?(Rubinius)
-    @aruba_timeout_seconds = 60
+    config.exit_timeout = 60
   else
-    @aruba_timeout_seconds = 10
+    config.exit_timeout = 10
   end
 end
 
-Aruba.configure do |config|
-  config.before_cmd do |_cmd|
-    set_env('JRUBY_OPTS', "-X-C #{ENV['JRUBY_OPTS']}") # disable JIT since these processes are so short lived
+Before do
+  if RUBY_PLATFORM == 'java'
+    # disable JIT since these processes are so short lived
+    set_environment_variable('JRUBY_OPTS', "-X-C #{ENV['JRUBY_OPTS']}")
   end
-end if RUBY_PLATFORM == 'java'
 
-Aruba.configure do |config|
-  config.before_cmd do |_cmd|
-    set_env('RBXOPT', "-Xint=true #{ENV['RBXOPT']}") # disable JIT since these processes are so short lived
+  if defined?(Rubinius)
+    # disable JIT since these processes are so short lived
+    set_environment_variable('RBXOPT', "-Xint=true #{ENV['RBXOPT']}")
   end
-end if defined?(Rubinius)
+end

--- a/rspec-expectations.gemspec
+++ b/rspec-expectations.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "diff-lcs", ">= 1.2.0", "< 2.0"
 
-  s.add_development_dependency "aruba",    "~> 0.6.2" # 0.7 is broken on ruby 1.8.7
+  s.add_development_dependency "aruba",    "~> 0.14.10"
   s.add_development_dependency 'cucumber', '~> 1.3'
   s.add_development_dependency 'minitest', '~> 5.2'
   s.add_development_dependency 'rake',     '~> 10.0.0'


### PR DESCRIPTION
- Bump dependency version
- Fix deprecations
- Limit version of transitive dependency on contracts gem on old Rubies