### PR TITLE
Mention notify_expectation_failures in custom matcher docs

### DIFF
--- a/features/custom_matchers/define_matcher.feature
+++ b/features/custom_matchers/define_matcher.feature
@@ -461,27 +461,29 @@ Feature: Define a custom matcher
 
     Given a file named "bubbling_expectation_errors_spec.rb" with:
       """ruby
-      RSpec::Matchers.define :be_close_to_pi do
+      RSpec::Matchers.define :be_a_palindrome do
         match(:notify_expectation_failures => true) do |actual|
-          expect(actual).to be_a(Float)
-          expect(actual).to be_within(0.0015).of(Math::PI)
+          expect(actual).to be_a(String)
+          expect(actual.reverse).to eq(actual)
         end
       end
 
       RSpec.describe "a custom matcher that bubbles up expectation errors" do
         it "bubbles expectation errors" do
-          expect(3.0).to be_close_to_pi
+          expect("carriage").to be_a_palindrome
         end
       end
       """
-    When I run `rspec ./bubbling_expectation_errors_spec.rb`
-    Then it should fail with:
-      """
-      Failures:
+    When I run `rspec bubbling_expectation_errors_spec.rb`
+    Then the output should contain all of these:
+      | Failures:                                                                           |
 
-        1) a custom matcher that bubbles up expectation errors bubbles expectation errors
-           Failure/Error: expect(actual).to be_within(0.0015).of(Math::PI)
-             expected 3.0 to be within 0.0015 of 3.141592653589793
-           # ./bubbling_expectation_errors_spec.rb:4:in `block (2 levels) in <top (required)>'
-           # ./bubbling_expectation_errors_spec.rb:10:in `block (2 levels) in <top (required)>'
-      """
+      |   1) a custom matcher that bubbles up expectation errors bubbles expectation errors |
+      |      Failure/Error: expect(actual.reverse).to eq(actual)                            |
+
+      |        expected: "carriage"                                                         |
+      |             got: "egairrac"                                                         |
+
+      |        (compared using ==)                                                          |
+      |      # ./bubbling_expectation_errors_spec.rb:4                                      |
+      |      # ./bubbling_expectation_errors_spec.rb:10                                     |

--- a/features/custom_matchers/define_matcher.feature
+++ b/features/custom_matchers/define_matcher.feature
@@ -454,3 +454,34 @@ Feature: Define a custom matcher
       """
     When I run `rspec ./alias_spec.rb --format documentation`
     Then the exit status should be 0
+
+  Scenario: With expectation errors that bubble up
+
+    By default the match block will swallow expectation errors (e.g. caused by using an expectation such as `expect(1).to eq 2`), if you with to allow these to bubble up, pass in the option `:notify_expectation_failures => true`.
+
+    Given a file named "bubbling_expectation_errors_spec.rb" with:
+      """ruby
+      RSpec::Matchers.define :be_close_to_pi do
+        match(:notify_expectation_failures => true) do |actual|
+          expect(actual).to be_a(Float)
+          expect(actual).to be_within(0.0015).of(Math::PI)
+        end
+      end
+
+      RSpec.describe "a custom matcher that bubbles up expectation errors" do
+        it "bubbles expectation errors" do
+          expect(3.0).to be_close_to_pi
+        end
+      end
+      """
+    When I run `rspec ./bubbling_expectation_errors_spec.rb`
+    Then it should fail with:
+      """
+      Failures:
+
+        1) a custom matcher that bubbles up expectation errors bubbles expectation errors
+           Failure/Error: expect(actual).to be_within(0.0015).of(Math::PI)
+             expected 3.0 to be within 0.0015 of 3.141592653589793
+           # ./bubbling_expectation_errors_spec.rb:4:in `block (2 levels) in <top (required)>'
+           # ./bubbling_expectation_errors_spec.rb:10:in `block (2 levels) in <top (required)>'
+      """

--- a/features/custom_matchers/define_matcher.feature
+++ b/features/custom_matchers/define_matcher.feature
@@ -457,7 +457,7 @@ Feature: Define a custom matcher
 
   Scenario: With expectation errors that bubble up
 
-    By default the match block will swallow expectation errors (e.g. caused by using an expectation such as `expect(1).to eq 2`), if you with to allow these to bubble up, pass in the option `:notify_expectation_failures => true`.
+    By default the match block will swallow expectation errors (e.g. caused by using an expectation such as `expect(1).to eq 2`), if you wish to allow these to bubble up, pass in the option `:notify_expectation_failures => true`.
 
     Given a file named "bubbling_expectation_errors_spec.rb" with:
       """ruby

--- a/lib/rspec/matchers/dsl.rb
+++ b/lib/rspec/matchers/dsl.rb
@@ -122,7 +122,7 @@ module RSpec
         #
         # By default the match block will swallow expectation errors (e.g.
         # caused by using an expectation such as `expect(1).to eq 2`), if you
-        # with to allow these to bubble up, pass in the option
+        # wish to allow these to bubble up, pass in the option
         # `:notify_expectation_failures => true`.
         #
         # @param [Hash] options for defining the behavior of the match block.
@@ -151,7 +151,7 @@ module RSpec
         #
         # By default the match block will swallow expectation errors (e.g.
         # caused by using an expectation such as `expect(1).to eq 2`), if you
-        # with to allow these to bubble up, pass in the option
+        # wish to allow these to bubble up, pass in the option
         # `:notify_expectation_failures => true`.
         #
         # @param [Hash] options for defining the behavior of the match block.


### PR DESCRIPTION
I defined a custom matcher that defined some `expect(...).to ...` expectations inside the `#match` block. I got one of these expectations to fail, and then was stumped as to why the file and line number of this failure didn't appear in the backtrace. Then I stumbled across the `notify_expectation_failures` option for `#match`, and realized that I needed to set it to `true` to get the failure to appear in the backtrace.

I think this would be good to mention in the relishapp documentation? It's currently mentioned in [the API documentation](https://rspec.info/documentation/3.9/rspec-expectations/RSpec/Matchers/DSL/Macros.html), which is good, but I feel this documentation a little more obscure.