### PR TITLE
Remove redundant checks for block expectations

### DIFF
--- a/lib/rspec/matchers/built_in/change.rb
+++ b/lib/rspec/matchers/built_in/change.rb
@@ -197,7 +197,6 @@ module RSpec
 
         # @private
         def failure_message
-          return not_given_a_block_failure unless Proc === @event_proc
           return before_value_failure      unless @matches_before
           return did_not_change_failure    unless @change_details.changed?
           after_value_failure
@@ -254,11 +253,6 @@ module RSpec
           "did change from #{@actual_before_description} " \
           "to #{description_of @change_details.actual_after}"
         end
-
-        def not_given_a_block_failure
-          "expected #{@change_details.value_representation} to have changed " \
-          "#{change_description}, but was not given a block"
-        end
       end
 
       # @api private
@@ -290,7 +284,6 @@ module RSpec
 
         # @private
         def failure_message_when_negated
-          return not_given_a_block_failure unless Proc === @event_proc
           return before_value_failure unless @matches_before
           did_change_failure
         end

--- a/lib/rspec/matchers/built_in/output.rb
+++ b/lib/rspec/matchers/built_in/output.rb
@@ -16,13 +16,12 @@ module RSpec
 
         def matches?(block)
           @block = block
-          return false unless Proc === block
           @actual = @stream_capturer.capture(block)
           @expected ? values_match?(@expected, @actual) : captured?
         end
 
         def does_not_match?(block)
-          !matches?(block) && Proc === block
+          !matches?(block)
         end
 
         # @api public

--- a/lib/rspec/matchers/built_in/raise_error.rb
+++ b/lib/rspec/matchers/built_in/raise_error.rb
@@ -53,8 +53,6 @@ module RSpec
           @eval_block = false
           @eval_block_passed = false
 
-          return false unless Proc === given_proc
-
           begin
             given_proc.call
           rescue Exception => @actual_error
@@ -78,7 +76,7 @@ module RSpec
         # @private
         def does_not_match?(given_proc)
           warn_for_negative_false_positives!
-          !matches?(given_proc, :negative_expectation) && Proc === given_proc
+          !matches?(given_proc, :negative_expectation)
         end
 
         # @private

--- a/lib/rspec/matchers/built_in/throw_symbol.rb
+++ b/lib/rspec/matchers/built_in/throw_symbol.rb
@@ -17,7 +17,6 @@ module RSpec
         # @private
         def matches?(given_proc)
           @block = given_proc
-          return false unless Proc === given_proc
 
           begin
             if @expected_symbol.nil?
@@ -63,7 +62,7 @@ module RSpec
         # rubocop:enable MethodLength
 
         def does_not_match?(given_proc)
-          !matches?(given_proc) && Proc === given_proc
+          !matches?(given_proc)
         end
 
         # @api private


### PR DESCRIPTION
BlockExpectationTarget enforces the target to be a block already.