### PR TITLE
Implement MatcherDelegator using the BlankSlate pattern

### DIFF
--- a/lib/rspec/matchers/matcher_delegator.rb
+++ b/lib/rspec/matchers/matcher_delegator.rb
@@ -1,8 +1,34 @@
 module RSpec
   module Matchers
+    # Provides a base class with as little methods as possible, so that
+    # most methods can be delegated via `method_missing`.
+    #
+    # On Ruby 2.0+ BasicObject could be used for this purpose, but it
+    # introduce some extra complexity with constant resolution, so the
+    # BlankSlate pattern was prefered.
+    # @private
+    class BaseDelegator
+      kept_methods = [
+        # Methods that raise warnings if removed.
+        :__id__, :__send__, :object_id,
+
+        # Methods that are explicitly undefined in some subclasses.
+        :==, :===,
+
+        # Methods we keep on purpose.
+        :class, :respond_to?, :__method__, :method, :dup,
+        :clone, :initialize_dup, :initialize_copy, :initialize_clone,
+      ]
+      instance_methods.each do |method|
+        unless kept_methods.include?(method.to_sym)
+          undef_method(method)
+        end
+      end
+    end
+
     # Provides the necessary plumbing to wrap a matcher with a decorator.
     # @private
-    class MatcherDelegator
+    class MatcherDelegator < BaseDelegator
       include Composable
       attr_reader :base_matcher
 


### PR DESCRIPTION
This allows to minimize the amount of method inherited by the delegator object, and protects RSpec from new methods being introduced by future Ruby versions or monkey patched in by user code or libraries.
    
On modern Rubies there is `BasicObject` for this purpose, that's what `delegate.rb` uses for instance, and is considered best practice for delegators and other proxy objects. However since RSpec still support Ruby 1.8 so it's not an option.
    
Additionally `BasicObject` doesn't inherit from `Object` so all constant resolutions in a `BasicObject` descendant must be fully qualified which is tedious, but more importantly changing this now would probably break third party code that inherit from `MatcherDelegator`.
