### PR TITLE
Add allowed feature path for TruffleRuby library wide checks

### DIFF
--- a/spec/rspec/expectations_spec.rb
+++ b/spec/rspec/expectations_spec.rb
@@ -1,6 +1,14 @@
 require 'rspec/support/spec/library_wide_checks'
 
 RSpec.describe "RSpec::Expectations" do
+  allowed_loaded_features = [
+    /stringio/, # Used by `output` matcher. Can't be easily avoided.
+    /rbconfig/  # required by rspec-support
+  ]
+
+  # Truffleruby cext files
+  allowed_loaded_features << /\/truffle\/cext/ if RSpec::Support::Ruby.truffleruby?
+
   it_behaves_like "library wide checks", "rspec-expectations",
     :preamble_for_lib => [
       # We define minitest constants because rspec/expectations/minitest_integration
@@ -8,10 +16,7 @@ RSpec.describe "RSpec::Expectations" do
       "module Minitest; class Assertion; end; module Test; end; end",
       'require "rspec/expectations"'
     ],
-    :allowed_loaded_feature_regexps => [
-      /stringio/, # Used by `output` matcher. Can't be easily avoided.
-      /rbconfig/  # required by rspec-support
-    ]
+    :allowed_loaded_feature_regexps => allowed_loaded_features
 
   it 'does not allow expectation failures to be caught by a bare rescue' do
     expect {


### PR DESCRIPTION
This PR is organized similar to `core_spec.rb`:
https://github.com/rspec/rspec-core/blob/1a1788768ec39a1f252ea756ed9b53cdd21124d5/spec/rspec/core_spec.rb#L17

Fixes this failure on TruffleRuby:

```
  1) RSpec::Expectations behaves like library wide checks only loads a known set of stdlibs so gem authors are forced to load libs they use to have passing specs
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected: []
            got: ["/Users/bfish/Documents/truffleruby-ws/graal/sdk/mxbuild/darwin-amd64/GRAALVM_67F33FC705_JAVA11/graa...VA11/graalvm-67f33fc705-java11-22.2.0-dev/Contents/Home/languages/ruby/lib/truffle/truffle/cext.rb"]
     
       (compared using ==)
```
