### PR TITLE
swap ordering for values with units

### DIFF
--- a/lib/rspec/matchers/built_in/be_within.rb
+++ b/lib/rspec/matchers/built_in/be_within.rb
@@ -23,7 +23,7 @@ module RSpec
         # a percent comparison.
         def percent_of(expected)
           @expected  = expected
-          @tolerance = @delta * @expected.abs / 100.0
+          @tolerance = @expected.abs * @delta / 100.0
           @unit      = '%'
           self
         end

--- a/spec/rspec/matchers/built_in/be_within_spec.rb
+++ b/spec/rspec/matchers/built_in/be_within_spec.rb
@@ -90,6 +90,22 @@ module RSpec
         matcher.matches?(5.1)
         expect(matcher.description).to eq "be within 0.5% of 5.0"
       end
+
+      it "works with custom measure objects" do
+        weight_class = Struct.new(:val) do
+          include Comparable
+          def <=>(other) ; val <=> other.val               ; end
+          def -(other)   ; self.class.new(val - other.val) ; end
+          def abs        ; self.class.new(val.abs)         ; end
+          def *(numeric) ; self.class.new(val * numeric)   ; end
+          def /(numeric) ; self.class.new(val / numeric)   ; end
+        end
+
+        expect(weight_class.new(99)).to be_within(2).percent_of(weight_class.new(100))
+        expect {
+          expect(weight_class.new(90)).to be_within(2).percent_of(weight_class.new(100))
+        }.to fail_with("expected #<struct val=90> to be within 2% of #<struct val=100>")
+      end
     end
 
     RSpec.describe "expect(actual).not_to be_within(delta).of(expected)" do

--- a/spec/rspec/matchers/built_in/be_within_spec.rb
+++ b/spec/rspec/matchers/built_in/be_within_spec.rb
@@ -94,17 +94,18 @@ module RSpec
       it "works with custom measure objects" do
         weight_class = Struct.new(:val) do
           include Comparable
-          def <=>(other) ; val <=> other.val               ; end
-          def -(other)   ; self.class.new(val - other.val) ; end
-          def abs        ; self.class.new(val.abs)         ; end
-          def *(numeric) ; self.class.new(val * numeric)   ; end
-          def /(numeric) ; self.class.new(val / numeric)   ; end
+          def <=>(other); val <=> other.val; end
+          def -(other); self.class.new(val - other.val); end
+          def abs; self.class.new(val.abs); end
+          def *(numeric); self.class.new(val * numeric); end
+          def /(numeric); self.class.new(val / numeric); end
+          def inspect; "<val: #{val}>"; end
         end
 
         expect(weight_class.new(99)).to be_within(2).percent_of(weight_class.new(100))
         expect {
           expect(weight_class.new(90)).to be_within(2).percent_of(weight_class.new(100))
-        }.to fail_with("expected #<struct val=90> to be within 2% of #<struct val=100>")
+        }.to fail_with("expected <val: 90> to be within 2% of <val: 100>")
       end
     end
 

--- a/spec/rspec/matchers/built_in/be_within_spec.rb
+++ b/spec/rspec/matchers/built_in/be_within_spec.rb
@@ -99,7 +99,6 @@ module RSpec
           def abs; self.class.new(val.abs); end
           def *(numeric); self.class.new(val * numeric); end
           def /(numeric); self.class.new(val / numeric); end
-          def inspect; "<val: #{val}>"; end
         end
 
         expect(weight_class.new(99)).to be_within(2).percent_of(weight_class.new(100))

--- a/spec/rspec/matchers/built_in/be_within_spec.rb
+++ b/spec/rspec/matchers/built_in/be_within_spec.rb
@@ -105,7 +105,7 @@ module RSpec
         expect(weight_class.new(99)).to be_within(2).percent_of(weight_class.new(100))
         expect {
           expect(weight_class.new(90)).to be_within(2).percent_of(weight_class.new(100))
-        }.to fail_with("expected <val: 90> to be within 2% of <val: 100>")
+        }.to fail_with(/expected #<struct.*val=90> to be within 2% of #<struct.*val=100>/)
       end
     end
 


### PR DESCRIPTION
The way `@delta * @expected.abs` is ordered currently, the expected
object *must* coerce into a Numeric to work with `#percent_of`.

Example of where this falls down:

```
expect(Weight.new("5 lb"))
  .to be_within(20).percent_of(Weight.new("4 lb"))
```

This is a statement that makes logical sense, but impossible to do with
`@delta * @expected.abs`.

By swapping the order, the expected merely has to respond to `#abs` and
`#*` and also be comparable.

I was debating making a test, but I couldn't think of a class in the stdlib that would trigger this problem and didn't want to write a whole large class just to swap the order of two variables.