### PR TITLE
Improve Hash formatting in `EnglishPhrasing.list`

### DIFF
--- a/lib/rspec/matchers/english_phrasing.rb
+++ b/lib/rspec/matchers/english_phrasing.rb
@@ -24,7 +24,7 @@ module RSpec
       #     list([]) #=> ""
       #
       def self.list(obj)
-        return " #{RSpec::Support::ObjectFormatter.format(obj)}" if !obj || Struct === obj
+        return " #{RSpec::Support::ObjectFormatter.format(obj)}" if !obj || Struct === obj || Hash === obj
         items = Array(obj).map { |w| RSpec::Support::ObjectFormatter.format(w) }
         case items.length
         when 0

--- a/spec/rspec/matchers/english_phrasing_spec.rb
+++ b/spec/rspec/matchers/english_phrasing_spec.rb
@@ -30,7 +30,16 @@ module RSpec
           end
         end
 
-        context "given an Enumerable" do
+        context "given a Hash" do
+          it "returns value from inspect, and a leading space" do
+            banana = { :flavor => 'Banana' }
+            expect(
+              described_class.list(banana)
+            ).to eq(" #{banana.inspect}")
+          end
+        end
+
+        context "given an Enumerable other than a Hash" do
           before do
             allow(RSpec::Support::ObjectFormatter).to(
               receive(:format).and_return("Banana")


### PR DESCRIPTION
We're currently treating all Enumerables as an Array in this method,
resulting in a Hash being formatted as a list of two-element key-value
arrays.

This results in unexpected formatting in the default failure message for
a custom matcher when the `expected` value is a Hash.

This commit updates `EnglishPhrasing.list` to no longer format a Hash as
if it were an Array.

Fixes #1192.

Before:
```
Failure/Error: expect(nil).to custom_match({a: 1, foo: 'bar', bang: Object.new})
  expected nil to custom match [:a, 1], [:foo, "bar"], and [:bang, #<Object:0x00007fb89542bad0>]
 ```

After:
```
Failure/Error: expect(nil).to custom_match({a: 1, foo: 'bar', bang: Object.new})
  expected nil to custom match {:a=>1, :bang=>#<Object:0x00007f9f363b0b28>, :foo=>"bar"}
 ```