### PR TITLE
Handle broken method handles in `respond_to` and `have_attributes` matchers.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ Bug Fixes:
   have changed. (Jon Rowe, #1132)
 * Mocks expectations can now set a custom failure message.
   (Benoit Tigeot and Nicolas Zermati, #1156)
+* Issue an improved warning when using `respond_to(...).with(n).arguments` and ignore
+  the warning when using with `have_attributes(...)`. (Jon Rowe, #1164)
 
 Enhancements:
 

--- a/lib/rspec/matchers/built_in/have_attributes.rb
+++ b/lib/rspec/matchers/built_in/have_attributes.rb
@@ -93,7 +93,7 @@ module RSpec
         end
 
         def respond_to_matcher
-          @respond_to_matcher ||= RespondTo.new(*expected.keys).with(0).arguments
+          @respond_to_matcher ||= RespondTo.new(*expected.keys).with(0).arguments.tap { |m| m.ignoring_method_signature_failure! }
         end
 
         def respond_to_failure_message_or

--- a/lib/rspec/matchers/built_in/respond_to.rb
+++ b/lib/rspec/matchers/built_in/respond_to.rb
@@ -1,5 +1,7 @@
 RSpec::Support.require_rspec_support "method_signature_verifier"
 
+# TODO: Refactor this file to be under our class length
+# rubocop:disable ClassLength
 module RSpec
   module Matchers
     module BuiltIn
@@ -194,3 +196,4 @@ module RSpec
     end
   end
 end
+# rubocop:enable ClassLength

--- a/lib/rspec/matchers/built_in/respond_to.rb
+++ b/lib/rspec/matchers/built_in/respond_to.rb
@@ -11,6 +11,7 @@ module RSpec
           @names = names
           @expected_arity = nil
           @expected_keywords = []
+          @ignoring_method_signature_failure = false
           @unlimited_arguments = nil
           @arbitrary_keywords = nil
         end
@@ -100,6 +101,12 @@ module RSpec
           "respond to #{pp_names}#{with_arity}"
         end
 
+        # @api private
+        # Used by other matchers to suppress a check
+        def ignoring_method_signature_failure!
+          @ignoring_method_signature_failure = true
+        end
+
       private
 
         def find_failing_method_names(actual, filter_method)
@@ -135,6 +142,7 @@ module RSpec
             Support::StrictSignatureVerifier.new(method_signature_for(actual, name)).
               with_expectation(expectation).valid?
           rescue NameError
+            return true if @ignoring_method_signature_failure
             raise ArgumentError, "The #{matcher_name} matcher requires that " \
                                  "the actual object define the method(s) in " \
                                  "order to check arity, but the method " \

--- a/spec/rspec/matchers/built_in/have_attributes_spec.rb
+++ b/spec/rspec/matchers/built_in/have_attributes_spec.rb
@@ -8,6 +8,21 @@ RSpec.describe "#have_attributes matcher" do
     end
   end
 
+  # This simulates a behaviour of Rails, see #1162.
+  class DynamicAttributes
+    def initialize(attributes)
+      @attributes = attributes
+    end
+
+    def method_missing(name, *args, &block)
+      @attributes[name] || super
+    end
+
+    def respond_to?(method_name)
+      @attributes.keys.include?(method_name) || super
+    end
+  end
+
   let(:wrong_name) { "Wrong Name" }
   let(:wrong_age) { 11 }
 
@@ -28,6 +43,10 @@ RSpec.describe "#have_attributes matcher" do
 
     it "passes if target has the provided attributes" do
       expect(person).to have_attributes(:name => correct_name)
+    end
+
+    it "passes if target responds to :sym but does not implement method" do
+      expect(DynamicAttributes.new(:name => "value")).to have_attributes(:name => "value")
     end
 
     it "fails if target does not have any of the expected attributes" do

--- a/spec/rspec/matchers/built_in/respond_to_spec.rb
+++ b/spec/rspec/matchers/built_in/respond_to_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe "expect(...).to respond_to(:sym)" do
     expect(Object.new).to respond_to(:methods)
   end
 
+  it "passes if target responds to :sym but does not implement method" do
+    # This simulates a behaviour of Rails, see #1162.
+    klass = Class.new { def respond_to?(_); true; end }
+    expect(klass.new).to respond_to(:my_method)
+  end
+
   it "fails if target does not respond to :sym" do
     expect {
       expect("this string").to respond_to(:some_method)
@@ -81,6 +87,14 @@ RSpec.describe "expect(...).to respond_to(:sym).with(1).argument" do
     def obj.method; end
     def obj.other_method(arg); end
     expect(obj).to respond_to(:other_method).with(1).argument
+  end
+
+  it "warns that the subject does not have the implementation required when method does not exist" do
+    # This simulates a behaviour of Rails, see #1162.
+    klass = Class.new { def respond_to?(_); true; end }
+    expect {
+      expect(klass.new).to respond_to(:my_method).with(0).arguments
+    }.to raise_error(ArgumentError)
   end
 end
 


### PR DESCRIPTION
Some objects using dynamic attributes (Rails) don't always define methods, but we require them to when checking the number of arguments a method `responds_to`, convert the error into something explicit that explains this. 

As a follow up this then means that the `have_attributes` matcher will never work with such objects as it always checks that an attribute method has `0` arguments. So we add a private api to allow the `have_attributes` matcher to check arguments when they are defined normally, but suppress the warning generated and consider that a pass.

Fixes #1162