### PR TITLE
Update Cucumber so that in runs across a range of Rubies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,4 +92,8 @@ if RUBY_VERSION >= '2.4' && RUBY_ENGINE == 'ruby'
   gem 'rubocop', "~> 0.52.1"
 end
 
+if RUBY_VERSION < '2.0.0'
+  gem 'cucumber', "<= 1.3.22"
+end
+
 eval File.read('Gemfile-custom') if File.exist?('Gemfile-custom')

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,10 +1,15 @@
 <%
-def tags(tag)
+
+USE_TILDE_TAGS = !defined?(::RUBY_ENGINE_VERSION) || (::RUBY_ENGINE_VERSION < '2.0.0')
+NOT_WIP_TAG = USE_TILDE_TAGS ? '~@wip' : '"not @wip"'
+NOT_RUBY_1_9_TAG = USE_TILDE_TAGS ? '~@ruby-1.9' : '"not @ruby-1.9"'
+
+def tags(tag = NOT_WIP_TAG)
   tags = [tag]
-  tags << "~@ruby-1.9" if RUBY_VERSION.to_f < 1.9
+  tags << NOT_RUBY_1_9_TAG if RUBY_VERSION.to_f < 1.9
   tags.join(" --tags ")
 end
 %>
 
-default: --require features --tags <%= tags("~@wip") %> --format progress
+default: --require features --tags <%= tags %> --format progress
 wip: --require features --tags @wip:3 --wip features

--- a/features/support/diff_lcs_versions.rb
+++ b/features/support/diff_lcs_versions.rb
@@ -1,8 +1,8 @@
 require 'diff-lcs'
 
 Around "@skip-when-diff-lcs-1.4" do |scenario, block|
-  if Diff::LCS::VERSION.to_f >= 1.4
-    warn "Skipping scenario #{scenario.title} on `diff-lcs` v#{Diff::LCS::VERSION.to_f}"
+  if Diff::LCS::VERSION >= '1.4'
+    skip_this_scenario "Skipping scenario #{scenario.name} on `diff-lcs` v#{Diff::LCS::VERSION}"
   else
     block.call
   end
@@ -10,15 +10,15 @@ end
 
 Around "@skip-when-diff-lcs-1.4.3" do |scenario, block|
   if Diff::LCS::VERSION =~ /1\.4\.3/
-    warn "Skipping scenario #{scenario.title} on `diff-lcs` v#{Diff::LCS::VERSION}"
+    skip_this_scenario "Skipping scenario #{scenario.name} on `diff-lcs` v#{Diff::LCS::VERSION}"
   else
     block.call
   end
 end
 
 Around "@skip-when-diff-lcs-1.3" do |scenario, block|
-  if Diff::LCS::VERSION.to_f < 1.4
-    warn "Skipping scenario #{scenario.title} on `diff-lcs` v#{Diff::LCS::VERSION.to_f}"
+  if Diff::LCS::VERSION < '1.4'
+    skip_this_scenario "Skipping scenario #{scenario.name} on `diff-lcs` v#{Diff::LCS::VERSION}"
   else
     block.call
   end

--- a/features/support/disallow_certain_apis.rb
+++ b/features/support/disallow_certain_apis.rb
@@ -3,7 +3,8 @@
 
 if defined?(Cucumber)
   require 'shellwords'
-  Before('~@allow-disallowed-api') do
+  tag = !defined?(::RUBY_ENGINE_VERSION) || (::RUBY_ENGINE_VERSION < '2.0.0') ? '~@allow-disallowed-api': 'not @allow-disallowed-api'
+  Before(tag) do
     set_environment_variable('SPEC_OPTS', "-r#{Shellwords.escape(__FILE__)}")
   end
 else

--- a/features/support/ruby_features.rb
+++ b/features/support/ruby_features.rb
@@ -4,7 +4,7 @@ Around "@skip-when-splat-args-unsupported" do |scenario, block|
   if ::RSpec::Support::RubyFeatures.optional_and_splat_args_supported?
     block.call
   else
-    warn "Skipping scenario #{scenario.title} because splat arguments are not supported"
+    skip_this_scenario "Skipping scenario #{scenario.name} because splat arguments are not supported"
   end
 end
 
@@ -14,7 +14,7 @@ Around "@skip-when-keyword-args-unsupported" do |scenario, block|
   if ::RSpec::Support::RubyFeatures.kw_args_supported?
     block.call
   else
-    warn "Skipping scenario #{scenario.title} because keyword arguments are not supported"
+    skip_this_scenario "Skipping scenario #{scenario.name} because keyword arguments are not supported"
   end
 end
 
@@ -24,7 +24,7 @@ Around "@skip-when-required-keyword-args-unsupported" do |scenario, block|
   if ::RSpec::Support::RubyFeatures.required_kw_args_supported?
     block.call
   else
-    warn "Skipping scenario #{scenario.title} because required keyword arguments are not supported"
+    skip_this_scenario "Skipping scenario #{scenario.name} because required keyword arguments are not supported"
   end
 end
 
@@ -34,6 +34,6 @@ Around "@skip-when-ripper-unsupported" do |scenario, block|
   if ::RSpec::Support::RubyFeatures.ripper_supported?
     block.call
   else
-    warn "Skipping scenario #{scenario.title} because Ripper is not supported"
+    skip_this_scenario "Skipping scenario #{scenario.name} because Ripper is not supported"
   end
 end

--- a/rspec-expectations.gemspec
+++ b/rspec-expectations.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "diff-lcs", ">= 1.2.0", "< 2.0"
 
   s.add_development_dependency "aruba",    "~> 0.14.10"
-  s.add_development_dependency 'cucumber', '~> 1.3'
+  s.add_development_dependency 'cucumber', '>= 1.3'
   s.add_development_dependency 'minitest', '~> 5.2'
   s.add_development_dependency 'rake',     '> 10.0.0'
 end

--- a/spec/rspec/matchers/built_in/contain_exactly_spec.rb
+++ b/spec/rspec/matchers/built_in/contain_exactly_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "should =~ array", :uses_should do
 
   context "when the array undefines `=~`" do
     it 'still works' do
-      array_klass = Class.new(Array) { undef =~ }
+      array_klass = Class.new(Array) { undef =~ if respond_to?(:=~) }
       array = array_klass.new([1, 2])
 
       array.should =~ [1, 2]


### PR DESCRIPTION
This PR allows more recent Rubies to use more recent versions of Cucumber, while still supporting older Cucumber versions. 