### PR TITLE
Allow matchers to be reused

### DIFF
--- a/lib/rspec/matchers/built_in/contain_exactly.rb
+++ b/lib/rspec/matchers/built_in/contain_exactly.rb
@@ -31,6 +31,14 @@ module RSpec
           "contain exactly#{list}"
         end
 
+        def matches?(actual)
+          @pairings_maximizer = nil
+          @best_solution = nil
+          @extra_items = nil
+          @missing_items = nil
+          super(actual)
+        end
+
       private
 
         def generate_failure_message

--- a/spec/rspec/matchers/built_in/contain_exactly_spec.rb
+++ b/spec/rspec/matchers/built_in/contain_exactly_spec.rb
@@ -473,6 +473,32 @@ RSpec.describe "Composing `contain_exactly` with other matchers" do
   end
 end
 
+RSpec.describe "Reusing a matcher that memoizes state" do
+  require "rspec/matchers/fail_matchers"
+
+  it "works properly in spite of the memoization" do
+    matcher = contain_exactly(eq(1))
+
+    expect {
+      expect([2]).to matcher
+    }.to fail_including(<<-MESSAGE)
+expected collection contained:  [(eq 1)]
+actual collection contained:    [2]
+the missing elements were:      [(eq 1)]
+the extra elements were:        [2]
+    MESSAGE
+
+    expect {
+      expect([3]).to matcher
+    }.to fail_including(<<-MESSAGE)
+expected collection contained:  [(eq 1)]
+actual collection contained:    [3]
+the missing elements were:      [(eq 1)]
+the extra elements were:        [3]
+    MESSAGE
+  end
+end
+
 module RSpec
   module Matchers
     module BuiltIn


### PR DESCRIPTION
This addresses issue #1287.

Previously, matchers retained state after being used as an argument to `RSpec::Expectations::ExpectationTarget#to`.  In particular, it leaked `@extra_items`, `@missing_items`, `@best_solution`, and `@pairings_maximizer`. This caused incorrect results when reusing a matcher in subsequent expectations.

This PR addresses the issue by reinitializing the matcher's state when the matcher is reused.

Co-authored by: Rai Feren <rferen@squareup.com>