### PR TITLE
Fix Include Matcher For Ranges

### DIFF
--- a/spec/rspec/matchers/built_in/include_spec.rb
+++ b/spec/rspec/matchers/built_in/include_spec.rb
@@ -169,9 +169,13 @@ RSpec.describe "#include matcher" do
     let(:range) { (start..finish) }
   end
 
-  shared_context "only runs for modern rubies" do
+  shared_context "runs for modern rubies, raises for old rubies" do
     around(:example) do |example|
-      example.run if RUBY_VERSION >= "2.1.9"
+      if RUBY_VERSION >= "2.1.9"
+        example.run
+      else
+        expect { example.run }.to raise_error(TypeError)
+      end
     end
   end
 
@@ -213,7 +217,7 @@ RSpec.describe "#include matcher" do
     end
 
     context "for a range target" do
-      include_context "only runs for modern rubies"
+      include_context "runs for modern rubies, raises for old rubies"
 
       context "with elements that support iteration" do
         let(:range) { 1..3 }
@@ -568,7 +572,7 @@ RSpec.describe "#include matcher" do
     end
 
     context "for a range target" do
-      include_context "only runs for modern rubies"
+      include_context "runs for modern rubies, raises for old rubies"
 
       context "with elements that support iteration" do
         let(:range) { 1..3 }
@@ -791,7 +795,7 @@ RSpec.describe "#include matcher" do
     end
 
     context "for a range target" do
-      include_context "only runs for modern rubies"
+      include_context "runs for modern rubies, raises for old rubies"
 
       context "with elements that support iteration" do
         let(:range) { 1..3 }
@@ -1039,7 +1043,7 @@ RSpec.describe "#include matcher" do
 
   describe "expect(...).not_to include(with, multiple, args)" do
     context "for a range target" do
-      include_context "only runs for modern rubies"
+      include_context "runs for modern rubies, raises for old rubies"
 
       context "with elements that support iteration" do
         let(:range) { 1..3 }
@@ -1477,7 +1481,7 @@ RSpec.describe "#include matcher" do
     end
 
     describe "expect(range).to include(matcher)" do
-      include_context "only runs for modern rubies"
+      include_context "runs for modern rubies, raises for old rubies"
 
       it "passes when the matcher matches one of the values" do
         expect(10..30).to include( a_value_within(5).of(24) )

--- a/spec/rspec/matchers/built_in/include_spec.rb
+++ b/spec/rspec/matchers/built_in/include_spec.rb
@@ -170,11 +170,9 @@ RSpec.describe "#include matcher" do
   end
 
   shared_context "runs for modern rubies, raises for old rubies" do
-    around(:example) do |example|
-      if RUBY_VERSION >= "2.1.9"
-        example.run
-      else
-        expect { example.run }.to raise_error(TypeError)
+    if RUBY_VERSION < "2.1.9"
+      def fail_matching(_message)
+        raise_error(TypeError)
       end
     end
   end


### PR DESCRIPTION
This PR addresses issue rspec/rspec#138 for ruby >= 2.1.9.

Previously, a few parts of the `Include` matcher assumed all `Range`s were iterable.  This caused it to raise errors like `TypeError: Can't iterate from [Float|Time]`

This happens because `Range`s require that their beginning element implement `succ`.  `Float` doesn't, which causes the error.  `Time` is different because it does implement `succ` but

a) `Range#succ` is deprecated as of ruby 1.9.2 and
b) Some Ruby implementations raise an exception when trying to iterate through a range of `Time` objects

This PR does a few things:
1) Fixes the `Include` matcher to handle `Range`s that don't support iteration, while continuing to support `Range`s that do
2) Adds specs for both types of `Range`s in 1).  There weren't any for the `Include` matcher used with `Range`s.