### PR TITLE
Ensure that has_<n> matcher works silently with keyword arguments

### DIFF
--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -238,7 +238,7 @@ module RSpec
   # best to find a more positive name for the negated form, such as
   # `avoid_changing` rather than `not_change`.
   #
-  module Matchers
+  module Matchers # rubocop:disable Metrics/ModuleLength
     extend ::RSpec::Matchers::DSL
 
     # @!macro [attach] alias_matcher
@@ -955,14 +955,29 @@ module RSpec
     HAS_REGEX = /^(?:have_)(.*)/
     DYNAMIC_MATCHER_REGEX = Regexp.union(BE_PREDICATE_REGEX, HAS_REGEX)
 
-    def method_missing(method, *args, &block)
-      case method.to_s
-      when BE_PREDICATE_REGEX
-        BuiltIn::BePredicate.new(method, *args, &block)
-      when HAS_REGEX
-        BuiltIn::Has.new(method, *args, &block)
-      else
-        super
+    if RSpec::Support::RubyFeatures.kw_args_supported?
+      binding.eval(<<-CODE, __FILE__, __LINE__)
+      def method_missing(method, *args, **kwargs, &block)
+        case method.to_s
+        when BE_PREDICATE_REGEX
+          BuiltIn::BePredicate.new(method, *args, **kwargs, &block)
+        when HAS_REGEX
+          BuiltIn::Has.new(method, *args, **kwargs, &block)
+        else
+          super
+        end
+      end
+      CODE
+    else
+      def method_missing(method, *args, &block)
+        case method.to_s
+        when BE_PREDICATE_REGEX
+          BuiltIn::BePredicate.new(method, *args, &block)
+        when HAS_REGEX
+          BuiltIn::Has.new(method, *args, &block)
+        else
+          super
+        end
       end
     end
 

--- a/spec/rspec/matchers/built_in/be_spec.rb
+++ b/spec/rspec/matchers/built_in/be_spec.rb
@@ -70,15 +70,22 @@ RSpec.describe "expect(...).to be_predicate" do
     }.to fail_including("expected nil to respond to `happy?`")
   end
 
+  it 'handles arguments to the predicate' do
+    object = Object.new
+    def object.predicate?(return_val); return_val; end
+    expect(object).to be_predicate(true)
+    expect(object).to_not be_predicate(false)
+
+    expect { expect(object).to be_predicate }.to raise_error(ArgumentError)
+    expect { expect(object).to be_predicate(false) }.to fail
+    expect { expect(object).not_to be_predicate(true) }.to fail
+  end
+
   it 'falls back to a present-tense form of the predicate when needed' do
     mouth = Object.new
     def mouth.frowns?(return_val); return_val; end
 
     expect(mouth).to be_frown(true)
-    expect(mouth).not_to be_frown(false)
-
-    expect { expect(mouth).to be_frown(false) }.to fail
-    expect { expect(mouth).not_to be_frown(true) }.to fail
   end
 
   it 'fails when :predicate? is private' do

--- a/spec/rspec/matchers/built_in/be_spec.rb
+++ b/spec/rspec/matchers/built_in/be_spec.rb
@@ -81,6 +81,22 @@ RSpec.describe "expect(...).to be_predicate" do
     expect { expect(object).not_to be_predicate(true) }.to fail
   end
 
+  it 'handles keyword arguments to the predicate', :if => RSpec::Support::RubyFeatures.required_kw_args_supported? do
+    object = Object.new
+    binding.eval(<<-CODE, __FILE__, __LINE__)
+    def object.predicate?(returns:); returns; end
+
+    expect(object).to be_predicate(returns: true)
+    expect(object).to_not be_predicate(returns: false)
+
+    expect { expect(object).to be_predicate(returns: false) }.to fail
+    expect { expect(object).to_not be_predicate(returns: true) }.to fail
+    CODE
+
+    expect { expect(object).to be_predicate }.to raise_error(ArgumentError)
+    expect { expect(object).to be_predicate(true) }.to raise_error(ArgumentError)
+  end
+
   it 'falls back to a present-tense form of the predicate when needed' do
     mouth = Object.new
     def mouth.frowns?(return_val); return_val; end

--- a/spec/rspec/matchers/built_in/has_spec.rb
+++ b/spec/rspec/matchers/built_in/has_spec.rb
@@ -8,6 +8,24 @@ RSpec.describe "expect(...).to have_sym(*args)" do
     expect({ :a => "A" }).to have_key(:a)
   end
 
+  if RSpec::Support::RubyFeatures.required_kw_args_supported?
+    binding.eval(<<-CODE, __FILE__, __LINE__)
+    it 'supports the use of required keyword arguments' do
+      thing = Class.new { def has_keyword?(keyword:); keyword == 'a'; end }
+      expect(thing.new).to have_keyword(keyword: 'a')
+    end
+    CODE
+  end
+
+  if RSpec::Support::RubyFeatures.kw_args_supported?
+    binding.eval(<<-CODE, __FILE__, __LINE__)
+    it 'supports the use of optional keyword arguments' do
+      thing = Class.new { def has_keyword?(keyword: 'b'); keyword == 'a'; end }
+      expect(thing.new).to have_keyword(keyword: 'a')
+    end
+    CODE
+  end
+
   it "fails if #has_sym?(*args) returns false" do
     expect {
       expect({ :b => "B" }).to have_key(:a)


### PR DESCRIPTION
Alternative to #1184 that doesn't use rspec-support meta magic.