### PR TITLE
Follow `frozen_string_literal` and `equal` and `be` matchers behavior in docs

### DIFF
--- a/features/built_in_matchers/equality.feature
+++ b/features/built_in_matchers/equality.feature
@@ -92,6 +92,8 @@ Feature: Equality matchers
   Scenario: compare using equal (equal?)
     Given a file named "compare_using_equal.rb" with:
       """ruby
+      # frozen_string_literal: false
+
       RSpec.describe "a string" do
         it "is equal to itself" do
           string = "this string"
@@ -114,6 +116,8 @@ Feature: Equality matchers
   Scenario: compare using be (equal?)
     Given a file named "compare_using_be.rb" with:
       """ruby
+      # frozen_string_literal: false
+
       RSpec.describe "a string" do
         it "is equal to itself" do
           string = "this string"

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -582,7 +582,7 @@ module RSpec
     #
     # @example
     #   expect(5).to       equal(5)   # Integers are equal
-    #   expect("5").not_to equal("5") # Strings that look the same are not the same object
+    #   expect(5).not_to equal(5.0) # Integer and Float are not the same object
     def equal(expected)
       BuiltIn::Equal.new(expected)
     end


### PR DESCRIPTION
I understand this PR just updates documentations part of #997 

