### PR TITLE
Show attribute details when composed have_attributes fails

### DIFF
--- a/lib/rspec/matchers/composable.rb
+++ b/lib/rspec/matchers/composable.rb
@@ -126,7 +126,7 @@ module RSpec
       # this method when using `values_match?`, so that any memoization
       # does not "leak" between checks.
       def with_matchers_cloned(object)
-        if Matchers.is_a_matcher?(object)
+        if Matchers.is_a_matcher?(object) && !(::RSpec::Matchers::BuiltIn::HaveAttributes === object)
           object.clone
         elsif Hash === object
           Hash[with_matchers_cloned(object.to_a)]

--- a/spec/rspec/matchers/built_in/have_attributes_spec.rb
+++ b/spec/rspec/matchers/built_in/have_attributes_spec.rb
@@ -115,6 +115,18 @@ RSpec.describe "#have_attributes matcher" do
         }.to fail_including("expected #{object_inspect person} to have attributes {:age => (a value < 10)}")
       end
     end
+
+    describe "expect([...]).to match(have_attributes(with_one_attribute))" do
+      it "fails with a clear message when attributes does not match" do
+        expect {
+          expect(person).to have_attributes(:age => 10)
+        }.to fail_including("expected #{object_inspect person} to have attributes {:age => 10} but had attributes {:age => 33}")
+
+        expect {
+          expect([person]).to match [have_attributes(:age => 10)]
+        }.to fail_including("expected [#{object_inspect person}] to match [(have attributes {:age => 10} but had attributes {:age => 33})]")
+      end
+    end
   end
 
   describe "expect(...).to_not have_attributes(with_one_attribute)" do

--- a/spec/support/shared_examples/value_matcher.rb
+++ b/spec/support/shared_examples/value_matcher.rb
@@ -36,10 +36,14 @@ RSpec.shared_examples "an RSpec value matcher" do |options|
 
   it 'can be used in a composed matcher expression' do
     expect([valid_value, invalid_value]).to include(matcher)
+    # matcher.description => "have attributes {:name => \"Correct name\"}"
+
+    expect([invalid_value]).not_to include(matcher)
+    # matcher.description => "have attributes {:name => \"Correct name\"} but had attributes {:name => \"Wrong Name\"}"
 
     expect {
       expect([invalid_value]).to include(matcher)
-    }.to fail_including("include (#{matcher.description})")
+    }.to fail_including("include (#{matcher.description})") # matcher.description contains description of the most recent assertion
   end
 
   it 'uses the `ObjectFormatter` for `failure_message`' do


### PR DESCRIPTION
As requested in rspec/rspec#131

For example
`expect([person]).to match [have_attributes(:age => 10)]`

Before
`expected [#{object_inspect person}] to match [(have attributes {:age => 10})]`

After
`expected [#{object_inspect person}] to match [(have attributes {:age => 10} but had attributes {:age => 33})]`