### PR TITLE
Drop dead (private) methods from BaseMatcher

### DIFF
--- a/lib/rspec/matchers/built_in/base_matcher.rb
+++ b/lib/rspec/matchers/built_in/base_matcher.rb
@@ -126,22 +126,6 @@ module RSpec
 
       private
 
-        def assert_ivars(*expected_ivars)
-          return unless (expected_ivars - present_ivars).any?
-          ivar_list = EnglishPhrasing.list(expected_ivars)
-          raise "#{self.class.name} needs to supply#{ivar_list}"
-        end
-
-        if RUBY_VERSION.to_f < 1.9
-          # :nocov:
-          def present_ivars
-            instance_variables.map(&:to_sym)
-          end
-          # :nocov:
-        else
-          alias present_ivars instance_variables
-        end
-
         # @private
         module HashFormatting
           # `{ :a => 5, :b => 2 }.inspect` produces:

--- a/lib/rspec/matchers/built_in/base_matcher.rb
+++ b/lib/rspec/matchers/built_in/base_matcher.rb
@@ -124,8 +124,6 @@ module RSpec
         end
         private_class_method :underscore
 
-      private
-
         # @private
         module HashFormatting
           # `{ :a => 5, :b => 2 }.inspect` produces:


### PR DESCRIPTION
Drop the `assert_ivars` and `present_ivars` methods from RSpec::Matchers::BuiltIn::BaseMatcher`.

They aren't referenced anymore, and apparently haven't been for ~10 years. I confirmed with git pickaxes, but then I also checked out a few random points in time over that period and looked for either string in the repository - no references in 2015, or at any point I looked since then.

It _is_ possible that (against your strong recommendations), people are subclassing this class for their custom matchers, but I think that's their problem. And this isn't a particularly obvious or natural method for them to be using anyway.