### PR TITLE
Raise an exception when a `nil` is passed as the first argument to `raise_error`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,8 @@ Breaking Changes:
   (Phil Pirozhkov, #1285)
 * Remove deprecated `match_regex` matcher. (Phil Pirozhkov, #1288)
 * Remove deprecated `StartAndEndWith` matcher base class. (Phil Pirozhkov, #1288)
+* Raise an exception when a `nil` is passed as the first argument to `raise_error`.
+  (Phil Pirozhkov, #1389)
 
 ### 3.12.0 / 2022-10-26
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.11.1...v3.12.0)

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,7 +15,7 @@ Breaking Changes:
   (Phil Pirozhkov, #1285)
 * Remove deprecated `match_regex` matcher. (Phil Pirozhkov, #1288)
 * Remove deprecated `StartAndEndWith` matcher base class. (Phil Pirozhkov, #1288)
-* Raise an exception when a `nil` is passed as the first argument to `raise_error`.
+* Raise `ArgumentError` when a `nil` is passed as the first argument to `raise_error`.
   (Phil Pirozhkov, #1389)
 
 ### 3.12.0 / 2022-10-26

--- a/lib/rspec/matchers/built_in/raise_error.rb
+++ b/lib/rspec/matchers/built_in/raise_error.rb
@@ -186,13 +186,14 @@ module RSpec
         end
 
         def raise_nil_argument_error!
-          raise "Using the `raise_error` matcher with a `nil` error is probably " \
-                "unintentional, it risks false positives, since `raise_error` " \
-                "will match when Ruby raises a `NoMethodError`, `NameError` or " \
-                "`ArgumentError`, potentially allowing the expectation to pass " \
-                "without even executing the method you are intending to call. " \
+          raise ArgumentError, "Using the `raise_error` matcher with a `nil` " \
+                "value is probably unintentional, it risks false positives, since " \
+                "`raise_error` will match when Ruby raises a `NoMethodError`" \
+                ", `NameError` or `ArgumentError`, potentially allowing the " \
+                "expectation to pass without even executing the method you "\
+                "are intending to call. " \
                 "#{warning}"\
-                "Instead consider providing a specific error class or message."
+                "Instead provide a specific error class or message."
         end
 
         def warn_about_negative_false_positive!(expression)

--- a/lib/rspec/matchers/built_in/raise_error.rb
+++ b/lib/rspec/matchers/built_in/raise_error.rb
@@ -19,10 +19,10 @@ module RSpec
           @block = block
           @actual_error = nil
           @warn_about_bare_error = UndefinedValue === expected_error_or_message
-          @warn_about_nil_error = expected_error_or_message.nil?
+          raise_nil_argument_error! if expected_error_or_message.nil?
 
           case expected_error_or_message
-          when nil, UndefinedValue
+          when UndefinedValue
             @expected_error = Exception
             @expected_message = expected_message
           when String
@@ -65,7 +65,6 @@ module RSpec
 
           unless negative_expectation
             warn_about_bare_error! if warn_about_bare_error?
-            warn_about_nil_error! if warn_about_nil_error?
             eval_block if ready_to_eval_block?
           end
 
@@ -158,8 +157,6 @@ module RSpec
                          "`expect { }.not_to raise_error(SpecificErrorClass)`"
                        elsif @expected_message
                          "`expect { }.not_to raise_error(message)`"
-                       elsif @warn_about_nil_error
-                         "`expect { }.not_to raise_error(nil)`"
                        end
 
           return unless expression
@@ -175,10 +172,6 @@ module RSpec
           @warn_about_bare_error && @block.nil?
         end
 
-        def warn_about_nil_error?
-          @warn_about_nil_error
-        end
-
         def warn_about_bare_error!
           handle_warning("Using the `raise_error` matcher without providing a specific " \
                          "error or message risks false positives, since `raise_error` " \
@@ -192,17 +185,14 @@ module RSpec
                          "_positives = :nothing`")
         end
 
-        def warn_about_nil_error!
-          handle_warning("Using the `raise_error` matcher with a `nil` error is probably " \
-                         "unintentional, it risks false positives, since `raise_error` " \
-                         "will match when Ruby raises a `NoMethodError`, `NameError` or " \
-                         "`ArgumentError`, potentially allowing the expectation to pass " \
-                         "without even executing the method you are intending to call. " \
-                         "#{warning}"\
-                         "Instead consider providing a specific error class or message. " \
-                         "This message can be suppressed by setting: " \
-                         "`RSpec::Expectations.configuration.on_potential_false" \
-                         "_positives = :nothing`")
+        def raise_nil_argument_error!
+          raise "Using the `raise_error` matcher with a `nil` error is probably " \
+                "unintentional, it risks false positives, since `raise_error` " \
+                "will match when Ruby raises a `NoMethodError`, `NameError` or " \
+                "`ArgumentError`, potentially allowing the expectation to pass " \
+                "without even executing the method you are intending to call. " \
+                "#{warning}"\
+                "Instead consider providing a specific error class or message."
         end
 
         def warn_about_negative_false_positive!(expression)

--- a/spec/rspec/matchers/built_in/raise_error_spec.rb
+++ b/spec/rspec/matchers/built_in/raise_error_spec.rb
@@ -22,14 +22,16 @@ RSpec.describe "expect { ... }.to raise_error" do
     expect { raise StandardError.new, 'boom' }.to raise_error
   end
 
-  it "issues a warning when `nil` is passed for an error class" do
-    expect_warning_with_call_site __FILE__, __LINE__+1, /with a `nil`/
-    expect { raise }.to raise_error(nil)
+  it "raises an exception when `nil` is passed for an error class" do
+    expect {
+      expect { raise }.to raise_error(nil)
+    }.to raise_error(/with a `nil`/)
   end
 
-  it "issues a warning when `nil` is passed for an error class when negated" do
-    expect_warning_with_call_site __FILE__, __LINE__+1, /raise_error\(nil\)/
-    expect { '' }.not_to raise_error(nil)
+  it "raises an exception when `nil` is passed for an error class when negated" do
+    expect {
+      expect { '' }.not_to raise_error(nil)
+    }.to raise_error(/with a `nil`/)
   end
 
   it "issues a warning that does not include current error when it's not present" do


### PR DESCRIPTION
Follow-up to #1143