### PR TITLE
EQ matcher to return diff when testing numbers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 branch = File.read(File.expand_path("../maintenance-branch", __FILE__)).chomp
-%w[rspec rspec-core rspec-mocks rspec-support].each do |lib|
+%w[rspec rspec-mocks rspec-support].each do |lib|
   library_path = File.expand_path("../../#{lib}", __FILE__)
   if File.exist?(library_path) && !ENV['USE_GIT_REPOS']
     gem lib, :path => library_path
@@ -11,6 +11,7 @@ branch = File.read(File.expand_path("../maintenance-branch", __FILE__)).chomp
     gem lib, :git => "https://github.com/rspec/#{lib}.git", :branch => branch
   end
 end
+gem 'rspec-core', :git => "https://github.com/mcyoung/rspec-core.git", :branch => "eq-diff-matcher"
 
 if RUBY_VERSION < '1.9.3'
   gem 'rake', '< 11.0.0' # rake 11 requires Ruby 1.9.3 or later

--- a/features/aggregating_failures.feature
+++ b/features/aggregating_failures.feature
@@ -35,6 +35,7 @@ Feature: Aggregating Failures
 
         1) expected: 200
                 got: 404
+               diff: -204
 
            (compared using ==)
 

--- a/lib/rspec/matchers/built_in/eq.rb
+++ b/lib/rspec/matchers/built_in/eq.rb
@@ -8,7 +8,11 @@ module RSpec
         # @api private
         # @return [String]
         def failure_message
-          "\nexpected: #{expected_formatted}\n     got: #{actual_formatted}\n\n(compared using ==)\n"
+          maybe_diff = ""
+          if (expected.nil? || expected.is_a?(Numeric)) && (actual.nil? || actual.is_a?(Numeric))
+            maybe_diff = "\n    diff: #{(expected || 0) - (actual || 0)}"
+          end
+          "\nexpected: #{expected_formatted}\n     got: #{actual_formatted}#{maybe_diff}\n\n(compared using ==)\n"
         end
 
         # @api private

--- a/spec/rspec/expectations/failure_aggregator_spec.rb
+++ b/spec/rspec/expectations/failure_aggregator_spec.rb
@@ -390,27 +390,27 @@ module RSpec::Expectations
         it 'strips the excess line breaks so that it formats well' do
           expect {
             aggregate_failures do
-              expect(1).to eq 2
-              expect(1).to eq 3
-              expect(1).to eq 4
+              expect("1").to eq 2
+              expect("1").to eq 3
+              expect("1").to eq 4
             end
           }.to fail_including { dedent <<-EOS }
             |  1) expected: 2
-            |          got: 1
+            |          got: "1"
             |
             |     (compared using ==)
             |
             |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 10}#{exception_complement(6)}
             |
             |  2) expected: 3
-            |          got: 1
+            |          got: "1"
             |
             |     (compared using ==)
             |
             |     ./spec/rspec/expectations/failure_aggregator_spec.rb:#{__LINE__ - 16}#{exception_complement(6)}
             |
             |  3) expected: 4
-            |          got: 1
+            |          got: "1"
             |
             |     (compared using ==)
             |

--- a/spec/rspec/matchers/built_in/compound_spec.rb
+++ b/spec/rspec/matchers/built_in/compound_spec.rb
@@ -296,6 +296,7 @@ module RSpec::Matchers::BuiltIn
             |
             |expected: 4
             |     got: 3
+            |    diff: 1
             |
             |(compared using ==)
             |
@@ -311,6 +312,7 @@ module RSpec::Matchers::BuiltIn
             |
             |expected: 4
             |     got: 3
+            |    diff: 1
             |
             |(compared using ==)
             |
@@ -327,6 +329,7 @@ module RSpec::Matchers::BuiltIn
               |
               |   expected: 4
               |        got: 3
+              |       diff: 1
               |
               |   (compared using ==)
               |
@@ -617,6 +620,7 @@ module RSpec::Matchers::BuiltIn
               |
               |   expected: 4
               |        got: 3
+              |       diff: 1
               |
               |   (compared using ==)
               |
@@ -853,6 +857,7 @@ module RSpec::Matchers::BuiltIn
           |
           |   expected: 1
           |        got: 3
+          |       diff: -2
           |
           |   (compared using ==)
           |
@@ -860,6 +865,7 @@ module RSpec::Matchers::BuiltIn
           |
           |      expected: 2
           |           got: 3
+          |          diff: -1
           |
           |      (compared using ==)
           |
@@ -867,6 +873,7 @@ module RSpec::Matchers::BuiltIn
           |
           |      expected: 4
           |           got: 3
+          |          diff: 1
           |
           |      (compared using ==)
           |

--- a/spec/rspec/matchers/built_in/eq_spec.rb
+++ b/spec/rspec/matchers/built_in/eq_spec.rb
@@ -41,6 +41,26 @@ module RSpec
         expect(matcher.failure_message).to eq "\nexpected: \"1\"\n     got: 1\n\n(compared using ==)\n"
       end
 
+      context "#failure_message with numbers" do
+        it "provides message, expected, actual, and diff on #failure_message with numbers" do
+          matcher = eq(1)
+          matcher.matches?(2)
+          expect(matcher.failure_message).to eq "\nexpected: 1\n     got: 2\n    diff: -1\n\n(compared using ==)\n"
+        end
+
+        it "provides message, expected, actual, and diff on #failure_message with numbers and expected nil" do
+          matcher = eq(nil)
+          matcher.matches?(2)
+          expect(matcher.failure_message).to eq "\nexpected: nil\n     got: 2\n    diff: -2\n\n(compared using ==)\n"
+        end
+
+        it "provides message, expected, actual, and diff on #failure_message with numbers and actual nil" do
+          matcher = eq(1)
+          matcher.matches?(nil)
+          expect(matcher.failure_message).to eq "\nexpected: 1\n     got: nil\n    diff: 1\n\n(compared using ==)\n"
+        end
+      end
+
       it "provides message, expected and actual on #negative_failure_message" do
         matcher = eq(1)
         matcher.matches?(1)


### PR DESCRIPTION
When using the `.eq` matcher to test numbers this allows there to be feedback on the difference between `expected` and `actual` results.  This allows for updating tests that use this matcher to be done in a quicker way than manually checking the results.

For example, if you've got a test written to verify that the total of a method is intentionally `1234`, but then update the method and your tests fails with:
```
   expected: 1234
        got: 1983
       diff: -749
```
the developer can much quicker know if this code change was doing what they wanted (in knowing that the difference of `-749` was an expected result) and therefore update their test suite accordingly.