### PR TITLE
Return true from aggregate_failures

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+### Development
+[Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.10.0...main)
+
+Enhancements:
+
+* Return `true` from `aggregate_failures` when no exception occurs. (Jon Rowe, #1225)
+
 ### 3.10.0 / 2020-10-30
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.9.3...v3.10.0)
 

--- a/lib/rspec/expectations/failure_aggregator.rb
+++ b/lib/rspec/expectations/failure_aggregator.rb
@@ -80,7 +80,7 @@ module RSpec
         all_errors = failures + other_errors
 
         case all_errors.size
-        when 0 then return nil
+        when 0 then return true
         when 1 then RSpec::Support.notify_failure all_errors.first
         else RSpec::Support.notify_failure MultipleExpectationsNotMetError.new(self)
         end

--- a/spec/rspec/expectations/failure_aggregator_spec.rb
+++ b/spec/rspec/expectations/failure_aggregator_spec.rb
@@ -10,6 +10,16 @@ module RSpec::Expectations
       }.not_to raise_error
     end
 
+    it 'returns true when no expectations fail' do
+      expect(
+        aggregate_failures do
+          expect(1).to be_odd
+          expect(2).to be_even
+          expect(3).to be_odd
+        end
+      ).to eq true
+    end
+
     it 'aggregates multiple failures into one exception that exposes all the failures' do
       expect {
         aggregate_failures('block label', :some => :metadata) do


### PR DESCRIPTION
Allows the result of `aggregate_failures` to be asserted on if desired, fixes #1223 