### PR TITLE
Update Cucumber

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,2 +1,2 @@
-default: --require features --tags ~@wip --format progress
+default: --require features --tags 'not @wip' --format progress
 wip: --require features --tags @wip:3 --wip features

--- a/features/support/ruby_features.rb
+++ b/features/support/ruby_features.rb
@@ -1,9 +1,8 @@
-Around "@skip-when-ripper-unsupported" do |scenario, block|
+Before "@skip-when-ripper-unsupported" do |scenario|
   require 'rspec/support/ruby_features'
 
-  if ::RSpec::Support::RubyFeatures.ripper_supported?
-    block.call
-  else
-    warn "Skipping scenario #{scenario.title} because Ripper is not supported"
+  unless ::RSpec::Support::RubyFeatures.ripper_supported?
+    warn "Skipping scenario #{scenario.name} because Ripper is not supported"
+    skip_this_scenario
   end
 end

--- a/rspec-expectations.gemspec
+++ b/rspec-expectations.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "diff-lcs", ">= 1.4.4", "< 2.0"
 
   s.add_development_dependency "aruba",    "~> 0.14.10"
-  s.add_development_dependency 'cucumber', '~> 1.3'
+  s.add_development_dependency 'cucumber', '>= 3.2', '!= 4.0.0', '< 8.0.0'
   s.add_development_dependency 'minitest', '~> 5.2'
   s.add_development_dependency 'rake',     '> 12.3.2'
 end


### PR DESCRIPTION
1.3-2.0 don't work for me locally with a weird error:
```
undefined method `[]' for nil:NilClass (NoMethodError) /Users/pirj/.rvm/gems/ruby-2.7.1@rspec-core/gems/cucumber-1.3.20/lib/cucumber/core_ext/proc.rb:17:in `file_colon_line'
```

2.4.0 spits "undefined method `with_filtered_backtrace`" in some other repository (`rspec-core` to my best memory)
~3.2.0 - "undefined method `ok?`" in that other repo as well~ - it was due to the lack of `skip_this_scenario`.
4.0.1-4.1 depend on `diff-lcs (< 1.4, >= 1.3, ~> 1.3)`, while we depend on `= 1.4.4`

5.2.0 only supports Ruby > 2.5. we support >=2.3. But it doesn't have a `diff-lcs` version conflict with its `>= 1.4.4` dependency.

2.4 and 5.x+ are incompatible in terms of `cucumber.yml`, the former expects `--tag ~@wip`, while the latter `--tag 'not @wip'`.

I've checked 3.2.0, 4.0.0, 4.1.0, 5.3.0, 6.1.0, and they work (except for 4.1.0).

~I vaguely recall we were discussing not running `cucumber` on older Rubies (2.3-2.4), is this correct?~
~Otherwise, I'll roll back to 3.2.0.~ ✔️ 

Sibling PRs:
 - https://github.com/rspec/rspec-mocks/pull/1439
 - https://github.com/rspec/rspec-support/pull/517
 -  https://github.com/rspec/rspec-core/pull/2877