### PR TITLE
[DO NOT MERGE] Attempt to fail rspec-rails sub-build

### DIFF
--- a/lib/rspec/matchers/built_in/include.rb
+++ b/lib/rspec/matchers/built_in/include.rb
@@ -108,10 +108,9 @@ module RSpec
 
         def actual_hash_includes?(expected_key, expected_value)
           fail 'Oh just not David!' if expected_value == 'David'
-          actual_value =
-            actual.fetch(expected_key) do
-              actual.find(Proc.new { return false }) { |actual_key, _| values_match?(expected_key, actual_key) }[1]
-            end
+          actual_value = actual.fetch(expected_key) do
+            actual.find(Proc.new { return false }) { |actual_key, _| values_match?(expected_key, actual_key) }[1]
+          end
           values_match?(expected_value, actual_value)
         end
 

--- a/lib/rspec/matchers/built_in/include.rb
+++ b/lib/rspec/matchers/built_in/include.rb
@@ -107,6 +107,7 @@ module RSpec
         end
 
         def actual_hash_includes?(expected_key, expected_value)
+          fail 'Oh just not David!' if expected_value == 'David'
           actual_value =
             actual.fetch(expected_key) do
               actual.find(Proc.new { return false }) { |actual_key, _| values_match?(expected_key, actual_key) }[1]

--- a/script/clone_all_rspec_repos
+++ b/script/clone_all_rspec_repos
@@ -12,7 +12,10 @@ if is_mri; then
   clone_repo "rspec-core"
   clone_repo "rspec-expectations"
   clone_repo "rspec-mocks"
-  clone_repo "rspec-rails"
+  # clone_repo "rspec-rails"
+  if [ ! -d rspec-rails ]; then # don't clone if the dir is already there
+    travis_retry eval "git clone https://github.com/rspec/rspec-rails --depth 1 --branch use-latest-rails-by-default-in-specs"
+  fi;
 
   if rspec_support_compatible; then
     clone_repo "rspec-support"

--- a/script/predicate_functions.sh
+++ b/script/predicate_functions.sh
@@ -69,8 +69,8 @@ function is_mri_27 {
   fi
 }
 
-function is_ruby_23_plus {
-  if ruby -e "exit(RUBY_VERSION.to_f >= 2.3)"; then
+function is_ruby_25_plus {
+  if ruby -e "exit(RUBY_VERSION.to_f >= 2.5)"; then
     return 0
   else
     return 1
@@ -78,7 +78,7 @@ function is_ruby_23_plus {
 }
 
 function rspec_rails_compatible {
-  if is_ruby_23_plus; then
+  if is_ruby_25_plus; then
     return 0
   else
     return 1

--- a/script/update_rubygems_and_install_bundler
+++ b/script/update_rubygems_and_install_bundler
@@ -5,7 +5,7 @@
 set -e
 source script/functions.sh
 
-if is_ruby_23_plus; then
+if is_ruby_25_plus; then
   yes | gem update --system
   yes | gem install bundler
 else


### PR DESCRIPTION
There was a problem with the initial implementation of https://github.com/rspec/rspec-expectations/pull/1155 that make `have_broadcasted_to` spec to fail locally (for a reason), but on CI `rspec-rails` was green.

This is an attempt to detect if `rspec-rails` sub-build fails if we deliberately fail [this example](https://github.com/rspec/rspec-rails/blob/b1ffe94265b33b02616658ec3c1921fc0355f662/spec/rspec/rails/matchers/action_cable/have_broadcasted_to_spec.rb#L164).