### PR TITLE
Fix diff for compound when transforming actual [onto main]

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,11 @@ Enhancements:
 * Update `eq` and `eql` matchers to better highlight difference in string encoding.
   (Alan Foster, #1425)
 
+Bug Fixes:
+
+* Fix the diff for redefined `actual` and reassigned `@actual` in compound
+  expectations failure messages. (Phil Pirozhkov, #1440)
+
 ### 3.12.3 / 2023-04-20
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.12.2...v3.12.3)
 

--- a/lib/rspec/expectations/fail_with.rb
+++ b/lib/rspec/expectations/fail_with.rb
@@ -30,7 +30,7 @@ module RSpec
                                "appropriate failure_message[_when_negated] method to return a string?"
         end
 
-        message = ::RSpec::Matchers::ExpectedsForMultipleDiffs.from(expected).message_with_diff(message, differ, actual)
+        message = ::RSpec::Matchers::MultiMatcherDiff.from(expected, actual).message_with_diff(message, differ)
 
         RSpec::Support.notify_failure(RSpec::Expectations::ExpectationNotMetError.new message)
       end

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -10,7 +10,7 @@ RSpec::Support.define_optimized_require_for_rspec(:matchers) { |f| require_relat
   dsl
   matcher_delegator
   aliased_matcher
-  expecteds_for_multiple_diffs
+  multi_matcher_diff
 ].each { |file| RSpec::Support.require_rspec_matchers(file) }
 
 # RSpec's top level namespace. All of rspec-expectations is contained

--- a/lib/rspec/matchers/built_in/compound.rb
+++ b/lib/rspec/matchers/built_in/compound.rb
@@ -51,10 +51,10 @@ module RSpec
         end
 
         # @api private
-        # @return [RSpec::Matchers::ExpectedsForMultipleDiffs]
+        # @return [RSpec::Matchers::MultiMatcherDiff]
         def expected
           return nil unless evaluator
-          ::RSpec::Matchers::ExpectedsForMultipleDiffs.for_many_matchers(diffable_matcher_list)
+          ::RSpec::Matchers::MultiMatcherDiff.for_many_matchers(diffable_matcher_list)
         end
 
       protected

--- a/spec/rspec/matchers/built_in/compound_spec.rb
+++ b/spec/rspec/matchers/built_in/compound_spec.rb
@@ -583,9 +583,9 @@ module RSpec::Matchers::BuiltIn
                   EOS
 
                 expect {
-                  expect("HELLO\nWORLD")
-                    .to eq_downcase("bonjour\nmonde")
-                    .and eq_downcase("hola\nmon")
+                  expect(
+                    "HELLO\nWORLD"
+                  ).to eq_downcase("bonjour\nmonde").and eq_downcase("hola\nmon")
                 }.to fail do |error|
                   expect(error.message).to include(expected_failure)
                 end
@@ -626,9 +626,9 @@ module RSpec::Matchers::BuiltIn
                   EOS
 
                 expect {
-                  expect("HELLO\nWORLD")
-                    .to eq_downcase("bonjour\nmonde")
-                    .and eq_downcase("hola\nmon")
+                  expect(
+                    "HELLO\nWORLD"
+                  ).to eq_downcase("bonjour\nmonde").and eq_downcase("hola\nmon")
                 }.to fail do |error|
                   expect(error.message).to include(expected_failure)
                 end

--- a/spec/rspec/matchers/built_in/output_spec.rb
+++ b/spec/rspec/matchers/built_in/output_spec.rb
@@ -194,5 +194,26 @@ module RSpec
         expect(output("foo").description).to eq('output "foo" to some stream')
       end
     end
+
+    RSpec.describe "can capture stdin and stderr" do
+      it "prints diff for both when both fail" do
+        expect {
+          expect { print "foo"; $stderr.print("bar") }
+            .to output(/baz/).to_stdout
+            .and output(/qux/).to_stderr
+        }
+          .to fail_including(
+            'expected block to output /baz/ to stdout, but output "foo"',
+            '...and:',
+            'expected block to output /qux/ to stderr, but output "bar"',
+            'Diff for (output /baz/ to stdout):',
+            '-/baz/',
+            '+"foo"',
+            'Diff for (output /qux/ to stderr):',
+            '-/qux/',
+            '+"bar"'
+          )
+      end
+    end
   end
 end

--- a/spec/rspec/matchers/built_in/output_spec.rb
+++ b/spec/rspec/matchers/built_in/output_spec.rb
@@ -198,9 +198,9 @@ module RSpec
     RSpec.describe "can capture stdin and stderr" do
       it "prints diff for both when both fail" do
         expect {
-          expect { print "foo"; $stderr.print("bar") }
-            .to output(/baz/).to_stdout
-            .and output(/qux/).to_stderr
+          expect {
+            print "foo"; $stderr.print("bar")
+          }.to output(/baz/).to_stdout.and output(/qux/).to_stderr
         }.to fail_including(
             'expected block to output /baz/ to stdout, but output "foo"',
             '...and:',

--- a/spec/rspec/matchers/built_in/output_spec.rb
+++ b/spec/rspec/matchers/built_in/output_spec.rb
@@ -201,8 +201,7 @@ module RSpec
           expect { print "foo"; $stderr.print("bar") }
             .to output(/baz/).to_stdout
             .and output(/qux/).to_stderr
-        }
-          .to fail_including(
+        }.to fail_including(
             'expected block to output /baz/ to stdout, but output "foo"',
             '...and:',
             'expected block to output /qux/ to stderr, but output "bar"',


### PR DESCRIPTION
fixes https://github.com/rspec/rspec-expectations/issues/1317
fixes https://github.com/rspec/rspec-expectations/issues/1406
resolves #1319

I cherry-picked the commits from #1319 onto 3-12-maintenance, they applied without conflicts, then I ran the scripts called in the test CI action and they all passed. I pushed this to https://github.com/rspec/rspec-expectations/compare/3-12-maintenance...henrahmagix:fix-compound-redefined-actual-diff-on-3-12 just for good measure =)

I did the same on main, bundle installed fine, but I wasn't able to run any of the tests locally because I kept getting the following error:
```
$ script/run_build
============= Starting binstub check ===============
Checking required binstubs
============= Ending binstub check ===============
============= Starting specs ===============
/path/to/rspec-expectations/bin/rspec
Could not find compatible versions

Because every version of rspec-core depends on rspec-support ~> 3.12.0
  and every version of rspec-expectations depends on rspec-support = 3.13.0.pre,
  every version of rspec-core is incompatible with rspec-expectations >= 0.
So, because Gemfile depends on rspec-expectations >= 0
  and Gemfile depends on rspec-core >= 0,
  version solving has failed.
```

So I hope the tests pass similarly when run in CI because I can't confirm locally unfortunately ☺️ 