### PR TITLE
Fix ruby 2.7 keyword args deprecation

### DIFF
--- a/lib/rspec/matchers/dsl.rb
+++ b/lib/rspec/matchers/dsl.rb
@@ -522,7 +522,7 @@ module RSpec
         # Rails' test helper methods, but it's also a useful
         # feature in its own right.
         if RUBY_VERSION.to_f >= 2.7
-          require_relative "dsl27"
+          require "rspec/matchers/dsl27"
           include DSL27
         else
           def method_missing(method, *args, &block)

--- a/lib/rspec/matchers/dsl.rb
+++ b/lib/rspec/matchers/dsl.rb
@@ -521,11 +521,21 @@ module RSpec
         # rspec-rails so that it can define matchers that wrap
         # Rails' test helper methods, but it's also a useful
         # feature in its own right.
-        def method_missing(method, *args, &block)
-          if @matcher_execution_context.respond_to?(method)
-            @matcher_execution_context.__send__ method, *args, &block
-          else
-            super(method, *args, &block)
+        if RUBY_VERSION.to_f >= 2.7
+          def method_missing(method, *args, **kwargs, &block)
+            if @matcher_execution_context.respond_to?(method)
+              @matcher_execution_context.__send__ method, *args, **kwargs, &block
+            else
+              super(method, *args, *kwargs, &block)
+            end
+          end
+        else
+          def method_missing(method, *args, &block)
+            if @matcher_execution_context.respond_to?(method)
+              @matcher_execution_context.__send__ method, *args, &block
+            else
+              super(method, *args, &block)
+            end
           end
         end
       end

--- a/lib/rspec/matchers/dsl.rb
+++ b/lib/rspec/matchers/dsl.rb
@@ -522,13 +522,8 @@ module RSpec
         # Rails' test helper methods, but it's also a useful
         # feature in its own right.
         if RUBY_VERSION.to_f >= 2.7
-          def method_missing(method, *args, **kwargs, &block)
-            if @matcher_execution_context.respond_to?(method)
-              @matcher_execution_context.__send__ method, *args, **kwargs, &block
-            else
-              super(method, *args, *kwargs, &block)
-            end
-          end
+          require_relative "dsl27"
+          include DSL27
         else
           def method_missing(method, *args, &block)
             if @matcher_execution_context.respond_to?(method)

--- a/lib/rspec/matchers/dsl27.rb
+++ b/lib/rspec/matchers/dsl27.rb
@@ -1,13 +1,16 @@
 module RSpec
   module Matchers
+    # Helper module to include code not parsable on very old rubies
     module DSL27
-      def method_missing(method, *args, **kwargs, &block)
-        if @matcher_execution_context.respond_to?(method)
-          @matcher_execution_context.__send__ method, *args, **kwargs, &block
-        else
-          super(method, *args, **kwargs, &block)
+      private
+
+        def method_missing(method, *args, **kwargs, &block)
+          if @matcher_execution_context.respond_to?(method)
+            @matcher_execution_context.__send__ method, *args, **kwargs, &block
+          else
+            super(method, *args, **kwargs, &block)
+          end
         end
-      end
     end
   end
 end

--- a/lib/rspec/matchers/dsl27.rb
+++ b/lib/rspec/matchers/dsl27.rb
@@ -5,7 +5,7 @@ module RSpec
         if @matcher_execution_context.respond_to?(method)
           @matcher_execution_context.__send__ method, *args, **kwargs, &block
         else
-          super(method, *args, *kwargs, &block)
+          super(method, *args, **kwargs, &block)
         end
       end
     end

--- a/lib/rspec/matchers/dsl27.rb
+++ b/lib/rspec/matchers/dsl27.rb
@@ -1,0 +1,13 @@
+module RSpec
+  module Matchers
+    module DSL27
+      def method_missing(method, *args, **kwargs, &block)
+        if @matcher_execution_context.respond_to?(method)
+          @matcher_execution_context.__send__ method, *args, **kwargs, &block
+        else
+          super(method, *args, *kwargs, &block)
+        end
+      end
+    end
+  end
+end

--- a/spec/rspec/expectations_spec.rb
+++ b/spec/rspec/expectations_spec.rb
@@ -1,7 +1,7 @@
 require 'rspec/support/spec/library_wide_checks'
 
 RSpec.describe "RSpec::Expectations" do
-  it_behaves_like "library wide checks", "rspec-expectations",
+  options = {
     :preamble_for_lib => [
       # We define minitest constants because rspec/expectations/minitest_integration
       # expects these constants to already be defined.
@@ -12,6 +12,18 @@ RSpec.describe "RSpec::Expectations" do
       /stringio/, # Used by `output` matcher. Can't be easily avoided.
       /rbconfig/  # required by rspec-support
     ]
+  }
+
+  if RUBY_VERSION.to_f >= 2.7
+    it_behaves_like "library wide checks", "rspec-expectations", options
+  else
+    options.merge!(
+      :consider_a_test_env_file => File.expand_path("../../../lib/rspec/matchers/dsl27.rb", __FILE__),
+      :skip_spec_files => /dsl27/
+    )
+
+    it_behaves_like "library wide checks", "rspec-expectations", options
+  end
 
   it 'does not allow expectation failures to be caught by a bare rescue' do
     expect {

--- a/spec/rspec/matchers/dsl27_syntax.rb
+++ b/spec/rspec/matchers/dsl27_syntax.rb
@@ -1,0 +1,9 @@
+module RSpec
+  module Matchers
+    module DSL27Syntax
+      def kw(a:)
+        a
+      end
+    end
+  end
+end

--- a/spec/rspec/matchers/dsl_spec.rb
+++ b/spec/rspec/matchers/dsl_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "a matcher defined using the matcher DSL" do
   end
 
   if RUBY_VERSION.to_f >= 2.7
-    require_relative "dsl27_syntax"
+    require "rspec/matchers/dsl27_syntax"
     include RSpec::Matchers::DSL27Syntax
   end
 

--- a/spec/rspec/matchers/dsl_spec.rb
+++ b/spec/rspec/matchers/dsl_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe "a matcher defined using the matcher DSL" do
     "ok"
   end
 
+  if RSpec::Support::RubyFeatures.required_kw_args_supported?
+    def kw(a:)
+      a
+    end
+  end
+
   it "supports calling custom matchers from within other custom matchers" do
     RSpec::Matchers.define :be_ok do
       match { |actual| actual == ok }
@@ -27,6 +33,13 @@ RSpec.describe "a matcher defined using the matcher DSL" do
   it "raises when method is missing from local scope as well as matcher" do
     RSpec::Matchers.define(:matcher_b) {}
     expect { matcher_b.i_dont_exist }.to raise_error(NameError)
+  end
+
+  if RSpec::Support::RubyFeatures.required_kw_args_supported?
+    it "doesn't warn when method available in the scope of the example uses keyword args" do
+      RSpec::Matchers.define(:matcher_kw) {}
+      expect(matcher_kw.kw(a: 1)).to eq(1)
+    end
   end
 
   it "clears user instance variables between invocations" do

--- a/spec/rspec/matchers/dsl_spec.rb
+++ b/spec/rspec/matchers/dsl_spec.rb
@@ -7,10 +7,9 @@ RSpec.describe "a matcher defined using the matcher DSL" do
     "ok"
   end
 
-  if RSpec::Support::RubyFeatures.required_kw_args_supported?
-    def kw(a:)
-      a
-    end
+  if RUBY_VERSION.to_f >= 2.7
+    require_relative "dsl27_syntax"
+    include RSpec::Matchers::DSL27Syntax
   end
 
   it "supports calling custom matchers from within other custom matchers" do
@@ -35,7 +34,7 @@ RSpec.describe "a matcher defined using the matcher DSL" do
     expect { matcher_b.i_dont_exist }.to raise_error(NameError)
   end
 
-  if RSpec::Support::RubyFeatures.required_kw_args_supported?
+  if RUBY_VERSION.to_f >= 2.7
     it "doesn't warn when method available in the scope of the example uses keyword args" do
       RSpec::Matchers.define(:matcher_kw) {}
       expect(matcher_kw.kw(a: 1)).to eq(1)


### PR DESCRIPTION
In particular,

```
<path/to/rspec-expectations>/lib/rspec/matchers/dsl.rb:526: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

Fixes #1150.