### PR TITLE
Notice when object implement inspect but == is different

### DIFF
--- a/lib/rspec/matchers/expecteds_for_multiple_diffs.rb
+++ b/lib/rspec/matchers/expecteds_for_multiple_diffs.rb
@@ -69,7 +69,12 @@ module RSpec
         @expected_list.map do |(expected, diff_label)|
           diff = differ.diff(actual, expected)
           next if diff.strip.empty?
-          "#{diff_label}#{diff}"
+          if diff == "\e[0m\n\e[0m"
+            "#{DEFAULT_DIFF_LABEL}\n" +
+              "  <diff is empty, do your objects produce identical inspect output?>"
+          else
+            "#{diff_label}#{diff}"
+          end
         end.compact.join("\n")
       end
     end

--- a/lib/rspec/matchers/expecteds_for_multiple_diffs.rb
+++ b/lib/rspec/matchers/expecteds_for_multiple_diffs.rb
@@ -70,7 +70,7 @@ module RSpec
           diff = differ.diff(actual, expected)
           next if diff.strip.empty?
           if diff == "\e[0m\n\e[0m"
-            "#{diff_label}\n" +
+            "#{diff_label}\n" \
               "  <The diff is empty, are your objects producing identical `#inspect` output?>"
           else
             "#{diff_label}#{diff}"

--- a/lib/rspec/matchers/expecteds_for_multiple_diffs.rb
+++ b/lib/rspec/matchers/expecteds_for_multiple_diffs.rb
@@ -70,8 +70,8 @@ module RSpec
           diff = differ.diff(actual, expected)
           next if diff.strip.empty?
           if diff == "\e[0m\n\e[0m"
-            "#{DEFAULT_DIFF_LABEL}\n" +
-              "  <diff is empty, do your objects produce identical inspect output?>"
+            "#{diff_label}\n" +
+              "  <The diff is empty, are your objects producing identical `#inspect` output?>"
           else
             "#{diff_label}#{diff}"
           end

--- a/spec/rspec/matchers/expecteds_for_multiple_diffs_spec.rb
+++ b/spec/rspec/matchers/expecteds_for_multiple_diffs_spec.rb
@@ -60,14 +60,14 @@ module RSpec
       end
 
       describe "#message_with_diff" do
-        it "returns message and warning if diff is empty" do
+        it "returns a message warning if the diff is empty" do
           allow(FakeDiffer).to receive(:diff) { "\e[0m\n\e[0m" }
           expect(wrapped_value.message_with_diff(
             message, differ, actual
           )).to eq(dedent <<-EOS)
             |a message
             |Diff:
-            |  <diff is empty, do your objects produce identical inspect output?>
+            |  <The diff is empty, are your objects producing identical `#inspect` output?>
           EOS
         end
 

--- a/spec/rspec/matchers/expecteds_for_multiple_diffs_spec.rb
+++ b/spec/rspec/matchers/expecteds_for_multiple_diffs_spec.rb
@@ -60,12 +60,14 @@ module RSpec
       end
 
       describe "#message_with_diff" do
-        it "returns just provided message if diff is empty" do
-          allow(FakeDiffer).to receive(:diff) { "" }
+        it "returns message and warning if diff is empty" do
+          allow(FakeDiffer).to receive(:diff) { "\e[0m\n\e[0m" }
           expect(wrapped_value.message_with_diff(
             message, differ, actual
           )).to eq(dedent <<-EOS)
             |a message
+            |Diff:
+            |  <diff is empty, do your objects produce identical inspect output?>
           EOS
         end
 


### PR DESCRIPTION
In few cases the object tested implement `inspect` but the eq matcher
will see a difference when doing ==.

This can lead to a misleading output like this one:

```
Failures:

  1) Foo confuses users with an empty diff
     Failure/Error: Foo.something(Foo.new)

       #<Foo (class)> received :something with unexpected arguments
         expected: ("foobar")
              got: ("foobar")
       Diff:

     # ./spec/foo_spec.rb:13:in `block (2 levels) in <top (required)>'
```

This change add a notice to help to understand this failed expectation.

Fix: https://github.com/rspec/rspec-support/issues/274