### PR TITLE
Speed up the ContainExactly matcher

### DIFF
--- a/lib/rspec/matchers/built_in/contain_exactly.rb
+++ b/lib/rspec/matchers/built_in/contain_exactly.rb
@@ -138,8 +138,8 @@ module RSpec
             expected.each_with_index {|v, i| (value_buckets[v] ||= []) << i }
             actual.each_with_index   {|v, i| (value_buckets[v] ||= []) << -i-1 }
             value_buckets.each do |_, indices|
-              e_indices = indices.filter {|i| i >= 0}.map {|i| i }
-              a_indices = indices.filter {|i| i < 0}.map {|i| -i-1 }
+              e_indices = indices.select {|i| i >= 0}.map {|i| i }
+              a_indices = indices.select {|i| i < 0}.map {|i| -i-1 }
               e_indices.zip(a_indices).each do |ei, ai|
                 break unless ai
                 expected_matches[ei] << ai

--- a/lib/rspec/matchers/built_in/contain_exactly.rb
+++ b/lib/rspec/matchers/built_in/contain_exactly.rb
@@ -128,18 +128,18 @@ module RSpec
           @best_solution ||= pairings_maximizer.find_best_solution
         end
 
-        def pairings_maximizer
+        def pairings_maximizer # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
           @pairings_maximizer ||= begin
             expected_matches = Hash[Array.new(expected.size) { |i| [i, []] }]
             actual_matches   = Hash[Array.new(actual.size)   { |i| [i, []] }]
 
             # Set the reciprocal pairings for matching elements
             value_buckets = {}
-            expected.each_with_index {|v, i| (value_buckets[v] ||= []) << i }
-            actual.each_with_index   {|v, i| (value_buckets[v] ||= []) << -i-1 }
+            expected.each_with_index { |v, i| (value_buckets[v] ||= []) << i }
+            actual.each_with_index   { |v, i| (value_buckets[v] ||= []) << -i-1 }
             value_buckets.each do |_, indices|
-              e_indices = indices.select {|i| i >= 0}.map {|i| i }
-              a_indices = indices.select {|i| i < 0}.map {|i| -i-1 }
+              e_indices = indices.select { |i| i >= 0 }.map { |i| i }
+              a_indices = indices.select { |i| i < 0 }.map { |i| -i-1 }
               e_indices.zip(a_indices).each do |ei, ai|
                 break unless ai
                 expected_matches[ei] << ai

--- a/spec/rspec/matchers/built_in/contain_exactly_spec.rb
+++ b/spec/rspec/matchers/built_in/contain_exactly_spec.rb
@@ -193,16 +193,17 @@ MESSAGE
   end
 
   it 'fails a match of 1000 items with duplicates in a reasonable amount of time' do
-    timeout_if_not_debugging(0.1) do
-      a = Array.new(1000) { rand(10) }
-      b = a.reverse
-      actual = b.shift
-      b << 10
+    timeout_if_not_debugging(0.5) do
+      actual = Array.new(1000) { rand(10) }
+      expected = actual.reverse
+      extra = expected.shift
+      missing = 10
+      expected << missing
       expect {
-        expect(a).to match_array(b)
+        expect(actual).to match_array(expected)
       }.to fail_including(<<-MESSAGE)
-the missing elements were:      [10]
-the extra elements were:        [#{actual}]
+the missing elements were:      [#{missing}]
+the extra elements were:        [#{extra}]
 MESSAGE
     end
   end

--- a/spec/rspec/matchers/built_in/contain_exactly_spec.rb
+++ b/spec/rspec/matchers/built_in/contain_exactly_spec.rb
@@ -192,27 +192,16 @@ MESSAGE
     end
   end
 
-  it 'fails a match of 11 items with duplicates in a reasonable amount of time' do
-    timeout_if_not_debugging(0.1) do
-      expected = [0, 1, 1,    3, 3, 3,    4, 4,    8, 8, 9   ]
-      actual   = [   1,    2, 3, 3, 3, 3,       7, 8, 8, 9, 9]
-
-      expect {
-        expect(actual).to contain_exactly(*expected)
-      }.to fail_including("the missing elements were:      [0, 1, 4, 4]")
-    end
-  end
-
   it 'fails a match of 1000 items with duplicates in a reasonable amount of time' do
     timeout_if_not_debugging(0.1) do
-      a = Array.new(1000) { rand(1..9) }
+      a = Array.new(1000) { rand(10) }
       b = a.reverse
       actual = b.shift
-      b << 0
+      b << 10
       expect {
         expect(a).to match_array(b)
       }.to fail_including(<<-MESSAGE)
-the missing elements were:      [0]
+the missing elements were:      [10]
 the extra elements were:        [#{actual}]
 MESSAGE
     end

--- a/spec/rspec/matchers/built_in/contain_exactly_spec.rb
+++ b/spec/rspec/matchers/built_in/contain_exactly_spec.rb
@@ -203,6 +203,21 @@ MESSAGE
     end
   end
 
+  it 'fails a match of 1000 items with duplicates in a reasonable amount of time' do
+    timeout_if_not_debugging(0.1) do
+      a = Array.new(1000) { rand(1..9) }
+      b = a.reverse
+      actual = b.shift
+      b << 0
+      expect {
+        expect(a).to match_array(b)
+      }.to fail_including(<<-MESSAGE)
+the missing elements were:      [0]
+the extra elements were:        [#{actual}]
+MESSAGE
+    end
+  end
+
   it "fails if target includes extra items" do
     expect {
       expect([1, 2, 3, 4]).to contain_exactly(1, 2, 3)


### PR DESCRIPTION
fixes #1006, #1161

Speed up the ContainExactly matcher by pre-emptively matching up corresponding elements in the expected and actual arrays.

This is an alternate implementation prototype for the issues addressed PR https://github.com/rspec/rspec-expectations/pull/1325

Please close this if I've stepped on any toes.