### PR TITLE
Handle dynamic mocks specially for null-object doubles

### DIFF
--- a/lib/rspec/matchers/built_in/has.rb
+++ b/lib/rspec/matchers/built_in/has.rb
@@ -49,15 +49,18 @@ module RSpec
         # Catch a semi-frequent typo - if you have strict_predicate_matchers disabled and
         # expect(spy).to have_receieveddd(:foo) it would be evergreen - the dynamic matcher
         # queries `has_receiveddd?`, the spy _fakes_ the method, returning its (truthy) self.
-        def really_responds_to?(method)
-          if defined?(RSpec::Mocks::Double) && @actual.is_a?(RSpec::Mocks::Double)
-            @actual.respond_to?(method) && methods_include?(method)
-          else
+        if defined?(RSpec::Mocks::Double)
+          def really_responds_to?(method)
+            if RSpec::Mocks::Double === @actual
+              @actual.respond_to?(method) && methods_include?(method)
+            else
+              @actual.respond_to?(method)
+            end
+          end
+        else
+          def really_responds_to?(method)
             @actual.respond_to?(method)
           end
-        rescue NoMethodError
-          # Proxied BasicObjects don't have `is_a?`, or basically anything else.
-          @actual.respond_to?(method)
         end
 
         def predicate_accessible?

--- a/lib/rspec/matchers/built_in/has.rb
+++ b/lib/rspec/matchers/built_in/has.rb
@@ -55,6 +55,9 @@ module RSpec
           else
             @actual.respond_to?(method)
           end
+        rescue NoMethodError
+          # Proxied BasicObjects don't have `is_a?`, or basically anything else.
+          @actual.respond_to?(method)
         end
 
         def predicate_accessible?

--- a/lib/rspec/matchers/built_in/has.rb
+++ b/lib/rspec/matchers/built_in/has.rb
@@ -51,7 +51,7 @@ module RSpec
         # queries `has_receiveddd?`, the spy _fakes_ the method, returning its (truthy) self.
         def really_responds_to?(method)
           if defined?(RSpec::Mocks::Double) && @actual.is_a?(RSpec::Mocks::Double)
-            @actual.respond_to?(method) && @actual.methods.include?(method)
+            @actual.respond_to?(method) && methods_include?(method)
           else
             @actual.respond_to?(method)
           end
@@ -70,10 +70,18 @@ module RSpec
           def private_predicate?
             @actual.private_methods.include? predicate.to_s
           end
+
+          def methods_include?(method)
+            @actual.methods.include?(method.to_s)
+          end
           # :nocov:
         else
           def private_predicate?
             @actual.private_methods.include? predicate
+          end
+
+          def methods_include?(method)
+            @actual.methods.include?(method)
           end
         end
 

--- a/spec/rspec/matchers/built_in/be_spec.rb
+++ b/spec/rspec/matchers/built_in/be_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "expect(...).to be_predicate" do
     end
 
     it "allows dynamic matchers to pass for supplied methods on spies" do
-      thing = spy("thing", has_recv?: true)
+      thing = spy("thing", :has_recv? => true)
       expect(thing).to have_recv(:foo)
       expect(thing).to have_received(:has_recv?).with(:foo)
     end

--- a/spec/rspec/matchers/built_in/be_spec.rb
+++ b/spec/rspec/matchers/built_in/be_spec.rb
@@ -85,6 +85,21 @@ RSpec.describe "expect(...).to be_predicate" do
         expect(actual).to be_happy
       }.to fail_with("expected `#{actual.inspect}.happy?` to be truthy, got false")
     end
+
+    it "does not allow non-supplied dynamic matchers to pass on spies" do
+      thing = spy("thing", has_recv?: true)
+
+      expect(thing).to have_recv(:foo)
+      expect(thing).to have_received(:has_recv?).with(:foo)
+
+      begin
+        expect(thing).to have_receivex(:foo)
+      rescue RSpec::Expectations::ExpectationNotMetError
+        @reached = true
+      end
+      expect(@reached).to be_truthy
+      expect(thing).not_to have_received(:has_receivex?)
+    end
   end
 
   it "fails when actual does not respond to :predicate?" do

--- a/spec/rspec/matchers/built_in/be_spec.rb
+++ b/spec/rspec/matchers/built_in/be_spec.rb
@@ -86,19 +86,18 @@ RSpec.describe "expect(...).to be_predicate" do
       }.to fail_with("expected `#{actual.inspect}.happy?` to be truthy, got false")
     end
 
-    it "does not allow non-supplied dynamic matchers to pass on spies" do
+    it "allows dynamic matchers to pass for supplied methods on spies" do
       thing = spy("thing", has_recv?: true)
-
       expect(thing).to have_recv(:foo)
       expect(thing).to have_received(:has_recv?).with(:foo)
+    end
 
-      begin
-        expect(thing).to have_receivex(:foo)
-      rescue RSpec::Expectations::ExpectationNotMetError
-        @reached = true
-      end
-      expect(@reached).to be_truthy
-      expect(thing).not_to have_received(:has_receivex?)
+    it "does not allow dynamic matchers to pass for inferred methods on spies" do
+      thing = spy("thing")
+      expect {
+        expect(thing).to have_recv(:foo)
+      }.to fail
+      expect(thing).not_to have_received(:has_recv?)
     end
   end
 

--- a/spec/rspec/matchers/built_in/has_spec.rb
+++ b/spec/rspec/matchers/built_in/has_spec.rb
@@ -160,19 +160,18 @@ RSpec.describe "expect(...).not_to have_sym(*args)" do
       expect(actual).not_to have_foo
     end
 
-    it "does not allow non-supplied dynamic matchers to pass on spies" do
+    it "allows dynamic matchers to pass for supplied methods on spies" do
       thing = spy("thing", furg?: true)
-
       expect(thing).to be_furg(:foo)
       expect(thing).to have_received(:furg?).with(:foo)
+    end
 
-      begin
-        expect(thing).to be_blurm(:foo)
-      rescue RSpec::Expectations::ExpectationNotMetError
-        @reached = true
-      end
-      expect(@reached).to be_truthy
-      expect(thing).not_to have_received(:blurm?)
+    it "does not allow dynamic matchers to pass for inferred methods on spies" do
+      thing = spy("thing")
+      expect {
+        expect(thing).to be_furg(:foo)
+      }.to fail
+      expect(thing).not_to have_received(:furg?)
     end
   end
 

--- a/spec/rspec/matchers/built_in/has_spec.rb
+++ b/spec/rspec/matchers/built_in/has_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe "expect(...).not_to have_sym(*args)" do
     end
 
     it "allows dynamic matchers to pass for supplied methods on spies" do
-      thing = spy("thing", furg?: true)
+      thing = spy("thing", :furg? => true)
       expect(thing).to be_furg(:foo)
       expect(thing).to have_received(:furg?).with(:foo)
     end

--- a/spec/rspec/matchers/built_in/has_spec.rb
+++ b/spec/rspec/matchers/built_in/has_spec.rb
@@ -159,6 +159,21 @@ RSpec.describe "expect(...).not_to have_sym(*args)" do
       actual = double("actual", :has_foo? => nil)
       expect(actual).not_to have_foo
     end
+
+    it "does not allow non-supplied dynamic matchers to pass on spies" do
+      thing = spy("thing", furg?: true)
+
+      expect(thing).to be_furg(:foo)
+      expect(thing).to have_received(:furg?).with(:foo)
+
+      begin
+        expect(thing).to be_blurm(:foo)
+      rescue RSpec::Expectations::ExpectationNotMetError
+        @reached = true
+      end
+      expect(@reached).to be_truthy
+      expect(thing).not_to have_received(:blurm?)
+    end
   end
 
   it "fails if #has_sym?(*args) returns true" do


### PR DESCRIPTION
This hopefully resolves #1132 and #1288 - essentially, if you leave `strict_predicate_matchers` disabled and use a null-object spy like this:

```
let(:thing) { spy('my thing') }

it "does the thing right" do
  do_it
  expect(thing).to have_receivedd(:foo)
end
```

It'll pass. Note the typo in `have_receivedd`? The dynamic matcher will call `has_receivedd?` on the spy, the spy will return itself (that's what it does), and the matcher will note that the result is truthy, and pass the spec. That's kind of an issue - turning off that setting _does_ solve it, but that won't be the default until rspec 4, and even then it's not the _ideal_ behavior, just a lot better.

This PR updates the dynamic matchers to notice when their target is a Double, and change behavior slightly - for Doubles, don't just check if they respond to the method, _also_ check if it's _in the `methods` list_. That'll suffice to confirm that it's explicitly mocked on the double, rather than being an automatic response.