### PR TITLE
Give correct error message for `expect {}.not_to raise_error(/foo/)`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ### Development
-[Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.12.3...main)
+[Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.13.0...main)
+
+Bug Fixes:
+
+* Fix the false positive warning message for negated raise error with a regexp argument.
+  (Eric Mueller, #1456)
 
 ### 3.13.0 / 2024-02-04
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.12.4...v3.13.0)

--- a/lib/rspec/matchers/built_in/raise_error.rb
+++ b/lib/rspec/matchers/built_in/raise_error.rb
@@ -25,7 +25,7 @@ module RSpec
           when nil, UndefinedValue
             @expected_error = Exception
             @expected_message = expected_message
-          when String
+          when String, Regexp
             @expected_error = Exception
             @expected_message = expected_error_or_message
           else

--- a/lib/rspec/matchers/built_in/raise_error.rb
+++ b/lib/rspec/matchers/built_in/raise_error.rb
@@ -13,6 +13,10 @@ module RSpec
         # argument. We can't use `nil` for that because we need to warn when `nil` is
         # passed in a different way. It's an Object, not a Module, since Module's `===`
         # does not evaluate to true when compared to itself.
+        #
+        # Note; this _is_ the default value supplied for expected_error_or_message, but
+        # because there are two method-calls involved, that default is actually supplied
+        # in the definition of the _matcher_ method, `RSpec::Matchers#raise_error`
         UndefinedValue = Object.new.freeze
 
         def initialize(expected_error_or_message, expected_message, &block)

--- a/spec/rspec/matchers/built_in/raise_error_spec.rb
+++ b/spec/rspec/matchers/built_in/raise_error_spec.rb
@@ -291,25 +291,27 @@ RSpec.describe "expect { ... }.to raise_error.with_message(message)" do
 end
 
 RSpec.describe "expect { ... }.not_to raise_error('message')" do
-  it "issues a warning" do
+  it "issues a warning when configured to do so", :warn_about_potential_false_positives do
+    RSpec::Expectations.configuration.warn_about_potential_false_positives = true
     expect_warning_with_call_site __FILE__, __LINE__+1, /not_to raise_error\(message\)` risks false positives/
-    expect { raise 'blarg' }.not_to raise_error("blah")
+    expect { raise 'blarg' }.not_to raise_error('blah')
   end
 
-  it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
+  it "supresses the warning when configured to do so", :warn_about_potential_false_positives do
     RSpec::Expectations.configuration.warn_about_potential_false_positives = false
     expect_no_warnings
-    expect { raise 'blarg' }.not_to raise_error("blah")
+    expect { raise 'blarg' }.not_to raise_error('blah')
   end
 end
 
 RSpec.describe "expect { ... }.not_to raise_error(/message/)" do
-  it "issues a warning" do
+  it "issues a warning when configured to do so", :warn_about_potential_false_positives do
+    RSpec::Expectations.configuration.warn_about_potential_false_positives = true
     expect_warning_with_call_site __FILE__, __LINE__+1, /not_to raise_error\(message\)` risks false positives/
     expect { raise 'blarg' }.not_to raise_error(/blah/)
   end
 
-  it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
+  it "supresses the warning when configured to do so", :warn_about_potential_false_positives do
     RSpec::Expectations.configuration.warn_about_potential_false_positives = false
     expect_no_warnings
     expect { raise 'blarg' }.not_to raise_error(/blah/)

--- a/spec/rspec/matchers/built_in/raise_error_spec.rb
+++ b/spec/rspec/matchers/built_in/raise_error_spec.rb
@@ -290,9 +290,22 @@ RSpec.describe "expect { ... }.to raise_error.with_message(message)" do
   end
 end
 
-RSpec.describe "expect { ... }.not_to raise_error(message)" do
+RSpec.describe "expect { ... }.not_to raise_error('message')" do
   it "issues a warning" do
-    expect_warning_with_call_site __FILE__, __LINE__+1, /risks false positives/
+    expect_warning_with_call_site __FILE__, __LINE__+1, /not_to raise_error\(message\)` risks false positives/
+    expect { raise 'blarg' }.not_to raise_error("blah")
+  end
+
+  it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
+    RSpec::Expectations.configuration.warn_about_potential_false_positives = false
+    expect_no_warnings
+    expect { raise 'blarg' }.not_to raise_error("blah")
+  end
+end
+
+RSpec.describe "expect { ... }.not_to raise_error(/message/)" do
+  it "issues a warning" do
+    expect_warning_with_call_site __FILE__, __LINE__+1, /not_to raise_error\(message\)` risks false positives/
     expect { raise 'blarg' }.not_to raise_error(/blah/)
   end
 


### PR DESCRIPTION
Found this while adding coverage - there was a test that _ought_ to have covered the line in question, but didn't because it was actually slightly too loose. Tightening it up shows that it's getting the wrong error message, because the RaiseError matcher is handling `expected_error_or_message` by checking the type, and it's looking for _String_, but not Regexp there.

Figured it'd make more sense as its own PR, since it's not just test coverage. (The line _is_ covered afterwards though!)

Failure with just the test change:
```
  1) expect { ... }.not_to raise_error(/message/) issues a warning
     Failure/Error: expect { raise 'blarg' }.not_to raise_error(/blah/)

       Kernel received :warn with unexpected arguments
         expected: (match /not_to raise_error\(message\)` risks false positives/ and match /Called from \/Users\/ericmueller\/src\/rspec-expectations\/spec\/rspec\/matchers\/built_in\/raise_error_spec.rb:309/)
              got: ("WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since lite...ons/spec/rspec/matchers/built_in/raise_error_spec.rb:309:in `block (2 levels) in <top (required)>'.")
     # ./spec/rspec/matchers/built_in/raise_error_spec.rb:309:in `block (2 levels) in <top (required)>'
```