### PR TITLE
Display default and custom failure messages together

### DIFF
--- a/lib/rspec/expectations/handler.rb
+++ b/lib/rspec/expectations/handler.rb
@@ -32,7 +32,10 @@ module RSpec
 
       def self.handle_failure(matcher, message, failure_message_method)
         message = message.call if message.respond_to?(:call)
-        message ||= matcher.__send__(failure_message_method)
+        message = [message, matcher.__send__(failure_message_method)]
+          .compact
+          .uniq
+          .join("\n")
 
         if matcher.respond_to?(:diffable?) && matcher.diffable?
           ::RSpec::Expectations.fail_with message, matcher.expected, matcher.actual

--- a/spec/rspec/expectations/handler_spec.rb
+++ b/spec/rspec/expectations/handler_spec.rb
@@ -115,7 +115,7 @@ module RSpec
           matcher = double("matcher", :failure_message => "message", :matches? => false)
           actual = Object.new
 
-          expect(::RSpec::Expectations).to receive(:fail_with).with("custom")
+          expect(::RSpec::Expectations).to receive(:fail_with).with("custom\nmessage")
 
           RSpec::Expectations::PositiveExpectationHandler.handle_matcher(actual, matcher, "custom")
         end
@@ -126,7 +126,7 @@ module RSpec
 
           failure_message = double("failure message", :call => "custom")
 
-          expect(::RSpec::Expectations).to receive(:fail_with).with("custom")
+          expect(::RSpec::Expectations).to receive(:fail_with).with("custom\nmessage")
 
           RSpec::Expectations::PositiveExpectationHandler.handle_matcher(actual, matcher, failure_message)
         end
@@ -209,7 +209,7 @@ module RSpec
           matcher = double("matcher", :failure_message_when_negated => "message", :matches? => true)
           actual = Object.new
 
-          expect(::RSpec::Expectations).to receive(:fail_with).with("custom")
+          expect(::RSpec::Expectations).to receive(:fail_with).with("custom\nmessage")
 
           RSpec::Expectations::NegativeExpectationHandler.handle_matcher(actual, matcher, "custom")
         end
@@ -220,7 +220,7 @@ module RSpec
 
           failure_message = double("failure message", :call => "custom")
 
-          expect(::RSpec::Expectations).to receive(:fail_with).with("custom")
+          expect(::RSpec::Expectations).to receive(:fail_with).with("custom\nmessage")
 
           RSpec::Expectations::NegativeExpectationHandler.handle_matcher(actual, matcher, failure_message)
         end


### PR DESCRIPTION
I've never needed to specify a custom message to a matcher in 14 years of using RSpec, but apparently some folks find it useful to have both the original message and the custom message. I don't really disagree with them. Anything that helps understand the failure more.

And honestly I'm doing this so maybe other open source maintainers can have less ammunition to [shit on other people's open source software](https://ruby.social/@zenspider/111547919694702860) for no reason. 🙃 Maybe OSS maintainers that do things like that might, I dunno, open a PR with the change they'd like to see instead of just whining on the internet if they realize it's possible. It could happen. I've seen stranger things.