### PR TITLE
Fix support for dynamic matchers

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,8 +6,13 @@ Enhancements:
 * Return `true` from `aggregate_failures` when no exception occurs. (Jon Rowe, #1225)
 
 Deprecations:
+
 * Print a deprecation message when using the implicit block expectation syntax.
   (Phil Pirozhkov, #1139)
+
+Bug Fixes:
+
+* Fix support for dynamic matchers for expectation target checks (Phil Pirozhkov, #1294)
 
 ### 3.10.1 / 2020-12-27
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.10.0...v3.10.1)

--- a/lib/rspec/expectations/expectation_target.rb
+++ b/lib/rspec/expectations/expectation_target.rb
@@ -124,9 +124,7 @@ module RSpec
       end
 
       def supports_value_expectations?(matcher)
-        matcher.supports_value_expectations?
-      rescue NoMethodError
-        true
+        !matcher.respond_to?(:supports_value_expectations?) || matcher.supports_value_expectations?
       end
     end
 
@@ -158,9 +156,7 @@ module RSpec
       end
 
       def supports_block_expectations?(matcher)
-        matcher.supports_block_expectations?
-      rescue NoMethodError
-        false
+        matcher.respond_to?(:supports_block_expectations?) && matcher.supports_block_expectations?
       end
     end
   end


### PR DESCRIPTION
See https://github.com/rspec/rspec-collection_matchers/pull/48

If a matcher supports dynamic arbitrary methods called on it, e.g.  `have_at_least(100).bucks`, it would also consider a `supports_value_expectations?` call as a dynamic part.

Instead of calling `supports_*?` methods on a matcher, explicitly check if it responds to it.