### PR TITLE
Add exception_complement for TruffleRuby

### DIFF
--- a/spec/rspec/expectations/failure_aggregator_spec.rb
+++ b/spec/rspec/expectations/failure_aggregator_spec.rb
@@ -440,6 +440,10 @@ module RSpec::Expectations
         def exception_complement(block_levels)
           ""
         end
+      elsif RSpec::Support::Ruby.truffleruby?
+        def exception_complement(block_levels)
+          ":in `block (#{block_levels} levels) in <module:Expectations>'"
+        end
       elsif RUBY_VERSION > "2.0.0"
         def exception_complement(block_levels)
           ":in `block in Expectations'"


### PR DESCRIPTION
Adding the correct `exception_complement` implementation for TruffleRuby allows all of the `rspec-expectations` specs to pass.