### PR TITLE
Remove kw args warning from has_<n> matcher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 branch = File.read(File.expand_path("../maintenance-branch", __FILE__)).chomp
-%w[rspec rspec-core rspec-mocks rspec-support].each do |lib|
+%w[rspec rspec-core rspec-mocks].each do |lib|
   library_path = File.expand_path("../../#{lib}", __FILE__)
   if File.exist?(library_path) && !ENV['USE_GIT_REPOS']
     gem lib, :path => library_path
@@ -11,6 +11,8 @@ branch = File.read(File.expand_path("../maintenance-branch", __FILE__)).chomp
     gem lib, :git => "https://github.com/rspec/#{lib}.git", :branch => branch
   end
 end
+
+gem "rspec-support", :git => "https://github.com/rspec/rspec-support.git", :branch => "add-send-to-with-keyword-args"
 
 if RUBY_VERSION < '1.9.3'
   gem 'rake', '< 11.0.0' # rake 11 requires Ruby 1.9.3 or later

--- a/lib/rspec/matchers/built_in/has.rb
+++ b/lib/rspec/matchers/built_in/has.rb
@@ -65,7 +65,7 @@ module RSpec
         end
 
         def predicate_matches?
-          @actual.__send__(predicate, *@args, &@block)
+          RSpec::Support::WithKeywordsWhenNeeded.send_to(@actual, predicate, *@args, &@block)
         end
 
         def predicate

--- a/spec/rspec/matchers/built_in/has_spec.rb
+++ b/spec/rspec/matchers/built_in/has_spec.rb
@@ -8,6 +8,24 @@ RSpec.describe "expect(...).to have_sym(*args)" do
     expect({ :a => "A" }).to have_key(:a)
   end
 
+  if RSpec::Support::RubyFeatures.required_kw_args_supported?
+    binding.eval(<<-CODE, __FILE__, __LINE__)
+    it 'supports the use of required keyword arguments' do
+      thing = Class.new { def has_keyword?(keyword:); keyword == 'a'; end }
+      expect(thing.new).to have_keyword(keyword: 'a')
+    end
+    CODE
+  end
+
+  if RSpec::Support::RubyFeatures.kw_args_supported?
+    binding.eval(<<-CODE, __FILE__, __LINE__)
+    it 'supports the use of optional keyword arguments' do
+      thing = Class.new { def has_keyword?(keyword: 'b'); keyword == 'a'; end }
+      expect(thing.new).to have_keyword(keyword: 'a')
+    end
+    CODE
+  end
+
   it "fails if #has_sym?(*args) returns false" do
     expect {
       expect({ :b => "B" }).to have_key(:a)


### PR DESCRIPTION
Fixes #1183 Requires rspec/rspec-support#413