### PR TITLE
Change MiniTest to Minitest

### DIFF
--- a/spec/rspec/expectations/minitest_integration_spec.rb
+++ b/spec/rspec/expectations/minitest_integration_spec.rb
@@ -12,7 +12,7 @@ module RSpec
 
       it "includes itself in Minitest::Test, and sets up our exceptions to be counted as assertion failures" do
         with_minitest_loaded do
-          minitest_case = MiniTest::Test.allocate
+          minitest_case = ::Minitest::Test.allocate
           expect(minitest_case).to respond_to(*sample_matchers)
 
           expect(RSpec::Expectations::ExpectationNotMetError).to be ::Minitest::Assertion


### PR DESCRIPTION
`rspec-core` builds are failing due to a mis-detected namespace suddenly, this namespaces it to the root to either fix or see whats going on

*edit* Turns out we were accidentally using `MiniTest` rather than `Minitest` in our tests so fix that