### PR TITLE
yield_control hardening

### DIFF
--- a/lib/rspec/matchers/built_in/yield.rb
+++ b/lib/rspec/matchers/built_in/yield.rb
@@ -98,7 +98,7 @@ module RSpec
       # Not intended to be instantiated directly.
       class YieldControl < BaseMatcher
         def initialize
-          at_least(:once)
+          @expectation_type = @expected_yields_count = nil
         end
 
         # @api public
@@ -153,7 +153,7 @@ module RSpec
         def matches?(block)
           @probe = YieldProbe.probe(block)
           return false unless @probe.has_block?
-
+          return @probe.num_yields > 0 unless @expectation_type
           @probe.num_yields.__send__(@expectation_type, @expected_yields_count)
         end
 
@@ -182,6 +182,8 @@ module RSpec
       private
 
         def set_expected_yields_count(relativity, n)
+          raise "Multiple count constraints are not supported" if @expectation_type
+
           @expectation_type = relativity
           @expected_yields_count = count_constraint_to_number(n)
         end
@@ -200,23 +202,24 @@ module RSpec
 
         def failure_reason
           return ' but was not a block' unless @probe.has_block?
-          " #{human_readable_expectation_type}#{human_readable_count(@expected_yields_count)}" \
-          " but yielded #{human_readable_count(@probe.num_yields)}"
+          "#{human_readable_expectation_type}#{human_readable_count(@expected_yields_count)}" \
+          " but yielded#{human_readable_count(@probe.num_yields)}"
         end
 
         def human_readable_expectation_type
           case @expectation_type
-          when :<= then 'at most '
-          when :>= then 'at least '
+          when :<= then ' at most'
+          when :>= then ' at least'
           else ''
           end
         end
 
         def human_readable_count(count)
           case count
-          when 1 then 'once'
-          when 2 then 'twice'
-          else "#{count} times"
+          when nil then ''
+          when 1 then ' once'
+          when 2 then ' twice'
+          else " #{count} times"
           end
         end
       end

--- a/lib/rspec/matchers/built_in/yield.rb
+++ b/lib/rspec/matchers/built_in/yield.rb
@@ -183,17 +183,23 @@ module RSpec
 
         def set_expected_yields_count(relativity, n)
           @expectation_type = relativity
-          @expected_yields_count = case n
-                                   when Numeric then n
-                                   when :once then 1
-                                   when :twice then 2
-                                   when :thrice then 3
-                                   end
+          @expected_yields_count = count_constraint_to_number(n)
+        end
+
+        def count_constraint_to_number(n)
+          case n
+          when Numeric then n
+          when :once then 1
+          when :twice then 2
+          when :thrice then 3
+          else
+            raise ArgumentError, "Expected a number, :once, :twice or :thrice," \
+              " but got #{n}"
+          end
         end
 
         def failure_reason
           return ' but was not a block' unless @probe.has_block?
-          return '' unless @expected_yields_count
           " #{human_readable_expectation_type}#{human_readable_count(@expected_yields_count)}" \
           " but yielded #{human_readable_count(@probe.num_yields)}"
         end

--- a/spec/rspec/matchers/built_in/yield_spec.rb
+++ b/spec/rspec/matchers/built_in/yield_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "yield_control matcher" do
     it 'fails if the block does not yield' do
       expect {
         expect { |b| _dont_yield(&b) }.to yield_control
-      }.to fail_with(/expected given block to yield control/)
+      }.to fail_with(/expected given block to yield control but/)
     end
 
     it 'does not return a meaningful value from the block' do
@@ -71,6 +71,16 @@ RSpec.describe "yield_control matcher" do
       expect { yield_control.exactly('2') }.to raise_error(ArgumentError)
       expect { yield_control.at_least(:trice_with_typo) }.to raise_error(ArgumentError)
       expect { yield_control.at_most(nil) }.to raise_error(ArgumentError)
+    end
+
+    it 'is yet to support multiple calls to compatible count constraints' do
+      pending
+      expect { |b| 1.upto(4, &b) }.to yield_control.at_least(3).at_most(4).times
+      expect { |b| 1.upto(2, &b) }.not_to yield_control.at_least(3).at_most(4).times
+    end
+
+    it 'raises an error on multiple incompatible calls to count constraints' do
+      expect { yield_control.once.twice }.to raise_error(/multiple/i)
     end
 
     context "with exact count" do

--- a/spec/rspec/matchers/built_in/yield_spec.rb
+++ b/spec/rspec/matchers/built_in/yield_spec.rb
@@ -67,6 +67,12 @@ RSpec.describe "yield_control matcher" do
       expect(val).to be_nil
     end
 
+    it 'raises an error if given an invalid count argument' do
+      expect { yield_control.exactly('2') }.to raise_error(ArgumentError)
+      expect { yield_control.at_least(:trice_with_typo) }.to raise_error(ArgumentError)
+      expect { yield_control.at_most(nil) }.to raise_error(ArgumentError)
+    end
+
     context "with exact count" do
       it 'fails if the block yields wrong number of times' do
         expect {


### PR DESCRIPTION
This fixes two misuses of `yield_control`.

The following resulted in strange failures
```
expect{ .. }.to yield_control.at_least(:trice)
```

Worse, the following doesn't test what is thought to be tested:

```
expect{ .. }.to yield_control.at_least(2).at_most(4).times
```

This PR fixes both.