### PR TITLE
Fix ill-defined warn expectation

### DIFF
--- a/spec/rspec/matchers/legacy_spec.rb
+++ b/spec/rspec/matchers/legacy_spec.rb
@@ -27,7 +27,7 @@ module RSpec
           end
 
           it 'warns about the deprecated protocol' do
-            expect_warn_deprecation_with_call_site(__FILE__, __LINE__ + 1, /legacy\s+RSpec\s+matcher/)
+            expect_warn_deprecation(/legacy\s+RSpec\s+matcher.+#{__FILE__}:#{__LINE__ + 1}/m)
             expect(true).to matcher
           end
 
@@ -48,7 +48,7 @@ module RSpec
           end
 
           it 'warns about the deprecated protocol' do
-            expect_warn_deprecation_with_call_site(__FILE__, __LINE__ + 1, /legacy\s+RSpec\s+matcher/)
+            expect_warn_deprecation(/legacy\s+RSpec\s+matcher.+#{__FILE__}:#{__LINE__ + 1}/m)
             expect(false).not_to matcher
           end
 


### PR DESCRIPTION
```
-["include {:message => (match /legacy\\s+RSpec\\s+matcher/), :call_site => (include \"/home/runner/work/rspec-support/rspec-expectations/spec/rspec/matchers/legacy_spec.rb:31\")}"]
       +[{:message=>
       +   "#<#<Class:0x000055fcd6e44840>:0x000055fcd6e52bc0> implements a legacy RSpec matcher\nprotocol. For the current protocol you should expose the failure messages\nvia the `failure_message` and `failure_message_when_negated` methods.\n(Used from /home/runner/work/rspec-support/rspec-expectations/spec/rspec/matchers/legacy_spec.rb:31:in `block (4 levels) in <module:Matchers>')\n",
       +  :type=>"legacy_matcher"}]
```
See https://github.com/rspec/rspec-support/issues/451