### PR TITLE
Fix diff for compound when transforming actual

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -48,6 +48,11 @@ Deprecations:
 * Print a deprecation message when using the implicit block expectation syntax.
   (Phil Pirozhkov, #1139)
 
+Bug Fixes:
+
+* Fix the diff for redefined `actual` and reassigned `@actual` in compound
+  expectations failure messages. (Phil Pirozhkov, #1319)
+
 ### 3.10.2 / 2022-01-14
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.10.1...v3.10.2)
 

--- a/lib/rspec/expectations/fail_with.rb
+++ b/lib/rspec/expectations/fail_with.rb
@@ -30,7 +30,7 @@ module RSpec
                                "appropriate failure_message[_when_negated] method to return a string?"
         end
 
-        message = ::RSpec::Matchers::ExpectedsForMultipleDiffs.from(expected).message_with_diff(message, differ, actual)
+        message = ::RSpec::Matchers::MultiMatcherDiff.from(expected, actual).message_with_diff(message, differ)
 
         RSpec::Support.notify_failure(RSpec::Expectations::ExpectationNotMetError.new message)
       end

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -10,7 +10,7 @@ RSpec::Support.define_optimized_require_for_rspec(:matchers) { |f| require_relat
   dsl
   matcher_delegator
   aliased_matcher
-  expecteds_for_multiple_diffs
+  multi_matcher_diff
 ].each { |file| RSpec::Support.require_rspec_matchers(file) }
 
 # RSpec's top level namespace. All of rspec-expectations is contained

--- a/lib/rspec/matchers/built_in/compound.rb
+++ b/lib/rspec/matchers/built_in/compound.rb
@@ -51,10 +51,10 @@ module RSpec
         end
 
         # @api private
-        # @return [RSpec::Matchers::ExpectedsForMultipleDiffs]
+        # @return [RSpec::Matchers::MultiMatcherDiff]
         def expected
           return nil unless evaluator
-          ::RSpec::Matchers::ExpectedsForMultipleDiffs.for_many_matchers(diffable_matcher_list)
+          ::RSpec::Matchers::MultiMatcherDiff.for_many_matchers(diffable_matcher_list)
         end
 
       protected

--- a/spec/rspec/matchers/built_in/output_spec.rb
+++ b/spec/rspec/matchers/built_in/output_spec.rb
@@ -194,5 +194,26 @@ module RSpec
         expect(output("foo").description).to eq('output "foo" to some stream')
       end
     end
+
+    RSpec.describe "can capture stdin and stderr" do
+      it "prints diff for both when both fail" do
+        expect {
+          expect { print "foo"; $stderr.print("bar") }
+            .to output(/baz/).to_stdout
+            .and output(/qux/).to_stderr
+        }
+          .to fail_including(
+            'expected block to output /baz/ to stdout, but output "foo"',
+            '...and:',
+            'expected block to output /qux/ to stderr, but output "bar"',
+            'Diff for (output /baz/ to stdout):',
+            '-/baz/',
+            '+"foo"',
+            'Diff for (output /qux/ to stderr):',
+            '-/qux/',
+            '+"bar"'
+          )
+      end
+    end
   end
 end


### PR DESCRIPTION
Previously, we were passing the untransformed actual to the differ.
Now, we take it from the matchers.

fixes #1317
fixes #1406 