### PR TITLE
Fix support for dynamic matchers

### DIFF
--- a/lib/rspec/expectations/expectation_target.rb
+++ b/lib/rspec/expectations/expectation_target.rb
@@ -121,9 +121,7 @@ module RSpec
       end
 
       def supports_value_expectations?(matcher)
-        matcher.supports_value_expectations?
-      rescue NoMethodError
-        true
+        !matcher.respond_to?(:supports_value_expectations?) || matcher.supports_value_expectations?
       end
     end
 
@@ -155,9 +153,7 @@ module RSpec
       end
 
       def supports_block_expectations?(matcher)
-        matcher.supports_block_expectations?
-      rescue NoMethodError
-        false
+        matcher.respond_to?(:supports_block_expectations?) && matcher.supports_block_expectations?
       end
     end
   end


### PR DESCRIPTION
See https://github.com/rspec/rspec-collection_matchers/pull/48

If a matcher supports dynamic arbitrary methods called on it, e.g.  `have_at_least(100).bucks`, it would also consider a `supports_value_expectations?` call as a dynamic part.

Instead of calling `supports_*?` methods on a matcher, explicitly check if it responds to it.

Symmetrical change for `main` that suffers when `rspec-rails` `4.1.0.pre` is used and `rspec-expectations` `3.11.0.pre` is at https://github.com/rspec/rspec-expectations/pull/1294