### PR TITLE
chore: Add Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - '3.2'
           - '3.1'
           - '3.0'
           - 2.7


### PR DESCRIPTION
Follow up: https://github.com/rspec/rspec-rails/pull/2648