### PR TITLE
Fix YARD type syntax

### DIFF
--- a/lib/rspec/expectations/expectation_target.rb
+++ b/lib/rspec/expectations/expectation_target.rb
@@ -57,7 +57,7 @@ module RSpec
         #   expect { perform }.to raise_error
         # @param [Matcher]
         #   matcher
-        # @param [String or Proc] message optional message to display when the expectation fails
+        # @param [String, Proc] message optional message to display when the expectation fails
         # @return [Boolean] true if the expectation succeeds (else raises)
         # @see RSpec::Matchers
         def to(matcher=nil, message=nil, &block)
@@ -70,7 +70,7 @@ module RSpec
         #   expect(value).not_to eq(5)
         # @param [Matcher]
         #   matcher
-        # @param [String or Proc] message optional message to display when the expectation fails
+        # @param [String, Proc] message optional message to display when the expectation fails
         # @return [Boolean] false if the negative expectation succeeds (else raises)
         # @see RSpec::Matchers
         def not_to(matcher=nil, message=nil, &block)


### PR DESCRIPTION
Both does not raise error in `bundle exec yard`, but looks wrong syntax in https://yardoc.org/types.html.

<img width="828" alt="スクリーンショット 2021-02-20 5 35 29" src="https://user-images.githubusercontent.com/1180335/108559398-a185d000-733e-11eb-933a-ab96fde9fb83.png">
<img width="1596" alt="スクリーンショット 2021-02-20 5 36 07" src="https://user-images.githubusercontent.com/1180335/108559404-a3e82a00-733e-11eb-91e4-d3b3c1b79c0c.png">

Or https://github.com/lsegal/yard-types-parser is wrong? Looks an ancient project 😓 

<img width="1150" alt="スクリーンショット 2021-02-20 5 47 03" src="https://user-images.githubusercontent.com/1180335/108559756-15c07380-733f-11eb-9f3f-88e7dcb86f3d.png">


