### PR TITLE
Improve ContainExactly matcher speed when elements obey transitivity

### DIFF
--- a/lib/rspec/matchers/built_in/contain_exactly.rb
+++ b/lib/rspec/matchers/built_in/contain_exactly.rb
@@ -6,19 +6,6 @@ module RSpec
       # Provides the implementation for `contain_exactly` and `match_array`.
       # Not intended to be instantiated directly.
       class ContainExactly < BaseMatcher
-        def initialize(expected=nil)
-          super
-          @transitive = false
-        end
-
-        # @api public
-        # Specifies that elements contained in actual and expected
-        # obey transitivity.  This lets match run much faster.
-        def transitive
-          @transitive = true
-          self
-        end
-
         # @api private
         # @return [String]
         def failure_message
@@ -100,6 +87,7 @@ module RSpec
         # the slowness of the full matching algorithm, and in common cases this
         # works, so it's worth a try.
         def match_when_sorted?
+          @transitive = true # Be optimistic. Let `safe_sort` reveal non-transitivity.
           @sorted_expected, @sorted_actual = safe_sort(expected), safe_sort(actual)
           values_match?(@sorted_expected, @sorted_actual)
         end
@@ -117,7 +105,7 @@ module RSpec
         def safe_sort(array)
           array.sort
         rescue Support::AllExceptionsExceptOnesWeMustNotRescue
-          raise "Invalid use of `.transitive` with unsortable array #{array}" if @transitive
+          @transitive = false
           array
         end
 

--- a/lib/rspec/matchers/built_in/contain_exactly.rb
+++ b/lib/rspec/matchers/built_in/contain_exactly.rb
@@ -86,8 +86,12 @@ module RSpec
 
         def match(_expected, _actual)
           return false unless convert_actual_to_an_array
+
           matched_when_sorted = match_when_sorted?
-          return matched_when_sorted if matched_when_sorted || @transitive
+
+          return true if matched_when_sorted
+          return matched_when_sorted if @transitive
+
           (extra_items.empty? && missing_items.empty?)
         end
 

--- a/lib/rspec/matchers/built_in/contain_exactly.rb
+++ b/lib/rspec/matchers/built_in/contain_exactly.rb
@@ -162,11 +162,11 @@ module RSpec
           end
 
           while i < @sorted_actual.size
-            extra << current_actual
+            extra << @sorted_actual[i]
             i += 1
           end
           while j < @sorted_expected.size
-            missing << current_expected
+            missing << @sorted_expected[j]
             j += 1
           end
 

--- a/spec/rspec/matchers/built_in/contain_exactly_spec.rb
+++ b/spec/rspec/matchers/built_in/contain_exactly_spec.rb
@@ -99,21 +99,6 @@ RSpec.describe "using contain_exactly with expect" do
   # never finishing!
   context "with transitive enabled" do
     require 'benchmark'
-    context "with actual and expected containing unsortable elements" do
-      it "raises" do
-        expect {
-          expect([be_positive, be_negative]).to contain_exactly(be_positive, be_negative).transitive
-        }.to raise_error(/Invalid use of/)
-      end
-    end
-
-    context "with expected containing unsortable elements" do
-      it "raises" do
-        expect {
-          expect([1, -1]).to contain_exactly(be_positive, be_negative).transitive
-        }.to raise_error(/Invalid use of/)
-      end
-    end
 
     context "with actual and expected containing sortable elements" do
       shared_examples "runs very fast" do
@@ -129,7 +114,7 @@ RSpec.describe "using contain_exactly with expect" do
       let(:a) { Array.new(10_000) { rand(10) } }
 
       context "with a positive expectation" do
-        subject { expect(a).to contain_exactly(*b).transitive }
+        subject { expect(a).to contain_exactly(*b) }
 
         context "that is valid" do
           let(:b) { a.shuffle }
@@ -155,7 +140,7 @@ RSpec.describe "using contain_exactly with expect" do
       end
 
       context "with a negative expectation" do
-        subject { expect(a).not_to contain_exactly(*b).transitive }
+        subject { expect(a).not_to contain_exactly(*b) }
 
         context "that is valid" do
           let(:b) { Array.new(10_000) { rand(10) } }
@@ -172,7 +157,7 @@ RSpec.describe "using contain_exactly with expect" do
 
           it "fails quickly" do
             time = Benchmark.realtime do
-              expect { expect(a).not_to contain_exactly(*b).transitive }.to fail_with(/not to contain exactly/)
+              expect { expect(a).not_to contain_exactly(*b) }.to fail_with(/not to contain exactly/)
             end
             expect(time).to be < 1
           end


### PR DESCRIPTION
This addresses issues #1006, #1161.

The current implementation for `ContainExactly` runs in O(n!).  The crux of the problem is that some elements don't obey transitivity.  As a result, knowing that sorting actual and expected doesn't result in a match *doesn't* guarantee that expected and actual don't match.

This PR makes improvements that ensure any test with comparable elements in `actual` and `expected` runs in O(n log n) time. 

There are two main updates:

**Update the core logic in `ContainExactly` to:**

1. Attempt to sort `actual` and `expected`
2. If the sort succeeds, this tells us the objects are comparable.  Use the result of the sort

This means that when `actual` and `expected` contain comparable elements, we can immediately return `false` when the sorted arrays don't match.  **This speeds up passing tests where `actual` and `expected` don't match from O(n!) to O(n log n).**

**Speed up determining `extra` and `missing` elements**

Previously, the logic for determining `extra` and `missing` items between `actual` and `expected` relied on code in `PairingsMaximizer` that generated all possible element pairings.  So even if you avoided comparing all possible pairings to determine if the matcher should return true, you would still incur that O(n!) cost when generating a failure message.

The code now calculates `extra` and `missing` in linear time.  **This speeds up failing tests from O(n!) to O(n log n).**

More practically, this means that common use cases for `ContainExactly` will enjoy a massive speedup.  Previously, users have examples where comparing arrays of 30 integers "never finishes." With this PR's update, comparing arrays of 10,000 integers runs in < 0.1s on my machine.