### PR TITLE
Improve composability of `include` matcher

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ Bug Fixes:
 Enhancements:
 
 * Add an explicit warning when `nil` is passed to `raise_error`. (Phil Pirozhkov, #1143)
+* Improve `include` matcher's composability. (Phil Pirozhkov, #1155)
 
 ### 3.9.0 / 2019-10-08
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.8.6...v3.9.0)

--- a/features/built_in_matchers/include.feature
+++ b/features/built_in_matchers/include.feature
@@ -23,6 +23,8 @@ Feature: `include` matcher
     expect(:a => 1, :b => 2).to include(:a, :b)
     expect(:a => 1, :b => 2).to include(:a => 1)
     expect(:a => 1, :b => 2).to include(:b => 2, :a => 1)
+    expect(:a => 1, :b => 2).to include(match(/b/) => 2)
+    expect(:a => 1, :b => 2).to include(match(/b/) => be_even)
     expect(:a => 1, :b => 2).not_to include(:c)
     expect(:a => 1, :b => 2).not_to include(:a => 2)
     expect(:a => 1, :b => 2).not_to include(:c => 3)
@@ -141,4 +143,3 @@ Feature: `include` matcher
       | expected {:a => 7, :b => 5} not to include :a                 |
       | expected {:a => 7, :b => 5} to include {:d => 3}              |
       | expected {:a => 7, :b => 5} not to include {:a => 7}          |
-

--- a/lib/rspec/matchers/built_in/include.rb
+++ b/lib/rspec/matchers/built_in/include.rb
@@ -107,7 +107,10 @@ module RSpec
         end
 
         def actual_hash_includes?(expected_key, expected_value)
-          actual_value = actual.fetch(expected_key) { return false }
+          actual_value =
+            actual.fetch(expected_key) do
+              actual.find(Proc.new { return false }) { |actual_key, _| values_match?(expected_key, actual_key) }[1]
+            end
           values_match?(expected_value, actual_value)
         end
 

--- a/spec/rspec/matchers/built_in/include_spec.rb
+++ b/spec/rspec/matchers/built_in/include_spec.rb
@@ -749,18 +749,59 @@ RSpec.describe "#include matcher" do
 
     describe "expect(hash).to include(key_matcher)" do
       it "passes when the matcher matches a key", :if => (RUBY_VERSION.to_f > 1.8) do
-        expect(:drink => "water", :food => "bread").to include(a_string_matching(/foo/))
+        expect(:drink => "water", :food => "bread").to include(match(/foo/))
       end
 
       it 'provides a description' do
-        description = include(a_string_matching(/foo/)).description
-        expect(description).to eq("include (a string matching /foo/)")
+        description = include(match(/foo/)).description
+        expect(description).to eq("include (match /foo/)")
       end
 
       it 'fails with a clear message when the matcher does not match', :if => (RUBY_VERSION.to_f > 1.8) do
         expect {
-          expect(:drink => "water", :food => "bread").to include(a_string_matching(/bar/))
-        }.to fail_matching('expected {:drink => "water", :food => "bread"} to include (a string matching /bar/)')
+          expect(:drink => "water", :food => "bread").to include(match(/bar/))
+        }.to fail_matching('expected {:drink => "water", :food => "bread"} to include (match /bar/)')
+      end
+    end
+
+    describe "expect(hash).to include(key_matcher => value)" do
+      it "passes when the matcher matches a pair", :if => (RUBY_VERSION.to_f > 1.8) do
+        expect(:drink => "water", :food => "bread").to include(match(/foo/) => "bread")
+      end
+
+      it "passes when the matcher matches all pairs", :if => (RUBY_VERSION.to_f > 1.8) do
+        expect(:drink => "water", :food => "bread").to include(match(/foo/) => "bread", match(/ink/) => "water")
+      end
+
+      it "passes with a natural matcher", :if => (RUBY_VERSION.to_f > 1.8) do
+        expect(:drink => "water", :food => "bread").to include(/foo/ => "bread")
+      end
+
+      it "passes with a natural matcher", :if => (RUBY_VERSION.to_f > 1.8) do
+        expect(:drink => "water", :food => "bread").to include(/foo/ => /read/)
+      end
+
+      it 'provides a description' do
+        description = include(match(/foo/) => "bread").description
+        expect(description).to eq('include {(match /foo/) => "bread"}')
+      end
+
+      it 'fails with a clear message when the value does not match', :if => (RUBY_VERSION.to_f > 1.8) do
+        expect {
+          expect(:drink => "water", :food => "bread").to include(match(/foo/) => "meat")
+        }.to fail_matching('expected {:drink => "water", :food => "bread"} to include {(match /foo/) => "meat"}')
+      end
+
+      it 'fails with a clear message when the matcher does not match', :if => (RUBY_VERSION.to_f > 1.8) do
+        expect {
+          expect(:drink => "water", :food => "bread").to include(match(/bar/) => "bread")
+        }.to fail_matching('expected {:drink => "water", :food => "bread"} to include {(match /bar/) => "bread"}')
+      end
+
+      it 'fails with a clear message when several matchers do not match', :if => (RUBY_VERSION.to_f > 1.8) do
+        expect {
+          expect(:drink => "water", :food => "bread").to include(match(/bar/) => "bread", match(/baz/) => "water")
+        }.to fail_matching('expected {:drink => "water", :food => "bread"} to include {(match /bar/) => "bread", (match /baz/) => "water"}')
       end
     end
 


### PR DESCRIPTION
To match
```ruby
hash = {OpenStruct.new(value: :special) => true}
```
a workaround had to be used
```ruby
expect(hash.to_a)
  .to contain_exactly([have_attributes(value: :special), true])
```

This change makes it simpler:
```ruby
expect(hash)
  .to include(have_attributes(value: :special) => true)
```

Found here: https://github.com/rubocop-hq/rubocop-rspec/pull/851#discussion_r362733064