### PR TITLE
Remove `include_chain_clauses_in_custom_matcher_descriptions` option

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@ Breaking Changes:
 * Turn `strict_predicate_matchers` on by default. (Phil Pirozhkov, #1277)
 * Remove deprecated `LegacyMacherAdapter`. (Phil Pirozhkov, #1253)
 * Remove support for legacy RSpec matchers (pre 3). (Phil Pirozhkov, #1253)
+* Remove `include_chain_clauses_in_custom_matcher_descriptions` option
+  and make it the default. (Phil Pirozhkov, #1279)
 
 Enhancements:
 

--- a/features/custom_matchers/define_matcher_with_fluent_interface.feature
+++ b/features/custom_matchers/define_matcher_with_fluent_interface.feature
@@ -42,15 +42,9 @@ Feature: define matcher with fluent interface
     Then the output should contain "1 example, 0 failures"
     And  the output should contain "is expected to be bigger than 4"
 
-    Scenario: include_chain_clauses_in_custom_matcher_descriptions configured to true, and chained method with argument
+    Scenario: chained method with an argument
       Given a file named "between_spec.rb" with:
         """ruby
-        RSpec.configure do |config|
-          config.expect_with :rspec do |c|
-            c.include_chain_clauses_in_custom_matcher_descriptions = true
-          end
-        end
-
         RSpec::Matchers.define :be_bigger_than do |first|
           match do |actual|
             (actual > first) && (actual < @second)

--- a/lib/rspec/expectations/configuration.rb
+++ b/lib/rspec/expectations/configuration.rb
@@ -80,18 +80,6 @@ module RSpec
                                  end
       end
 
-      # Sets if custom matcher descriptions and failure messages
-      # should include clauses from methods defined using `chain`.
-      # @param value [Boolean]
-      attr_writer :include_chain_clauses_in_custom_matcher_descriptions
-
-      # Indicates whether or not custom matcher descriptions and failure messages
-      # should include clauses from methods defined using `chain`. It is
-      # false by default for backwards compatibility.
-      def include_chain_clauses_in_custom_matcher_descriptions?
-        @include_chain_clauses_in_custom_matcher_descriptions ||= false
-      end
-
       # @api private
       # Null implementation of a backtrace formatter used by default
       # when rspec-core is not loaded. Does no filtering.

--- a/lib/rspec/matchers/dsl.rb
+++ b/lib/rspec/matchers/dsl.rb
@@ -262,10 +262,8 @@ module RSpec
         # Convenience for defining methods on this matcher to create a fluent
         # interface. The trick about fluent interfaces is that each method must
         # return self in order to chain methods together. `chain` handles that
-        # for you. If the method is invoked and the
-        # `include_chain_clauses_in_custom_matcher_descriptions` config option
-        # hash been enabled, the chained method name and args will be added to the
-        # default description and failure message.
+        # for you. If the method is invoked, the chained method name and args
+        # will be added to the default description and failure message.
         #
         # In the common case where you just want the chained method to store some
         # value(s) for later use (e.g. in `match`), you can provide one or more
@@ -371,8 +369,6 @@ module RSpec
       private
 
         def chained_method_clause_sentences
-          return '' unless Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions?
-
           @chained_method_clauses.map do |(method_name, method_args)|
             english_name = EnglishPhrasing.split_words(method_name)
             arg_list = EnglishPhrasing.list(method_args)

--- a/spec/rspec/expectations/configuration_spec.rb
+++ b/spec/rspec/expectations/configuration_spec.rb
@@ -44,23 +44,6 @@ module RSpec
         end
       end
 
-      describe "#include_chain_clauses_in_custom_matcher_descriptions?" do
-        it "is false by default" do
-          expect(config.include_chain_clauses_in_custom_matcher_descriptions?).to be false
-        end
-
-        it "can be set to true" do
-          config.include_chain_clauses_in_custom_matcher_descriptions = true
-          expect(config.include_chain_clauses_in_custom_matcher_descriptions?).to be true
-        end
-
-        it "can be set back to false" do
-          config.include_chain_clauses_in_custom_matcher_descriptions = true
-          config.include_chain_clauses_in_custom_matcher_descriptions = false
-          expect(config.include_chain_clauses_in_custom_matcher_descriptions?).to be false
-        end
-      end
-
       describe "#strict_predicate_matchers?" do
         it "is true by default" do
           expect(config.strict_predicate_matchers?).to be(true)

--- a/spec/rspec/matchers/dsl_spec.rb
+++ b/spec/rspec/matchers/dsl_spec.rb
@@ -291,54 +291,19 @@ module RSpec::Matchers::DSL
       end
 
       context "when the matchers are chained" do
-        include_context "isolate include_chain_clauses_in_custom_matcher_descriptions"
-
-        context "without include_chain_clauses_in_custom_matcher_descriptions configured" do
-          before { RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions = false }
-          let(:match) { matcher.and_smaller_than(10).and_divisible_by(3) }
-
-          it "provides a default description that does not include any of the chained matchers' descriptions" do
-            expect(match.description).to eq 'be bigger than 5'
-          end
-
-          it "provides a default positive expectation failure message that does not include any of the chained matchers' descriptions" do
-            expect { expect(8).to match }.to fail_with 'expected 8 to be bigger than 5'
-          end
-
-          it "provides a default negative expectation failure message that does not include the any of the chained matchers's descriptions" do
-            expect { expect(9).to_not match }.to fail_with 'expected 9 not to be bigger than 5'
-          end
+        it "provides a default description that includes the chained matchers' descriptions in they were used" do
+          expect(matcher.and_divisible_by(3).and_smaller_than(29).and_smaller_than(20).and_divisible_by(5).description).to \
+            eq 'be bigger than 5 and divisible by 3 and smaller than 29 and smaller than 20 and divisible by 5'
         end
 
-        context "with include_chain_clauses_in_custom_matcher_descriptions configured to be true" do
-          before do
-            expect(RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions?).to be true
-          end
-
-          it "provides a default description that includes the chained matchers' descriptions in they were used" do
-            expect(matcher.and_divisible_by(3).and_smaller_than(29).and_smaller_than(20).and_divisible_by(5).description).to \
-              eq 'be bigger than 5 and divisible by 3 and smaller than 29 and smaller than 20 and divisible by 5'
-          end
-
-          it "provides a default positive expectation failure message that includes the chained matchers' failures" do
-            expect { expect(30).to matcher.and_smaller_than(29).and_divisible_by(3) }.to \
-              fail_with 'expected 30 to be bigger than 5 and smaller than 29 and divisible by 3'
-          end
-
-          it "provides a default negative expectation failure message that includes the chained matchers' failures" do
-            expect { expect(21).to_not matcher.and_smaller_than(29).and_divisible_by(3) }.to \
-              fail_with 'expected 21 not to be bigger than 5 and smaller than 29 and divisible by 3'
-          end
+        it "provides a default positive expectation failure message that includes the chained matchers' failures" do
+          expect { expect(30).to matcher.and_smaller_than(29).and_divisible_by(3) }.to \
+            fail_with 'expected 30 to be bigger than 5 and smaller than 29 and divisible by 3'
         end
 
-        it 'only decides if to include the chained clauses at the time description is invoked' do
-          matcher.and_divisible_by(3)
-
-          expect {
-            RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions = false
-          }.to change { matcher.description }.
-            from('be bigger than 5 and divisible by 3').
-            to('be bigger than 5')
+        it "provides a default negative expectation failure message that includes the chained matchers' failures" do
+          expect { expect(21).to_not matcher.and_smaller_than(29).and_divisible_by(3) }.to \
+            fail_with 'expected 21 not to be bigger than 5 and smaller than 29 and divisible by 3'
         end
       end
     end
@@ -816,19 +781,8 @@ module RSpec::Matchers::DSL
           end
         end
 
-        context "with include_chain_clauses_in_custom_matcher_descriptions configured to false" do
-          include_context "isolate include_chain_clauses_in_custom_matcher_descriptions"
-          before { RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions = false }
-
-          it "provides a default description that does not include any of the chained matchers' descriptions" do
-            expect(matcher.and_divisible_by(10).description).to eq 'be even and divisible by 10'
-          end
-        end
-
-        context "with include_chain_clauses_in_custom_matcher_descriptions configured to true" do
-          it "provides a default description that does includes the chained matchers' descriptions" do
-            expect(matcher.and_divisible_by(10).description).to eq 'be even and divisible by 10 and divisible by 10'
-          end
+        it "provides a default description that does includes the chained matchers' descriptions" do
+          expect(matcher.and_divisible_by(10).description).to eq 'be even and divisible by 10 and divisible by 10'
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,10 +38,6 @@ RSpec.configure do |config|
   config.include CommonHelperMethods
   config.include RSpec::Support::InSubProcess
 
-  config.expect_with :rspec do |expectations|
-    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
-  end
-
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end
@@ -52,14 +48,6 @@ RSpec.configure do |config|
   # ...which isn't very helpful. Far better for it to find the expectation
   # call site in the spec.
   config.project_source_dirs -= ["lib"]
-end
-
-RSpec.shared_context "isolate include_chain_clauses_in_custom_matcher_descriptions" do
-  around do |ex|
-    orig = RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions?
-    ex.run
-    RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions = orig
-  end
 end
 
 RSpec.shared_context "with warn_about_potential_false_positives set to false" do


### PR DESCRIPTION
As discussed in https://github.com/rspec/rspec/issues/61#issuecomment-754968435

Depends on:
 - https://github.com/rspec/rspec-core/pull/2848
 - https://github.com/rspec/rspec-rails/pull/2444