### PR TITLE
Prevent be operator false positives

### DIFF
--- a/lib/rspec/matchers/built_in/be.rb
+++ b/lib/rspec/matchers/built_in/be.rb
@@ -143,8 +143,13 @@ module RSpec
         end
 
         def matches?(actual)
-          @actual = actual
-          @actual.__send__ @operator, @expected
+          perform_match(actual)
+        rescue ArgumentError, NoMethodError
+          false
+        end
+
+        def does_not_match?(actual)
+          !perform_match(actual)
         rescue ArgumentError, NoMethodError
           false
         end
@@ -172,6 +177,13 @@ module RSpec
         # @return [String]
         def description
           "be #{@operator} #{expected_to_sentence}#{args_to_sentence}"
+        end
+
+      private
+
+        def perform_match(actual)
+          @actual = actual
+          @actual.__send__ @operator, @expected
         end
       end
 

--- a/spec/rspec/matchers/built_in/be_spec.rb
+++ b/spec/rspec/matchers/built_in/be_spec.rb
@@ -628,9 +628,19 @@ RSpec.describe "expect(...).to be ==" do
   end
 
   it "fails when == operator raises ArgumentError" do
+    failing_equality_klass = Class.new do
+      def inspect
+        "<Class>"
+      end
+
+      def ==(other)
+        raise ArgumentError
+      end
+    end
+
     expect {
-      expect('a').to be == 1
-    }.to fail_with(%(expected: == 1\n     got:    "a"))
+      expect(failing_equality_klass.new).to be == 1
+    }.to fail_with(%(expected: == 1\n     got:    <Class>))
   end
 
   it 'works when the target overrides `#send`' do


### PR DESCRIPTION
We rescue `ArgumentError` and `NoMethodError` when checking comparison operators for objects, this is due to our desired behaviour to fail this matcher and not blow up when encountering things like `'a' < 1` or internal comparisons of attributes. However when negated these errors cause the matcher to pass, which is obviously not the intent of the rescue, so we now do that separately.

It's debatable if we should stop this behaviour in a future version if the objects being compared are more complicated methods but for now this helps.

Fixes #1207 