### PR TITLE
Speed up the ContainExactly matcher

### DIFF
--- a/lib/rspec/matchers/built_in/contain_exactly.rb
+++ b/lib/rspec/matchers/built_in/contain_exactly.rb
@@ -128,6 +128,15 @@ module RSpec
           @best_solution ||= pairings_maximizer.find_best_solution
         end
 
+        # This implementation is complicated but it facilitates an enormous speedup.
+        # The previous implementation never finished when comparing arrays of 50
+        # random integers between 1 and 10 (I stopped the execution after a full day).
+        # This implementation finishes that task in .03s on my laptop.
+        # This represents a speedup of over 259,000x for that task!  The gap widens
+        # exponentially as the array size increases:
+        # Assuming the old implementation takes a day to compare arrays of 50 random
+        # integers, comparing arrays of 1000 elements would take 10^2486 billion years.
+        # The new implementation finishes this task in 1 second!
         def pairings_maximizer # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
           @pairings_maximizer ||= begin
             expected_matches = Hash[Array.new(expected.size) { |i| [i, []] }]

--- a/spec/rspec/matchers/built_in/contain_exactly_spec.rb
+++ b/spec/rspec/matchers/built_in/contain_exactly_spec.rb
@@ -193,7 +193,7 @@ MESSAGE
       end
     end
 
-    shared_examples "succeeds fast" do
+    shared_examples "for succeeding quickly" do
       it do
         timeout_if_not_debugging(max_runtime) do
           subject
@@ -201,7 +201,7 @@ MESSAGE
       end
     end
 
-    shared_examples "fails fast" do |failure_msg|
+    shared_examples "for failing fast with" do |failure_msg|
       it do
         timeout_if_not_debugging(max_runtime) do
           expect {
@@ -215,42 +215,46 @@ MESSAGE
     let(:actual) { Array.new(1000) { rand(10) } }
 
     context "with a positive expectation" do
-      subject { expect(actual).to contain_exactly(*expected) }
+      subject(:expect_actual_to_contain_exactly_expected) do
+        expect(actual).to contain_exactly(*expected)
+      end
 
       context "that is valid" do
         let(:expected) { actual.shuffle }
 
         it "matches" do
-          subject
+          expect_actual_to_contain_exactly_expected
         end
 
-        include_examples "succeeds fast"
+        include_examples "for succeeding quickly"
       end
 
       context "that is not valid" do
         let(:expected) { Array.new(1000) { rand(10) } }
 
-        include_examples "fails fast", "expected collection contained"
+        include_examples "for failing fast with", "expected collection contained"
       end
     end
 
     context "with a negative expectation" do
-      subject { expect(actual).not_to contain_exactly(*expected) }
+      subject(:expect_actual_not_to_contain_exactly_expected) do
+        expect(actual).not_to contain_exactly(*expected)
+      end
 
       context "that is valid" do
         let(:expected) { Array.new(1000) { rand(10) } }
 
         it "does not match" do
-          subject
+          expect_actual_not_to_contain_exactly_expected
         end
 
-        include_examples "succeeds fast"
+        include_examples "for succeeding quickly"
       end
 
       context "that is not valid" do
         let(:expected) { actual.shuffle }
 
-        include_examples "fails fast", "not to contain exactly"
+        include_examples "for failing fast with", "not to contain exactly"
       end
     end
   end

--- a/spec/rspec/matchers/built_in/contain_exactly_spec.rb
+++ b/spec/rspec/matchers/built_in/contain_exactly_spec.rb
@@ -211,8 +211,8 @@ MESSAGE
       end
     end
 
-    let(:max_runtime) { 2 }
-    let(:actual) { Array.new(10_000) { rand(10) } }
+    let(:max_runtime) { 0.5 }
+    let(:actual) { Array.new(1000) { rand(10) } }
 
     context "with a positive expectation" do
       subject { expect(actual).to contain_exactly(*expected) }
@@ -228,7 +228,7 @@ MESSAGE
       end
 
       context "that is not valid" do
-        let(:expected) { Array.new(10_000) { rand(10) } }
+        let(:expected) { Array.new(1000) { rand(10) } }
 
         include_examples "fails fast", "expected collection contained"
       end
@@ -238,7 +238,7 @@ MESSAGE
       subject { expect(actual).not_to contain_exactly(*expected) }
 
       context "that is valid" do
-        let(:expected) { Array.new(10_000) { rand(10) } }
+        let(:expected) { Array.new(1000) { rand(10) } }
 
         it "does not match" do
           subject


### PR DESCRIPTION
Speed up the ContainExactly matcher by pre-emptively matching up corresponding elements in the expected and actual arrays. 

This addresses issues rspec/rspec#84, rspec/rspec#136.

**Before this PR, comparing two arrays of 50 random integers never finished.  Now, comparing arrays of 10,000 random integers takes 1 second.**

This PR is a collaboration between @genehsu and I based on a couple of our earlier PRs and discussion that resulted:
1) https://github.com/rspec/rspec-expectations/pull/1325
2) https://github.com/rspec/rspec-expectations/pull/1328

Co-authored-by: Gene Hsu <gene@hsufarm.com>