### PR TITLE
Update matchers to show detected string encoding differences

### DIFF
--- a/lib/rspec/matchers/built_in/base_matcher.rb
+++ b/lib/rspec/matchers/built_in/base_matcher.rb
@@ -167,20 +167,35 @@ module RSpec
           # @return [Boolean] True if the actual and expected string encoding are different.
           #   i.e. the failure may be related to encoding differences and the encoding
           #   should be shown to the user. false otherwise.
-          def string_encoding_differs?
-            actual.is_a?(String) && expected.is_a?(String) &&
-              # Older Ruby versions do not support #encoding
-              actual.respond_to?(:encoding) && expected.respond_to?(:encoding) &&
-              actual.encoding != expected.encoding
+          if String.method_defined?(:encoding)
+            def string_encoding_differs?
+              actual.is_a?(String) && expected.is_a?(String) && actual.encoding != expected.encoding
+            end
+          else
+            # @api private
+            # @return [Boolean] False always as the curent Ruby version does not support String encoding
+            def string_encoding_differs?
+              false
+            end
           end
           module_function :string_encoding_differs?
 
-          # @api private
-          # Formats a String's encoding as a human readable string
-          # @param value [String]
-          # @return [String]
-          def format_encoding(value)
-            "#<Encoding:#{value.encoding.name}>"
+          if String.method_defined?(:encoding)
+            # @api private
+            # Formats a String's encoding as a human readable string
+            # @param value [String]
+            # @return [String]
+            def format_encoding(value)
+              "#<Encoding:#{value.encoding.name}>"
+            end
+          else
+            # @api private
+            # Formats a String's encoding as a human readable string
+            # @param _value [String]
+            # @return [nil] nil as the curent Ruby version does not support String encoding
+            def format_encoding(_value)
+              nil
+            end
           end
           module_function :format_encoding
         end

--- a/lib/rspec/matchers/built_in/base_matcher.rb
+++ b/lib/rspec/matchers/built_in/base_matcher.rb
@@ -161,6 +161,32 @@ module RSpec
 
         include HashFormatting
 
+        # @private
+        module StringEncodingFormatting
+          # @api private
+          # @return [Boolean] True if the actual and expected string encoding are different.
+          #   i.e. the failure may be related to encoding differences and the encoding
+          #   should be shown to the user. false otherwise.
+          def string_encoding_differs?
+            actual.is_a?(String) && expected.is_a?(String) &&
+              # Older Ruby versions do not support #encoding
+              actual.respond_to?(:encoding) && expected.respond_to?(:encoding) &&
+              actual.encoding != expected.encoding
+          end
+          module_function :string_encoding_differs?
+
+          # @api private
+          # Formats a String's encoding as a human readable string
+          # @param value [String]
+          # @return [String]
+          def format_encoding(value)
+            "#<Encoding:#{value.encoding.name}>"
+          end
+          module_function :format_encoding
+        end
+
+        include StringEncodingFormatting
+
         # @api private
         # Provides default implementations of failure messages, based on the `description`.
         module DefaultFailureMessages

--- a/lib/rspec/matchers/built_in/eq.rb
+++ b/lib/rspec/matchers/built_in/eq.rb
@@ -8,7 +8,11 @@ module RSpec
         # @api private
         # @return [String]
         def failure_message
-          "\nexpected: #{expected_formatted}\n     got: #{actual_formatted}\n\n(compared using ==)\n"
+          if string_encoding_differs?
+            "\nexpected: #{format_encoding(expected)} #{expected_formatted}\n     got: #{format_encoding(actual)} #{actual_formatted}\n\n(compared using ==)\n"
+          else
+            "\nexpected: #{expected_formatted}\n     got: #{actual_formatted}\n\n(compared using ==)\n"
+          end
         end
 
         # @api private

--- a/lib/rspec/matchers/built_in/eql.rb
+++ b/lib/rspec/matchers/built_in/eql.rb
@@ -8,7 +8,11 @@ module RSpec
         # @api private
         # @return [String]
         def failure_message
-          "\nexpected: #{expected_formatted}\n     got: #{actual_formatted}\n\n(compared using eql?)\n"
+          if string_encoding_differs?
+            "\nexpected: #{format_encoding(expected)} #{expected_formatted}\n     got: #{format_encoding(actual)} #{actual_formatted}\n\n(compared using eql?)\n"
+          else
+            "\nexpected: #{expected_formatted}\n     got: #{actual_formatted}\n\n(compared using eql?)\n"
+          end
         end
 
         # @api private

--- a/spec/rspec/matchers/built_in/eq_spec.rb
+++ b/spec/rspec/matchers/built_in/eq_spec.rb
@@ -47,6 +47,33 @@ module RSpec
         expect(matcher.failure_message_when_negated).to eq "\nexpected: value != 1\n     got: 1\n\n(compared using ==)\n"
       end
 
+      # Older versions of Ruby do not have String#encoding available, they are an array of bytes
+      if RUBY_VERSION > "1.9"
+        context "with String encoding as UTF-16LE" do
+          it "provides message, expected and actual on #failure_message when string encoding is the same" do
+            matcher = eq('abc'.encode('UTF-16LE'))
+            matcher.matches?('def'.encode('UTF-16LE'))
+            expect(matcher.failure_message).to eq "\nexpected: \"abc\"\n     got: \"def\"\n\n(compared using ==)\n"
+          end
+
+          it "matches when actual is BINARY encoding and expected is UTF-8 encoding with the same chars" do
+            expect('abc'.encode('BINARY')).to eq 'abc'.encode('UTF-8')
+          end
+
+          it "provides message, expected and actual with encoding details on #failure_message when string encoding is different" do
+            matcher = eq('abc'.encode('UTF-16LE'))
+            matcher.matches?('abc'.force_encoding('ASCII-8BIT'))
+            expect(matcher.failure_message).to eq "\nexpected: #<Encoding:UTF-16LE> \"abc\"\n     got: #<Encoding:ASCII-8BIT> \"abc\"\n\n(compared using ==)\n"
+          end
+
+          it "provides message, expected and actual on #negative_failure_message" do
+            matcher = eq('abc'.encode('UTF-16LE'))
+            matcher.matches?('abc'.encode('UTF-16LE'))
+            expect(matcher.failure_message_when_negated).to eq "\nexpected: value != \"abc\"\n     got: \"abc\"\n\n(compared using ==)\n"
+          end
+        end
+      end
+
       context "with Time objects" do
         RSpec::Matchers.define :a_string_with_differing_output do
           match do |string|

--- a/spec/rspec/matchers/built_in/eq_spec.rb
+++ b/spec/rspec/matchers/built_in/eq_spec.rb
@@ -47,8 +47,8 @@ module RSpec
         expect(matcher.failure_message_when_negated).to eq "\nexpected: value != 1\n     got: 1\n\n(compared using ==)\n"
       end
 
-      # Older versions of Ruby do not have String#encoding available, they are an array of bytes
-      if RUBY_VERSION > "1.9"
+      # Older versions of Ruby such as less than 1.9 do not have String#encoding available, they are an array of bytes
+      if String.method_defined?(:encoding)
         context "with String encoding as UTF-16LE" do
           it "provides message, expected and actual on #failure_message when string encoding is the same" do
             matcher = eq('abc'.encode('UTF-16LE'))

--- a/spec/rspec/matchers/built_in/eql_spec.rb
+++ b/spec/rspec/matchers/built_in/eql_spec.rb
@@ -34,6 +34,33 @@ module RSpec
         matcher.matches?(1)
         expect(matcher.failure_message_when_negated).to eq "\nexpected: value != 1\n     got: 1\n\n(compared using eql?)\n"
       end
+
+      # Older versions of Ruby do not have String#encoding available, they are an array of bytes
+      if RUBY_VERSION > "1.9"
+        context "with String encoding as UTF-16LE" do
+          it "provides message, expected and actual on #failure_message when string encoding is the same" do
+            matcher = eql('abc'.encode('UTF-16LE'))
+            matcher.matches?('def'.encode('UTF-16LE'))
+            expect(matcher.failure_message).to eq "\nexpected: \"abc\"\n     got: \"def\"\n\n(compared using eql?)\n"
+          end
+
+          it "matches when actual is BINARY encoding and expected is UTF-8 encoding with the same chars" do
+            expect('abc'.encode('BINARY')).to eq 'abc'.encode('UTF-8')
+          end
+
+          it "provides message, expected and actual with encoding details on #failure_message when string encoding is different" do
+            matcher = eql('abc'.encode('UTF-16LE'))
+            matcher.matches?('abc'.force_encoding('ASCII-8BIT'))
+            expect(matcher.failure_message).to eq "\nexpected: #<Encoding:UTF-16LE> \"abc\"\n     got: #<Encoding:ASCII-8BIT> \"abc\"\n\n(compared using eql?)\n"
+          end
+
+          it "provides message, expected and actual on #negative_failure_message" do
+            matcher = eql('abc'.encode('UTF-16LE'))
+            matcher.matches?('abc'.encode('UTF-16LE'))
+            expect(matcher.failure_message_when_negated).to eq "\nexpected: value != \"abc\"\n     got: \"abc\"\n\n(compared using eql?)\n"
+          end
+        end
+      end
     end
   end
 end

--- a/spec/rspec/matchers/built_in/eql_spec.rb
+++ b/spec/rspec/matchers/built_in/eql_spec.rb
@@ -35,8 +35,8 @@ module RSpec
         expect(matcher.failure_message_when_negated).to eq "\nexpected: value != 1\n     got: 1\n\n(compared using eql?)\n"
       end
 
-      # Older versions of Ruby do not have String#encoding available, they are an array of bytes
-      if RUBY_VERSION > "1.9"
+      # Older versions of Ruby such as less than 1.9 do not have String#encoding available, they are an array of bytes
+      if String.method_defined?(:encoding)
         context "with String encoding as UTF-16LE" do
           it "provides message, expected and actual on #failure_message when string encoding is the same" do
             matcher = eql('abc'.encode('UTF-16LE'))


### PR DESCRIPTION
closes https://github.com/rspec/rspec-expectations/issues/1422

Updates the `eq` and `eql` matchers to show detected string encoding differences - https://github.com/rspec/rspec-expectations/issues/1422

### Before

Unclear why the test is failing. For an average user this might be confusing:

```
Example F

  1) Example Example
     Failure/Error: expect(actual).to eq(expected)

       expected: "abc"
            got: "abc"

       (compared using ==)
```

### After

Immediately clear that the string encodings are not the same and the tests might be impacted by this difference:

```
Example F

  1) Example Example
     Failure/Error: expect(actual).to eq(expected)

       expected: #<Encoding:ASCII-8BIT> "abc"
            got: #<Encoding:UTF-16LE> "abc"

       (compared using ==)
```