### PR TITLE
Fail `Include` matcher when comparing String with non-String

### DIFF
--- a/lib/rspec/matchers/built_in/include.rb
+++ b/lib/rspec/matchers/built_in/include.rb
@@ -165,6 +165,9 @@ module RSpec
         end
 
         def actual_collection_includes?(expected_item)
+          # if the actual is a String, the expected_item must also be a String
+          return false if actual.is_a?(String) && !expected_item.is_a?(String)
+
           return true if actual.include?(expected_item)
 
           # String lacks an `any?` method...

--- a/spec/rspec/matchers/built_in/include_spec.rb
+++ b/spec/rspec/matchers/built_in/include_spec.rb
@@ -203,6 +203,10 @@ RSpec.describe "#include matcher" do
         expect("abc").to include("a")
       end
 
+      it "passes if target includes multiple expecteds" do
+        expect(" foo\nbar\nbazz").to include("foo", "bar", "baz")
+      end
+
       it "fails if target does not include expected" do
         expect {
           expect("abc").to include("d")
@@ -225,6 +229,12 @@ RSpec.describe "#include matcher" do
         expect {
           expect(" foo\nbar\nbazz").to include("foo", "bar", "gaz")
         }.to fail_with(a_string_not_matching(/Diff/i))
+      end
+
+      it "fails when matching a collection" do
+        expect {
+          expect("foo").to include({:bar => "baz"})
+        }.to fail_with(/expected "foo" to include {:bar => "baz"}/)
       end
 
       context "with exact count" do


### PR DESCRIPTION
If the actual is a String and the expected is not, a `TypeError` occurs
when we try to call `actual.include?`, becuase this method expects
a String when called on a String.

If the actual is a `String` and the expected is not, then the match
can't possibly succeed and we can return early.
