### PR TITLE
Remove rubysl

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,10 +78,6 @@ platforms :jruby do
   end
 end
 
-platforms :rbx do
-  gem 'rubysl'
-end
-
 if RUBY_VERSION >= '2.4' && RUBY_ENGINE == 'ruby'
   gem 'rubocop', "~> 0.52.1"
 end


### PR DESCRIPTION
This is an attempt to fix the rspec-mocks build, its the only difference in the Gemfile I can see and its mentioned in the output.