### PR TITLE
Strict predicate

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -29,6 +29,9 @@ Enhancements:
   (Jon Rowe, #1169)
 * Dynamic `have_<n>` matchers now have output consistent with other dynamic matchers.
   (Marc-André Lafortune, #1195)
+* New config option `strict_predicate_matchers` allows predicate matcher to be strict
+  (i.e. match for `true` or `false`) instead of the default (match truthy vs `false` or `nil`).
+  (Marc-André Lafortune, #1196)
 
 ### 3.9.2 / 2020-05-08
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.9.1...v3.9.2)

--- a/features/test_frameworks/minitest.feature
+++ b/features/test_frameworks/minitest.feature
@@ -47,7 +47,7 @@ Feature: Minitest integration
       """
      When I run `ruby rspec_expectations_test.rb`
      Then the output should contain "4 runs, 5 assertions, 2 failures, 0 errors"
-      And the output should contain "expected `[1, 2].empty?` to return true, got false"
+      And the output should contain "expected `[1, 2].empty?` to be truthy, got false"
       And the output should contain "be_an_int is deprecated"
       And the output should contain "Got 2 failures from failure aggregation block"
 
@@ -105,7 +105,7 @@ Feature: Minitest integration
       """
      When I run `ruby rspec_expectations_spec.rb`
      Then the output should contain "9 runs, 10 assertions, 5 failures, 0 errors"
-      And the output should contain "expected `[1, 2].empty?` to return true, got false"
+      And the output should contain "expected `[1, 2].empty?` to be truthy, got false"
       And the output should contain "expected ZeroDivisionError but nothing was raised"
       And the output should contain "Got 2 failures from failure aggregation block"
       And the output should contain "Expected [1, 2] to be empty?"

--- a/lib/rspec/expectations/configuration.rb
+++ b/lib/rspec/expectations/configuration.rb
@@ -28,6 +28,7 @@ module RSpec
 
       def initialize
         @on_potential_false_positives = :warn
+        @strict_predicate_matchers = false
       end
 
       # Configures the supported syntax.
@@ -183,6 +184,20 @@ module RSpec
           raise ArgumentError, "Supported values are: #{FALSE_POSITIVE_BEHAVIOURS.keys}"
         end
         @on_potential_false_positives = behavior
+      end
+
+      # Configures RSpec to check predicate matchers to `be(true)` / `be(false)` (strict),
+      # or `be_truthy` / `be_falsey` (not strict).
+      # Historically, the default was `false`, but `true` is recommended.
+      def strict_predicate_matchers=(flag)
+        raise ArgumentError, "Pass `true` or `false`" unless flag == true || flag == false
+        @strict_predicate_matchers = flag
+      end
+
+      attr_reader :strict_predicate_matchers
+
+      def strict_predicate_matchers?
+        @strict_predicate_matchers
       end
 
       # Indicates what RSpec will do about matcher use which will

--- a/spec/rspec/matchers/built_in/be_spec.rb
+++ b/spec/rspec/matchers/built_in/be_spec.rb
@@ -58,6 +58,35 @@ RSpec.describe "expect(...).to be_predicate" do
     }.to fail_with("expected `#{actual.inspect}.happy?` to return true, got nil")
   end
 
+  context "when strict_predicate_matchers is set to true" do
+    it "fails when actual returns 42 for :predicate?" do
+      actual = double("actual", :happy? => 42)
+      expect {
+        expect(actual).to be_happy
+      }.to fail_with("expected `#{actual.inspect}.happy?` to return true, got 42")
+    end
+  end
+
+  context "when strict_predicate_matchers is set to false" do
+    around do |example|
+      RSpec::Expectations.configuration.strict_predicate_matchers = false
+      example.run
+      RSpec::Expectations.configuration.strict_predicate_matchers = true
+    end
+
+    it "passes when actual returns truthy value for :predicate?" do
+      actual = double("actual", :happy? => 42)
+      expect(actual).to be_happy
+    end
+
+    it "states actual predicate used when it fails" do
+      actual = double("actual", :happy? => false)
+      expect {
+        expect(actual).to be_happy
+      }.to fail_with("expected `#{actual.inspect}.happy?` to be truthy, got false")
+    end
+  end
+
   it "fails when actual does not respond to :predicate?" do
     expect {
       expect(Object.new).to be_happy
@@ -184,14 +213,47 @@ RSpec.describe "expect(...).to be_predicate" do
 end
 
 RSpec.describe "expect(...).not_to be_predicate" do
+  let(:strict_predicate_matchers) { true }
+
+  around do |example|
+    default = RSpec::Expectations.configuration.strict_predicate_matchers?
+    RSpec::Expectations.configuration.strict_predicate_matchers = strict_predicate_matchers
+    example.run
+    RSpec::Expectations.configuration.strict_predicate_matchers = default
+  end
+
   it "passes when actual returns false for :sym?" do
     actual = double("actual", :happy? => false)
     expect(actual).not_to be_happy
   end
 
-  it "passes when actual returns nil for :sym?" do
-    actual = double("actual", :happy? => nil)
-    expect(actual).not_to be_happy
+  context "when strict_predicate_matchers is set to true" do
+    it "fails when actual returns nil for :sym?" do
+      actual = double("actual", :happy? => nil)
+      expect {
+        expect(actual).not_to be_happy
+      }.to fail_with("expected `#{actual.inspect}.happy?` to return false, got nil")
+    end
+  end
+
+  context "when strict_predicate_matchers is set to false" do
+    around do |example|
+      RSpec::Expectations.configuration.strict_predicate_matchers = false
+      example.run
+      RSpec::Expectations.configuration.strict_predicate_matchers = true
+    end
+
+    it "passes when actual returns nil for :sym?" do
+      actual = double("actual", :happy? => nil)
+      expect(actual).not_to be_happy
+    end
+
+    it "shows actual comparision made when it fails" do
+      actual = double("actual", :happy? => 42)
+      expect {
+        expect(actual).not_to be_happy
+      }.to fail_with("expected `#{actual.inspect}.happy?` to be falsey, got 42")
+    end
   end
 
   it "fails when actual returns true for :sym?" do

--- a/spec/rspec/matchers/built_in/has_spec.rb
+++ b/spec/rspec/matchers/built_in/has_spec.rb
@@ -139,12 +139,26 @@ RSpec.describe "expect(...).not_to have_sym(*args)" do
     expect({ :a => "A" }).not_to have_key(:b)
   end
 
-  it "passes if #has_sym?(*args) returns nil" do
-    klass = Class.new do
-      def has_foo?
-      end
+  context "when strict_predicate_matchers is set to true" do
+    it "fails when #has_sym? returns nil" do
+      actual = double("actual", :has_foo? => nil)
+      expect {
+        expect(actual).not_to have_foo
+      }.to fail_with("expected `#{actual.inspect}.has_foo?` to return false, got nil")
     end
-    expect(klass.new).not_to have_foo
+  end
+
+  context "when strict_predicate_matchers is set to false" do
+    around do |example|
+      RSpec::Expectations.configuration.strict_predicate_matchers = false
+      example.run
+      RSpec::Expectations.configuration.strict_predicate_matchers = true
+    end
+
+    it "passes if #has_sym?(*args) returns nil" do
+      actual = double("actual", :has_foo? => nil)
+      expect(actual).not_to have_foo
+    end
   end
 
   it "fails if #has_sym?(*args) returns true" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,6 +52,7 @@ RSpec.configure do |config|
     $default_expectation_syntax = expectations.syntax # rubocop:disable Style/GlobalVars
     expectations.syntax = :expect
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+    expectations.strict_predicate_matchers = true
   end
 
   config.mock_with :rspec do |mocks|


### PR DESCRIPTION
This PR adds a config setting `strict_predicate_matchers` which makes the checks for the dynamic predicate matchers strict. Default is `false` but for internal specs the setting is changed to `true` in `spec_helper`.

It changes the failure messages in the non-strict case from "expected ... to return true/false, ..." to  "expected ... to be truthy/falsey, ...".

It builds on #1195 