### PR TITLE
Add an_array_matching alias for match_array

### DIFF
--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -36,7 +36,7 @@ module RSpec
   #     expect([]).to be_empty     # => [].empty?() | passes
   #     expect([]).not_to be_empty # => [].empty?() | fails
   #
-  # In addtion to prefixing the predicate matchers with "be_", you can also use "be_a_"
+  # In addition to prefixing the predicate matchers with "be_", you can also use "be_a_"
   # and "be_an_", making your specs read much more naturally:
   #
   #     expect("a string").to be_an_instance_of(String) # =>"a string".instance_of?(String) # passes
@@ -715,6 +715,9 @@ module RSpec
     def match_array(items)
       contain_exactly(*items)
     end
+    alias_matcher :an_array_matching, :match_array do |desc|
+      desc.sub("contain exactly", "an array containing exactly")
+    end
 
     # With no arg, passes if the block outputs `to_stdout` or `to_stderr`.
     # With a string, passes if the block outputs that specific string `to_stdout` or `to_stderr`.
@@ -753,8 +756,8 @@ module RSpec
 
     # With no args, matches if any error is raised.
     # With a named error, matches only if that specific error is raised.
-    # With a named error and messsage specified as a String, matches only if both match.
-    # With a named error and messsage specified as a Regexp, matches only if both match.
+    # With a named error and message specified as a String, matches only if both match.
+    # With a named error and message specified as a Regexp, matches only if both match.
     # Pass an optional block to perform extra verifications on the exception matched
     #
     # @example

--- a/spec/rspec/matchers/aliases_spec.rb
+++ b/spec/rspec/matchers/aliases_spec.rb
@@ -294,6 +294,14 @@ module RSpec
 
     specify do
       expect(
+        an_array_matching([1, 2])
+      ).to be_aliased_to(
+        match_array([1, 2])
+      ).with_description('an array containing exactly 1 and 2')
+    end
+
+    specify do
+      expect(
         a_block_outputting('foo').to_stdout
       ).to be_aliased_to(
         output('foo').to_stdout


### PR DESCRIPTION
This improves readability when used as an argument matcher.

```
expect(obj).to receive(:msg).with(an_array_matching([1, 2]))
```
