### PR TITLE
Fix #1160 - aggregate_failures without line path

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,7 +14,7 @@ Enhancements:
 * Improve `include` matcher's composability. (Phil Pirozhkov, #1155)
 * Mocks expectations can now set a custom failure message.
   (Benoit Tigeot and Nicolas Zermati, #1156)
-* The `aggregate_failures` method now shows the line path of each failure. (Fabricio Bedin, #1160)
+* `aggregate_failures` now shows the backtrace line for each failure. (Fabricio Bedin, #1163)
 
 ### 3.9.0 / 2019-10-08
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.8.6...v3.9.0)

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ Enhancements:
 * Improve `include` matcher's composability. (Phil Pirozhkov, #1155)
 * Mocks expectations can now set a custom failure message.
   (Benoit Tigeot and Nicolas Zermati, #1156)
+* The `aggregate_failures` method now shows the line path of each failure. (Fabricio Bedin, #1160)
 
 ### 3.9.0 / 2019-10-08
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.8.6...v3.9.0)

--- a/features/aggregating_failures.feature
+++ b/features/aggregating_failures.feature
@@ -24,7 +24,7 @@ Feature: Aggregating Failures
           expect(response.body).to eq('{"message":"Success"}')
         end
       rescue RSpec::Expectations::MultipleExpectationsNotMetError => e
-        puts e.message
+        puts e.message.gsub(":in `block in <main>'", '')
         exit(1)
       end
       """
@@ -38,19 +38,19 @@ Feature: Aggregating Failures
 
            (compared using ==)
 
-           spec/aggregated_failure_spec.rb:9:in `block in <main>'
+           spec/aggregated_failure_spec.rb:9
 
         2) expected: "application/json"
                 got: "text/plain"
 
            (compared using ==)
 
-           spec/aggregated_failure_spec.rb:10:in `block in <main>'
+           spec/aggregated_failure_spec.rb:10
 
         3) expected: "{"message":"Success"}"
                 got: "Not Found"
 
            (compared using ==)
 
-           spec/aggregated_failure_spec.rb:11:in `block in <main>'
+           spec/aggregated_failure_spec.rb:11
       """

--- a/features/aggregating_failures.feature
+++ b/features/aggregating_failures.feature
@@ -32,19 +32,25 @@ Feature: Aggregating Failures
     Then it should fail with:
       """
       Got 3 failures from failure aggregation block "testing response":
-
+      
         1) expected: 200
                 got: 404
-
+      
            (compared using ==)
-
+      
+           spec/aggregated_failure_spec.rb:9:in `block in <main>'
+      
         2) expected: "application/json"
                 got: "text/plain"
-
+      
            (compared using ==)
-
-        3) expected: "{\"message\":\"Success\"}"
+      
+           spec/aggregated_failure_spec.rb:10:in `block in <main>'
+      
+        3) expected: "{"message":"Success"}"
                 got: "Not Found"
-
+      
            (compared using ==)
+      
+           spec/aggregated_failure_spec.rb:11:in `block in <main>'
       """

--- a/features/aggregating_failures.feature
+++ b/features/aggregating_failures.feature
@@ -24,7 +24,7 @@ Feature: Aggregating Failures
           expect(response.body).to eq('{"message":"Success"}')
         end
       rescue RSpec::Expectations::MultipleExpectationsNotMetError => e
-        puts e.message.gsub(":in `block in <main>'", '')
+        puts e.message.gsub(":in `block in <main>'", '').gsub(":in `(root)'", '').gsub(":in `block in (root)'", '')
         exit(1)
       end
       """

--- a/features/aggregating_failures.feature
+++ b/features/aggregating_failures.feature
@@ -32,25 +32,25 @@ Feature: Aggregating Failures
     Then it should fail with:
       """
       Got 3 failures from failure aggregation block "testing response":
-      
+
         1) expected: 200
                 got: 404
-      
+
            (compared using ==)
-      
+
            spec/aggregated_failure_spec.rb:9:in `block in <main>'
-      
+
         2) expected: "application/json"
                 got: "text/plain"
-      
+
            (compared using ==)
-      
+
            spec/aggregated_failure_spec.rb:10:in `block in <main>'
-      
+
         3) expected: "{"message":"Success"}"
                 got: "Not Found"
-      
+
            (compared using ==)
-      
+
            spec/aggregated_failure_spec.rb:11:in `block in <main>'
       """

--- a/features/aggregating_failures.feature
+++ b/features/aggregating_failures.feature
@@ -24,7 +24,7 @@ Feature: Aggregating Failures
           expect(response.body).to eq('{"message":"Success"}')
         end
       rescue RSpec::Expectations::MultipleExpectationsNotMetError => e
-        puts e.message.gsub(":in `block in <main>'", '').gsub(":in `(root)'", '').gsub(":in `block in (root)'", '')
+        puts e.message.gsub(/(:in).+/, '')
         exit(1)
       end
       """

--- a/lib/rspec/expectations/failure_aggregator.rb
+++ b/lib/rspec/expectations/failure_aggregator.rb
@@ -157,7 +157,7 @@ module RSpec
 
       def exclusion_patterns
         patterns = %w[/lib\d*/ruby/ bin/ exe/rspec /lib/bundler/ /exe/bundle:]
-        patterns << "org/jruby/" if RUBY_PLATFORM == 'java'
+        patterns << "org/jruby/" if RSpec::Support::Ruby.jruby?
         patterns.map! { |s| Regexp.new(s.gsub('/', File::SEPARATOR)) }
       end
 
@@ -168,6 +168,8 @@ module RSpec
       def backtrace_line(line)
         return if [Regexp.union(RSpec::CallerFilter::IGNORE_REGEX, *exclusion_patterns)].any? { |p| line =~ p }
 
+        # It changes the current path that is relative to
+        # system root to be relative to the project root.
         line.sub(/(\A|\s)#{File.expand_path('.')}(#{File::SEPARATOR}|\s|\Z)/, '\\1.\\2'.freeze).sub(/\A([^:]+:\d+)$/, '\\1'.freeze)
       end
 

--- a/lib/rspec/expectations/failure_aggregator.rb
+++ b/lib/rspec/expectations/failure_aggregator.rb
@@ -156,11 +156,13 @@ module RSpec
       end
 
       def exclusion_patterns
-        %w[/lib\d*/ruby/ bin/ exe/rspec /lib/bundler/ /exe/bundle:].map! { |s| Regexp.new(s.gsub('/', File::SEPARATOR)) }
+        patterns = %w[/lib\d*/ruby/ bin/ exe/rspec /lib/bundler/ /exe/bundle:]
+        patterns << "org/jruby/" if RUBY_PLATFORM == 'java'
+        patterns.map! { |s| Regexp.new(s.gsub('/', File::SEPARATOR)) }
       end
 
       def format_backtrace(backtrace)
-        backtrace&.map { |l| backtrace_line(l) }&.compact&.tap { |filtered| filtered.concat backtrace if filtered.empty? }
+        backtrace.map { |l| backtrace_line(l) }.compact.tap { |filtered| filtered.concat backtrace if filtered.empty? }
       end
 
       def backtrace_line(line)

--- a/spec/rspec/expectations/failure_aggregator_spec.rb
+++ b/spec/rspec/expectations/failure_aggregator_spec.rb
@@ -420,12 +420,12 @@ module RSpec::Expectations
       # This method gets the current version and return the
       # right complement.
       def exception_complement(block_levels)
-        return '' unless RUBY_ENGINE
-
-        if RUBY_VERSION == '1.8.7' then ''
-        elsif RUBY_VERSION > '2.0.0' && RUBY_ENGINE == 'jruby' then ":in `block in Expectations'"
-        elsif RUBY_ENGINE == 'jruby' then ":in `Expectations'"
-        else ":in `block (#{block_levels} levels) in <module:Expectations>'"
+        engine = RUBY_ENGINE || ''
+        version = RUBY_VERSION.gsub('ruby-', '') || '0'
+        if engine == 'ruby'
+          version > '1.8.7' ? ":in `block (#{block_levels} levels) in <module:Expectations>'" : ''
+        else
+          version > '2.0.0' ? ":in `block in Expectations'" : ":in `Expectations'"
         end
       end
     end

--- a/spec/rspec/expectations/failure_aggregator_spec.rb
+++ b/spec/rspec/expectations/failure_aggregator_spec.rb
@@ -420,10 +420,12 @@ module RSpec::Expectations
       # This method gets the current version and return the
       # right complement.
       def exception_complement(block_levels)
-        if RUBY_ENGINE == 'ruby'
-          RUBY_VERSION > '1.8.7' ? ":in `block (#{block_levels} levels) in <module:Expectations>'" : ''
-        else
-          RUBY_VERSION > '2.0.0' ? ":in `block in Expectations'" : ":in `Expectations'"
+        return '' unless RUBY_ENGINE
+
+        if RUBY_VERSION == '1.8.7' then ''
+        elsif RUBY_VERSION > '2.0.0' && RUBY_ENGINE == 'jruby' then ":in `block in Expectations'"
+        elsif RUBY_ENGINE == 'jruby' then ":in `Expectations'"
+        else ":in `block (#{block_levels} levels) in <module:Expectations>'"
         end
       end
     end

--- a/spec/rspec/expectations/failure_aggregator_spec.rb
+++ b/spec/rspec/expectations/failure_aggregator_spec.rb
@@ -262,13 +262,13 @@ module RSpec::Expectations
           end
         }.to fail_including { dedent <<-EOS }
           |  1) expected `1.even?` to return true, got false
-          |     ./spec/rspec/expectations/failure_aggregator_spec.rb:259:in `block (5 levels) in <module:Expectations>'
+          |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 6}#{":in `block (5 levels) in <module:Expectations>'" if RUBY_VERSION > '1.8.7'}
           |
           |  2) expected `2.odd?` to return true, got false
-          |     ./spec/rspec/expectations/failure_aggregator_spec.rb:260:in `block (5 levels) in <module:Expectations>'
+          |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 8}#{":in `block (5 levels) in <module:Expectations>'" if RUBY_VERSION > '1.8.7'}
           |
           |  3) expected `3.even?` to return true, got false
-          |     ./spec/rspec/expectations/failure_aggregator_spec.rb:261:in `block (5 levels) in <module:Expectations>'
+          |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 10}#{":in `block (5 levels) in <module:Expectations>'" if RUBY_VERSION > '1.8.7'}
         EOS
       end
 
@@ -337,12 +337,12 @@ module RSpec::Expectations
             |  1) line 1
             |     a
             |     line 3
-            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:333:in `block (6 levels) in <module:Expectations>'
+            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 7}#{":in `block (6 levels) in <module:Expectations>'" if RUBY_VERSION > '1.8.7'}
             |
             |  2) line 1
             |     b
             |     line 3
-            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:334:in `block (6 levels) in <module:Expectations>'
+            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 11}#{":in `block (6 levels) in <module:Expectations>'" if RUBY_VERSION > '1.8.7'}
           EOS
         end
 
@@ -357,12 +357,12 @@ module RSpec::Expectations
             |  9)  line 1
             |      9
             |      line 3
-            |      ./spec/rspec/expectations/failure_aggregator_spec.rb:353:in `block (7 levels) in <module:Expectations>'
+            |      ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 7}#{":in `block (7 levels) in <module:Expectations>'" if RUBY_VERSION > '1.8.7'}
             |
             |  10) line 1
             |      10
             |      line 3
-            |      ./spec/rspec/expectations/failure_aggregator_spec.rb:353:in `block (7 levels) in <module:Expectations>'
+            |      ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 12}#{":in `block (7 levels) in <module:Expectations>'" if RUBY_VERSION > '1.8.7'}
           EOS
         end
       end
@@ -387,21 +387,21 @@ module RSpec::Expectations
             |
             |     (compared using ==)
             |
-            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:380:in `block (6 levels) in <module:Expectations>'
+            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 10}#{":in `block (6 levels) in <module:Expectations>'" if RUBY_VERSION > '1.8.7'}
             |
             |  2) expected: 3
             |          got: 1
             |
             |     (compared using ==)
             |
-            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:381:in `block (6 levels) in <module:Expectations>'
+            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 16}#{":in `block (6 levels) in <module:Expectations>'" if RUBY_VERSION > '1.8.7'}
             |
             |  3) expected: 4
             |          got: 1
             |
             |     (compared using ==)
             |
-            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:382:in `block (6 levels) in <module:Expectations>'
+            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 22}#{":in `block (6 levels) in <module:Expectations>'" if RUBY_VERSION > '1.8.7'}
           EOS
         end
       end

--- a/spec/rspec/expectations/failure_aggregator_spec.rb
+++ b/spec/rspec/expectations/failure_aggregator_spec.rb
@@ -262,13 +262,13 @@ module RSpec::Expectations
           end
         }.to fail_including { dedent <<-EOS }
           |  1) expected `1.even?` to return true, got false
-          |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 6}#{":in `block (5 levels) in <module:Expectations>'" if RUBY_VERSION > '1.8.7'}
+          |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 6}#{exception_complement(5)}
           |
           |  2) expected `2.odd?` to return true, got false
-          |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 8}#{":in `block (5 levels) in <module:Expectations>'" if RUBY_VERSION > '1.8.7'}
+          |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 8}#{exception_complement(5)}
           |
           |  3) expected `3.even?` to return true, got false
-          |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 10}#{":in `block (5 levels) in <module:Expectations>'" if RUBY_VERSION > '1.8.7'}
+          |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 10}#{exception_complement(5)}
         EOS
       end
 
@@ -311,10 +311,10 @@ module RSpec::Expectations
             |Got 1 failure and 1 other error from failure aggregation block:
             |
             |  1) expected `1.even?` to return true, got false
-            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:307:in `block (6 levels) in <module:Expectations>'
+            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 7}#{exception_complement(6)}
             |
             |  2) RuntimeError: boom
-            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:308:in `block (6 levels) in <module:Expectations>'
+            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 9}#{exception_complement(6)}
           EOS
         end
       end
@@ -337,12 +337,12 @@ module RSpec::Expectations
             |  1) line 1
             |     a
             |     line 3
-            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 7}#{":in `block (6 levels) in <module:Expectations>'" if RUBY_VERSION > '1.8.7'}
+            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 7}#{exception_complement(6)}
             |
             |  2) line 1
             |     b
             |     line 3
-            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 11}#{":in `block (6 levels) in <module:Expectations>'" if RUBY_VERSION > '1.8.7'}
+            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 11}#{exception_complement(6)}
           EOS
         end
 
@@ -357,12 +357,12 @@ module RSpec::Expectations
             |  9)  line 1
             |      9
             |      line 3
-            |      ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 7}#{":in `block (7 levels) in <module:Expectations>'" if RUBY_VERSION > '1.8.7'}
+            |      ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 7}#{exception_complement(7)}
             |
             |  10) line 1
             |      10
             |      line 3
-            |      ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 12}#{":in `block (7 levels) in <module:Expectations>'" if RUBY_VERSION > '1.8.7'}
+            |      ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 12}#{exception_complement(7)}
           EOS
         end
       end
@@ -387,21 +387,21 @@ module RSpec::Expectations
             |
             |     (compared using ==)
             |
-            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 10}#{":in `block (6 levels) in <module:Expectations>'" if RUBY_VERSION > '1.8.7'}
+            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 10}#{exception_complement(6)}
             |
             |  2) expected: 3
             |          got: 1
             |
             |     (compared using ==)
             |
-            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 16}#{":in `block (6 levels) in <module:Expectations>'" if RUBY_VERSION > '1.8.7'}
+            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 16}#{exception_complement(6)}
             |
             |  3) expected: 4
             |          got: 1
             |
             |     (compared using ==)
             |
-            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 22}#{":in `block (6 levels) in <module:Expectations>'" if RUBY_VERSION > '1.8.7'}
+            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 22}#{exception_complement(6)}
           EOS
         end
       end
@@ -414,6 +414,18 @@ module RSpec::Expectations
       # to not include the message for some reason.
       def fail_including
         fail { |e| expect(e.message).to include(yield) }
+      end
+
+      # Each Ruby version return a different exception complement.
+      # This method gets the current version and return the
+      # right complement.
+      def exception_complement(block_levels)
+        case RUBY_VERSION
+        when '1.8.7', 'ree' then ''
+        when 'jruby-9.1.7.0' then ":in `block in Expectations'"
+        when 'jruby-1.7', 'rbx-3' then ":in `Expectations'"
+        else ":in `block (#{block_levels} levels) in <module:Expectations>'"
+        end
       end
     end
   end

--- a/spec/rspec/expectations/failure_aggregator_spec.rb
+++ b/spec/rspec/expectations/failure_aggregator_spec.rb
@@ -253,7 +253,7 @@ module RSpec::Expectations
     end
 
     describe "message formatting" do
-      it "enumerates the failures with an index label and the path of each failure with a blank line in between" do
+      it "enumerates the failures with an index label, the path of each failure and a blank line in between" do
         expect {
           aggregate_failures do
             expect(1).to be_even
@@ -419,12 +419,21 @@ module RSpec::Expectations
       # Each Ruby version return a different exception complement.
       # This method gets the current version and return the
       # right complement.
-      def exception_complement(block_levels)
-        version = RUBY_VERSION.gsub('ruby-', '') || '0'
-        if RSpec::Support::Ruby.mri?
-          version > '1.8.7' ? ":in `block (#{block_levels} levels) in <module:Expectations>'" : ''
-        else
-          version > '2.0.0' ? ":in `block in Expectations'" : ":in `Expectations'"
+      if RSpec::Support::Ruby.mri? && RUBY_VERSION > "1.8.7"
+        def exception_complement(block_levels)
+          ":in `block (#{block_levels} levels) in <module:Expectations>'"
+        end
+      elsif RSpec::Support::Ruby.mri?
+        def exception_complement(block_levels)
+          ""
+        end
+      elsif RUBY_VERSION > "2.0.0"
+        def exception_complement(block_levels)
+          ":in `block in Expectations'"
+        end
+      else
+        def exception_complement(block_levels)
+          ":in `Expectations'"
         end
       end
     end

--- a/spec/rspec/expectations/failure_aggregator_spec.rb
+++ b/spec/rspec/expectations/failure_aggregator_spec.rb
@@ -423,7 +423,7 @@ module RSpec::Expectations
         case RUBY_VERSION
         when '1.8.7', 'ree' then ''
         when 'jruby-9.1.7.0' then ":in `block in Expectations'"
-        when 'jruby-1.7', 'rbx-3' then ":in `Expectations'"
+        when 'jruby-1.7.27', 'rbx-3' then ":in `Expectations'"
         else ":in `block (#{block_levels} levels) in <module:Expectations>'"
         end
       end

--- a/spec/rspec/expectations/failure_aggregator_spec.rb
+++ b/spec/rspec/expectations/failure_aggregator_spec.rb
@@ -420,12 +420,10 @@ module RSpec::Expectations
       # This method gets the current version and return the
       # right complement.
       def exception_complement(block_levels)
-        puts "#################################### #{RUBY_VERSION}"
-        case RUBY_VERSION
-        when '1.8.7', 'ree' then ''
-        when 'jruby-9.1.7.0' then ":in `block in Expectations'"
-        when 'jruby-1.7', 'rbx-3' then ":in `Expectations'"
-        else ":in `block (#{block_levels} levels) in <module:Expectations>'"
+        if RUBY_ENGINE == 'ruby'
+          RUBY_VERSION > '1.8.7' ? ":in `block (#{block_levels} levels) in <module:Expectations>'" : ''
+        else
+          RUBY_VERSION > '1.8.7' ? ":in `block in Expectations'" : ":in `Expectations'"
         end
       end
     end

--- a/spec/rspec/expectations/failure_aggregator_spec.rb
+++ b/spec/rspec/expectations/failure_aggregator_spec.rb
@@ -420,10 +420,11 @@ module RSpec::Expectations
       # This method gets the current version and return the
       # right complement.
       def exception_complement(block_levels)
+        puts "#################################### #{RUBY_VERSION}"
         case RUBY_VERSION
         when '1.8.7', 'ree' then ''
         when 'jruby-9.1.7.0' then ":in `block in Expectations'"
-        when 'jruby-1.7.27', 'rbx-3' then ":in `Expectations'"
+        when 'jruby-1.7', 'rbx-3' then ":in `Expectations'"
         else ":in `block (#{block_levels} levels) in <module:Expectations>'"
         end
       end

--- a/spec/rspec/expectations/failure_aggregator_spec.rb
+++ b/spec/rspec/expectations/failure_aggregator_spec.rb
@@ -420,9 +420,8 @@ module RSpec::Expectations
       # This method gets the current version and return the
       # right complement.
       def exception_complement(block_levels)
-        engine = RUBY_ENGINE || ''
         version = RUBY_VERSION.gsub('ruby-', '') || '0'
-        if engine == 'ruby'
+        if RSpec::Support::Ruby.mri?
           version > '1.8.7' ? ":in `block (#{block_levels} levels) in <module:Expectations>'" : ''
         else
           version > '2.0.0' ? ":in `block in Expectations'" : ":in `Expectations'"

--- a/spec/rspec/expectations/failure_aggregator_spec.rb
+++ b/spec/rspec/expectations/failure_aggregator_spec.rb
@@ -253,7 +253,7 @@ module RSpec::Expectations
     end
 
     describe "message formatting" do
-      it "enumerates the failures with an index label and blank line in between" do
+      it "enumerates the failures with an index label and the path of each failure with a blank line in between" do
         expect {
           aggregate_failures do
             expect(1).to be_even
@@ -262,10 +262,13 @@ module RSpec::Expectations
           end
         }.to fail_including { dedent <<-EOS }
           |  1) expected `1.even?` to return true, got false
+          |     ./spec/rspec/expectations/failure_aggregator_spec.rb:259:in `block (5 levels) in <module:Expectations>'
           |
           |  2) expected `2.odd?` to return true, got false
+          |     ./spec/rspec/expectations/failure_aggregator_spec.rb:260:in `block (5 levels) in <module:Expectations>'
           |
           |  3) expected `3.even?` to return true, got false
+          |     ./spec/rspec/expectations/failure_aggregator_spec.rb:261:in `block (5 levels) in <module:Expectations>'
         EOS
       end
 
@@ -308,8 +311,10 @@ module RSpec::Expectations
             |Got 1 failure and 1 other error from failure aggregation block:
             |
             |  1) expected `1.even?` to return true, got false
+            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:307:in `block (6 levels) in <module:Expectations>'
             |
             |  2) RuntimeError: boom
+            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:308:in `block (6 levels) in <module:Expectations>'
           EOS
         end
       end
@@ -332,10 +337,12 @@ module RSpec::Expectations
             |  1) line 1
             |     a
             |     line 3
+            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:333:in `block (6 levels) in <module:Expectations>'
             |
             |  2) line 1
             |     b
             |     line 3
+            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:334:in `block (6 levels) in <module:Expectations>'
           EOS
         end
 
@@ -350,10 +357,12 @@ module RSpec::Expectations
             |  9)  line 1
             |      9
             |      line 3
+            |      ./spec/rspec/expectations/failure_aggregator_spec.rb:353:in `block (7 levels) in <module:Expectations>'
             |
             |  10) line 1
             |      10
             |      line 3
+            |      ./spec/rspec/expectations/failure_aggregator_spec.rb:353:in `block (7 levels) in <module:Expectations>'
           EOS
         end
       end
@@ -378,15 +387,21 @@ module RSpec::Expectations
             |
             |     (compared using ==)
             |
+            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:380:in `block (6 levels) in <module:Expectations>'
+            |
             |  2) expected: 3
             |          got: 1
             |
             |     (compared using ==)
             |
+            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:381:in `block (6 levels) in <module:Expectations>'
+            |
             |  3) expected: 4
             |          got: 1
             |
             |     (compared using ==)
+            |
+            |     ./spec/rspec/expectations/failure_aggregator_spec.rb:382:in `block (6 levels) in <module:Expectations>'
           EOS
         end
       end

--- a/spec/rspec/expectations/failure_aggregator_spec.rb
+++ b/spec/rspec/expectations/failure_aggregator_spec.rb
@@ -423,7 +423,7 @@ module RSpec::Expectations
         if RUBY_ENGINE == 'ruby'
           RUBY_VERSION > '1.8.7' ? ":in `block (#{block_levels} levels) in <module:Expectations>'" : ''
         else
-          RUBY_VERSION > '1.8.7' ? ":in `block in Expectations'" : ":in `Expectations'"
+          RUBY_VERSION > '2.0.0' ? ":in `block in Expectations'" : ":in `Expectations'"
         end
       end
     end


### PR DESCRIPTION
https://github.com/rspec/rspec-expectations/issues/1160

changed from this return
```
Got 3 failures from failure aggregation block:

1) expected 1.eql?(2) to return true, got false

2) expected 2.eql?(3) to return true, got false

3) expected 3.eql?(4) to return true, got false (RSpec::Expectations::MultipleExpectationsNotMetError)
./features/steps_definitions/test_aggregate_failures_steps.rb:16:in 'some scenario description'
features/gherkins/test_aggregate_failures.feature:5:in '* some scenario description'
```

to it
```
Got 3 failures from failure aggregation block:

1) expected 1.eql?(2) to return true, got false
./features/steps_definitions/test_aggregate_failures_steps.rb:28

2) expected 2.eql?(3) to return true, got false
./features/steps_definitions/test_aggregate_failures_steps.rb:29

3) expected 3.eql?(4) to return true, got false
./features/steps_definitions/test_aggregate_failures_steps.rb:31

(RSpec::Expectations::MultipleExpectationsNotMetError)
./features/steps_definitions/test_aggregate_failures_steps.rb:27:in 'some scenario description'
features/gherkins/test_aggregate_failures.feature:5:in '* some scenario description'
```