### PR TITLE
Add Expectations namespace to ExpectationTarget tags.

### DIFF
--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -266,9 +266,9 @@ module RSpec
     # @example
     #   expect(actual).to eq(expected)
     #   expect(actual).not_to eq(expected)
-    # @return [ExpectationTarget]
-    # @see ExpectationTarget#to
-    # @see ExpectationTarget#not_to
+    # @return [Expectations::ExpectationTarget]
+    # @see Expectations::ExpectationTarget#to
+    # @see Expectations::ExpectationTarget#not_to
 
     # Allows multiple expectations in the provided block to fail, and then
     # aggregates them into a single exception, rather than aborting on the


### PR DESCRIPTION
The `@!method` tag for `RSpec::Matchers#expect` references `ExpectationTarget`, but that class is not exposed there. `Expectations::ExpectationTarget` resolves correctly.