### PR TITLE
Prevent deprecation warning from `expect(FileTest).to exist(x)`

### DIFF
--- a/lib/rspec/matchers/built_in/exist.rb
+++ b/lib/rspec/matchers/built_in/exist.rb
@@ -81,7 +81,7 @@ module RSpec
           end
 
           def deprecated(predicate, actual)
-            predicate == :exists? && File == actual
+            predicate == :exists? && (File == actual || FileTest == actual)
           end
         end
       end

--- a/spec/rspec/matchers/built_in/exist_spec.rb
+++ b/spec/rspec/matchers/built_in/exist_spec.rb
@@ -125,6 +125,12 @@ RSpec.describe "exist matcher" do
           expect(File).to exist __FILE__
         end
       end
+
+      context 'FileTest has deprecated exists?' do
+        it 'will not call exists? triggering the warning' do
+          expect(FileTest).to exist __FILE__
+        end
+      end
     end
   end
 


### PR DESCRIPTION
I found that `expect(FileTest).to exist(x)` also outputs deprecation warnings in the same way as `expect(File).to exist(x)` before https://github.com/rspec/rspec-expectations/pull/954.

```
FileTest.exists? is a deprecated name, use FileTest.exist? instead
```

I confirmed that this warning is displayed on Ruby 2.7.6 and Ruby 3.1.2.

So it would be nice that we also support `FileTest` as well as `File`. It won't be used that much, but it's not a big change and it would be better to support it.