### PR TITLE
Fix `be` and `be_nil` matcher description

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ expect(actual).to be_a_kind_of(expected)      # another alias
 
 ```ruby
 expect(actual).to be_truthy   # passes if actual is truthy (not nil or false)
-expect(actual).to be true     # passes if actual == true
+expect(actual).to be true     # passes if actual.equal?(true)
 expect(actual).to be_falsy    # passes if actual is falsy (nil or false)
-expect(actual).to be false    # passes if actual == false
-expect(actual).to be_nil      # passes if actual is nil
-expect(actual).to_not be_nil  # passes if actual is not nil
+expect(actual).to be false    # passes if actual.equal?(false)
+expect(actual).to be_nil      # passes if actual.nil?
+expect(actual).to_not be_nil  # passes if !actual.nil?
 ```
 
 ### Expecting errors

--- a/features/built_in_matchers/README.md
+++ b/features/built_in_matchers/README.md
@@ -48,10 +48,10 @@ e.g.
 ## Truthiness and existentialism
 
     expect(actual).to be_truthy    # passes if actual is truthy (not nil or false)
-    expect(actual).to be true      # passes if actual == true
+    expect(actual).to be true      # passes if actual.equal?(true)
     expect(actual).to be_falsey    # passes if actual is falsy (nil or false)
-    expect(actual).to be false     # passes if actual == false
-    expect(actual).to be_nil       # passes if actual is nil
+    expect(actual).to be false     # passes if actual.equal?(false)
+    expect(actual).to be_nil       # passes if actual.nil?
     expect(actual).to exist        # passes if actual.exist? and/or actual.exists? are truthy
     expect(actual).to exist(*args) # passes if actual.exist?(*args) and/or actual.exists?(*args) are truthy
 


### PR DESCRIPTION
```console
$ bundle exec ruby -v
ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-darwin20]

$ bundle exec gem list | grep rspec
rspec (3.11.0.pre)
rspec-core (3.11.0.pre)
rspec-expectations (3.11.0.pre)
rspec-mocks (3.11.0.pre)
rspec-support (3.11.0.pre)
```

```ruby
RSpec.describe 'equality matcher', aggregate_failures: true do
  subject(:actual) { instance_double(Object) }

  before do
    allow(actual).to receive(:==).and_return(true)
  end

  describe 'eq' do
    it 'depends `actual.==`' do
      expect(actual).to eq true
      expect(actual).to eq false
    end
  end

  describe 'be' do
    it 'does not depend `actual.==`' do
      expect(actual).to_not be true
      expect(actual).to_not be false
    end

    it 'depends `actual.equal?`' do
      allow(actual).to receive(:equal?).and_return(true)

      expect(actual).to be true
      expect(actual).to be false
    end
  end

  describe 'be_nil' do
    it 'does not depend `actual.==`' do
      expect(actual).to_not be_nil
    end

    it 'depends `actual.nil?`' do
      allow(actual).to receive(:nil?).and_return(true)

      expect(actual).to be_nil
    end
  end
end
```

```console
$ bundle exec rspec spec/be_matcher_spec.rb --format documentation

equality matcher
  eq
    depends `actual.==`
  be
    does not depend `actual.==`
    depends `actual.equal?`
  be_nil
    does not depend `actual.==`
    depends `actual.nil?`

Finished in 0.02076 seconds (files took 0.26464 seconds to load)
5 examples, 0 failures
```

When documentation described as this, I could avoid confusion at least to me. 🙏 