### PR TITLE
Updated travis build scripts (from rspec-dev): Pin to minor versions

### DIFF
--- a/.rubocop_rspec_base.yml
+++ b/.rubocop_rspec_base.yml
@@ -1,4 +1,4 @@
-# This file was generated on 2020-03-30T16:31:25+02:00 from the rspec-dev repo.
+# This file was generated on 2020-04-03T18:24:23+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 # This file contains defaults for RSpec projects. Individual projects

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# This file was generated on 2020-03-30T16:31:25+02:00 from the rspec-dev repo.
+# This file was generated on 2020-04-03T18:24:23+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 # In order to install old Rubies, we need to use old Ubuntu distibution.
@@ -20,12 +20,12 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
-  - 2.2.10
-  - 2.3.8
-  - 2.4.9
-  - 2.5.7
-  - 2.6.5
-  - 2.7.0
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
   - ruby-head
   - ree
   - rbx-3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-# This file was generated on 2020-03-30T16:31:25+02:00 from the rspec-dev repo.
+# This file was generated on 2020-04-03T18:24:23+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 version: "{build}"

--- a/script/clone_all_rspec_repos
+++ b/script/clone_all_rspec_repos
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This file was generated on 2020-03-30T16:31:25+02:00 from the rspec-dev repo.
+# This file was generated on 2020-04-03T18:24:23+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 set -e

--- a/script/functions.sh
+++ b/script/functions.sh
@@ -1,4 +1,4 @@
-# This file was generated on 2020-03-30T16:31:25+02:00 from the rspec-dev repo.
+# This file was generated on 2020-04-03T18:24:23+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/script/predicate_functions.sh
+++ b/script/predicate_functions.sh
@@ -1,4 +1,4 @@
-# This file was generated on 2020-03-30T16:31:25+02:00 from the rspec-dev repo.
+# This file was generated on 2020-04-03T18:24:23+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 function is_mri {

--- a/script/run_build
+++ b/script/run_build
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This file was generated on 2020-03-30T16:31:25+02:00 from the rspec-dev repo.
+# This file was generated on 2020-04-03T18:24:23+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 set -e

--- a/script/travis_functions.sh
+++ b/script/travis_functions.sh
@@ -1,4 +1,4 @@
-# This file was generated on 2020-03-30T16:31:25+02:00 from the rspec-dev repo.
+# This file was generated on 2020-04-03T18:24:23+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 # Taken from:

--- a/script/update_rubygems_and_install_bundler
+++ b/script/update_rubygems_and_install_bundler
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This file was generated on 2020-03-30T16:31:25+02:00 from the rspec-dev repo.
+# This file was generated on 2020-04-03T18:24:23+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 set -e


### PR DESCRIPTION
Having patch versions pinned comes with a burden of sending such pull requests once in a while.
We can depend on Travis to pick the latest patch version as RVM updates.

On the other hand, problems with the patch versions would be discovered later, during the next pull request.
This, however, is unlikely to happen too often.
Also, it should be possible to set up periodic builds for `master`.