### PR TITLE
Add support for not swallowing expectation errors when matching negated blocks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ Enhancements:
   for `new` (unless `new` is non standard). (Jon Rowe, #1072)
 * Generated descriptions for matchers now use `is expected to` rather than `should` in
   line with our preferred DSL. (Pete Johns, #1080, rspec/rspec-core#2572)
+* Add the ability to re-raise expectation errors when matching
+  with `match_when_negated` blocks. (Jon Rowe, #1130)
 
 ### 3.8.4 / 2019-06-10
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.8.3...v3.8.4)

--- a/lib/rspec/matchers/dsl.rb
+++ b/lib/rspec/matchers/dsl.rb
@@ -147,8 +147,14 @@ module RSpec
         # is rarely necessary, but can be helpful, for example, when specifying
         # asynchronous processes that require different timeouts.
         #
+        # By default the match block will swallow expectation errors (e.g.
+        # caused by using an expectation such as `expect(1).to eq 2`), if you
+        # with to allow these to bubble up, pass in the option
+        # `:notify_expectation_failures => true`.
+        #
+        # @param [Hash] options for defining the behavior of the match block.
         # @yield [Object] actual the actual value (i.e. the value wrapped by `expect`)
-        def match_when_negated(&match_block)
+        def match_when_negated(options={}, &match_block)
           define_user_override(:does_not_match?, match_block) do |actual|
             begin
               @actual = actual
@@ -156,6 +162,7 @@ module RSpec
                 super(*actual_arg_for(match_block))
               end
             rescue RSpec::Expectations::ExpectationNotMetError
+              raise if options[:notify_expectation_failures]
               false
             end
           end

--- a/spec/rspec/matchers/dsl_spec.rb
+++ b/spec/rspec/matchers/dsl_spec.rb
@@ -920,6 +920,41 @@ module RSpec::Matchers::DSL
       end
     end
 
+    context "matching blocks when negated" do
+      it 'cannot match blocks by default' do
+        matcher = new_matcher(:foo) { match_when_negated { true } }
+        expect(3).to_not matcher
+
+        expect {
+          expect { 3 }.to_not matcher
+        }.to fail_with(/must pass an argument/)
+      end
+
+      it 'can match blocks if it declares `supports_block_expectations`' do
+        matcher = new_matcher(:foo) do
+          match_when_negated { true }
+          supports_block_expectations
+        end
+
+        expect(3).to_not matcher
+        expect { 3 }.to_not matcher
+      end
+
+      it 'will not swallow expectation errors from blocks when told to' do
+        matcher = new_matcher(:foo) do
+          match_when_negated(:notify_expectation_failures => true) do |actual|
+            actual.call
+            true
+          end
+          supports_block_expectations
+        end
+
+        expect {
+          expect { raise RSpec::Expectations::ExpectationNotMetError.new('original') }.to_not matcher
+        }.to raise_error(RSpec::Expectations::ExpectationNotMetError, /original/)
+      end
+    end
+
     context "#new" do
       it "passes matches? arg to match block" do
         matcher = new_matcher(:ignore) do


### PR DESCRIPTION
Fixes #1124 