### PR TITLE
100% test coverage

### DIFF
--- a/lib/rspec/expectations/block_snippet_extractor.rb
+++ b/lib/rspec/expectations/block_snippet_extractor.rb
@@ -46,11 +46,13 @@ module RSpec
           RSpec.world.source_from_file(file_path)
         end
       else
+        # :nocov:
         RSpec::Support.require_rspec_support 'source'
         def source
           raise TargetNotFoundError unless File.exist?(file_path)
           @source ||= RSpec::Support::Source.from_file(file_path)
         end
+        # :nocov:
       end
 
       def file_path

--- a/lib/rspec/expectations/configuration.rb
+++ b/lib/rspec/expectations/configuration.rb
@@ -89,6 +89,7 @@ module RSpec
           ::RSpec.configuration.color_enabled?
         end
       else
+        # :nocov:
         # Indicates whether or not diffs should be colored.
         # Delegates to rspec-core's color option if rspec-core
         # is loaded; otherwise you can set it here.
@@ -100,8 +101,11 @@ module RSpec
         def color?
           defined?(@color) && @color
         end
+        # :nocov:
       end
 
+      # :nocov: Because this is only really _useful_ on 1.8, and hard to test elsewhere.
+      #
       # Adds `should` and `should_not` to the given classes
       # or modules. This can be used to ensure `should` works
       # properly on things like proxy objects (particular
@@ -114,6 +118,7 @@ module RSpec
           Expectations::Syntax.enable_should(mod)
         end
       end
+      # :nocov:
 
       # Sets or gets the backtrace formatter. The backtrace formatter should
       # implement `#format_backtrace(Array<String>)`. This is used

--- a/lib/rspec/expectations/failure_aggregator.rb
+++ b/lib/rspec/expectations/failure_aggregator.rb
@@ -75,11 +75,13 @@ module RSpec
         # a backtrace that has a continuous common section with the raised `MultipleExpectationsNotMetError`,
         # so that rspec-core's truncation logic can work properly on it to list the backtrace
         # relative to the `aggregate_failures` block.
+        # :nocov:
         def assign_backtrace(failure)
           raise failure
         rescue failure.class => e
           failure.set_backtrace(e.backtrace)
         end
+        # :nocov:
       else
         # Using `caller` performs better (and is simpler) than `raise` on most Rubies.
         def assign_backtrace(failure)

--- a/lib/rspec/expectations/failure_aggregator.rb
+++ b/lib/rspec/expectations/failure_aggregator.rb
@@ -6,6 +6,10 @@ module RSpec
 
       # @private
       class AggregatedFailure
+        # :nocov:
+        # `inspect` was apparently used by some versions early in ruby 3 while constructing
+        # NoMethodError, but seems to be no longer.
+        #
         # @private
         MESSAGE =
           'AggregatedFailure: This method caused a failure which has been ' \
@@ -15,6 +19,7 @@ module RSpec
         def inspect
           MESSAGE
         end
+        # :nocov:
       end
 
       AGGREGATED_FAILURE = AggregatedFailure.new

--- a/lib/rspec/matchers.rb
+++ b/lib/rspec/matchers.rb
@@ -1018,6 +1018,7 @@ module RSpec
         # than _before_, like `append_features`. It's important we check this before
         # in order to find the cases where it was already previously included.
         # @api private
+        # :nocov:
         def append_features(mod)
           return super if mod < self # `mod < self` indicates a re-inclusion.
 
@@ -1038,6 +1039,7 @@ module RSpec
 
           super
         end
+        # :nocov:
       end
     end
   end

--- a/lib/rspec/matchers/built_in/base_matcher.rb
+++ b/lib/rspec/matchers/built_in/base_matcher.rb
@@ -156,9 +156,11 @@ module RSpec
           else
             # @api private
             # @return [Boolean] False always as the curent Ruby version does not support String encoding
+            # :nocov:
             def string_encoding_differs?
               false
             end
+            # :nocov:
           end
           module_function :string_encoding_differs?
 
@@ -175,9 +177,11 @@ module RSpec
             # Formats a String's encoding as a human readable string
             # @param _value [String]
             # @return [nil] nil as the curent Ruby version does not support String encoding
+            # :nocov:
             def format_encoding(_value)
               nil
             end
+            # :nocov:
           end
           module_function :format_encoding
         end

--- a/lib/rspec/matchers/built_in/change.rb
+++ b/lib/rspec/matchers/built_in/change.rb
@@ -440,9 +440,11 @@ module RSpec
             Expectations::BlockSnippetExtractor.try_extracting_single_line_body_of(@value_proc, @matcher_name)
           end
         else
+          # :nocov:
           def extract_value_block_snippet
             nil
           end
+          # :nocov:
         end
       end
     end

--- a/lib/rspec/matchers/built_in/contain_exactly.rb
+++ b/lib/rspec/matchers/built_in/contain_exactly.rb
@@ -108,12 +108,14 @@ module RSpec
         end
 
         if RUBY_VERSION == "1.8.7"
+          # :nocov:
           def to_a_disallowed?(object)
             case object
             when NilClass, String then true
             else Kernel == RSpec::Support.method_handle_for(object, :to_a).owner
             end
           end
+          # :nocov:
         else
           def to_a_disallowed?(object)
             NilClass === object

--- a/lib/rspec/matchers/built_in/count_expectation.rb
+++ b/lib/rspec/matchers/built_in/count_expectation.rb
@@ -61,9 +61,11 @@ module RSpec
             count.cover?(number)
           end
         else
+          # :nocov:
           def cover?(count, number)
             number >= count.first && number <= count.last
           end
+          # :nocov:
         end
 
         def expected_count_matches?(actual_count)

--- a/lib/rspec/matchers/built_in/has.rb
+++ b/lib/rspec/matchers/built_in/has.rb
@@ -58,9 +58,11 @@ module RSpec
             end
           end
         else
+          # :nocov:
           def really_responds_to?(method)
             @actual.respond_to?(method)
           end
+          # :nocov:
         end
 
         def predicate_accessible?

--- a/lib/rspec/matchers/built_in/include.rb
+++ b/lib/rspec/matchers/built_in/include.rb
@@ -174,9 +174,11 @@ module RSpec
         end
 
         if RUBY_VERSION < '1.9'
+          # :nocov:
           def count_enumerable(expected_item)
             actual.select { |value| values_match?(expected_item, value) }.size
           end
+          # :nocov:
         else
           def count_enumerable(expected_item)
             actual.count { |value| values_match?(expected_item, value) }

--- a/lib/rspec/matchers/built_in/match.rb
+++ b/lib/rspec/matchers/built_in/match.rb
@@ -78,9 +78,11 @@ module RSpec
           # @api private
           # Returns match data names for named captures
           # @return Array
+          # :nocov:
           def names
             []
           end
+          # :nocov:
         else
           # @api private
           # Returns match data names for named captures

--- a/lib/rspec/matchers/built_in/satisfy.rb
+++ b/lib/rspec/matchers/built_in/satisfy.rb
@@ -50,9 +50,11 @@ module RSpec
             Expectations::BlockSnippetExtractor.try_extracting_single_line_body_of(@block, matcher_name)
           end
         else
+          # :nocov:
           def block_representation
             'block'
           end
+          # :nocov:
         end
       end
     end

--- a/lib/rspec/matchers/english_phrasing.rb
+++ b/lib/rspec/matchers/english_phrasing.rb
@@ -45,12 +45,14 @@ module RSpec
         # So here we replace `Kernel#Array` with our own warning-free implementation for 1.8.7.
         # @private
         # rubocop:disable Naming/MethodName
+        # :nocov:
         def self.Array(obj)
           case obj
           when Array then obj
           else [obj]
           end
         end
+        # :nocov:
         # rubocop:enable Naming/MethodName
       end
     end

--- a/spec/rspec/expectations/configuration_spec.rb
+++ b/spec/rspec/expectations/configuration_spec.rb
@@ -146,6 +146,12 @@ module RSpec
           config.on_potential_false_positives = :raise
           expect(config.on_potential_false_positives).to eq :raise
         end
+
+        it 'cannot be set to :fooba' do
+          expect {
+            config.on_potential_false_positives = :fooba
+          }.to raise_error(ArgumentError, /Supported values are/)
+        end
       end
 
       shared_examples "configuring the expectation syntax" do

--- a/spec/rspec/matchers/built_in/all_spec.rb
+++ b/spec/rspec/matchers/built_in/all_spec.rb
@@ -12,6 +12,12 @@ module RSpec::Matchers::BuiltIn
       end
     end
 
+    it "refuses to invert" do
+      expect {
+        expect([5, 3, 3]).not_to all(be_odd)
+      }.to raise_error(NotImplementedError, /not_to all.*is not supported/)
+    end
+
     context 'when single matcher is given' do
 
       describe 'expect(...).to all(expected)' do

--- a/spec/rspec/matchers/built_in/be_spec.rb
+++ b/spec/rspec/matchers/built_in/be_spec.rb
@@ -524,6 +524,22 @@ RSpec.describe "expect(...).to be_truthy" do
   end
 end
 
+RSpec.describe "expect(...).not_to be_truthy" do
+  it "passes when actual equal?(false)" do
+    expect(false).not_to be_truthy
+  end
+
+  it "passes when actual equal?(nil)" do
+    expect(nil).not_to be_truthy
+  end
+
+  it "fails when actual equal?(true)" do
+    expect {
+      expect(true).not_to be_truthy
+    }.to fail_with("expected: falsey value\n     got: true")
+  end
+end
+
 RSpec.describe "expect(...).to be_falsey" do
   it "passes when actual equal?(false)" do
     expect(false).to be_falsey
@@ -553,6 +569,22 @@ RSpec.describe "expect(...).to be_falsy" do
     expect {
       expect(true).to be_falsy
     }.to fail_with("expected: falsey value\n     got: true")
+  end
+end
+
+RSpec.describe "expect(...).not_to be_falsey" do
+  it "passes when actual equal?(true)" do
+    expect(true).not_to be_falsey
+  end
+
+  it "passes when actual is 1" do
+    expect(1).not_to be_falsey
+  end
+
+  it "fails when actual equal?(false)" do
+    expect {
+      expect(false).not_to be_falsey
+    }.to fail_with("expected: truthy value\n     got: false")
   end
 end
 

--- a/spec/rspec/matchers/built_in/compound_spec.rb
+++ b/spec/rspec/matchers/built_in/compound_spec.rb
@@ -260,6 +260,26 @@ module RSpec::Matchers::BuiltIn
       end
     end
 
+    describe "expect(...).to custom_matcher.and(other_matcher)" do
+      it "treats a matcher that doesn't support value expectations correctly" do
+        expect {
+          expect([1, 2]).to include(1).and raise_error(/test/)
+        }.to fail_with(/but was not given a block/)
+      end
+
+      it "treats a matcher that does support value expectations correctly" do
+        expect([1, 2]).to include(1).and include(2)
+      end
+
+      it "treats a matcher that doesn't _specify_ as supporting value expectations" do
+        unsupporting_includes_class = Class.new(Object) do
+          def matches?(actual); actual.include?(2); end
+        end
+        unsupporting_includes = unsupporting_includes_class.new
+        expect([1, 2]).to include(1).and unsupporting_includes
+      end
+    end
+
     describe "expect(...).to matcher.and(other_matcher)" do
 
       it_behaves_like "an RSpec value matcher", :valid_value => 3, :invalid_value => 4, :disallows_negation => true do

--- a/spec/rspec/matchers/built_in/compound_spec.rb
+++ b/spec/rspec/matchers/built_in/compound_spec.rb
@@ -993,5 +993,30 @@ module RSpec::Matchers::BuiltIn
         }.to raise_error(NotImplementedError, /matcher.or matcher` is not supported/)
       end
     end
+
+    describe "#expects_call_stack_jump?" do
+      subject(:expects_call_stack_jump?) { matcher.expects_call_stack_jump? }
+      let(:matcher) { described_class.new(matcher_1, matcher_2) }
+      let(:matcher_1) { double("Matcher 1") }
+      let(:matcher_2) { double("Matcher 2") }
+
+      context "when neither matcher expects a call-stack jump" do
+        let(:matcher_1) { double("Matcher 1", :expects_call_stack_jump? => false) }
+        let(:matcher_2) { double("Matcher 2", :expects_call_stack_jump? => false) }
+        it { is_expected.to be_falsey }
+      end
+
+      context "when one of the matchers expects a call-stack jump" do
+        let(:matcher_1) { double("Matcher 1", :expects_call_stack_jump? => false) }
+        let(:matcher_2) { double("Matcher 2", :expects_call_stack_jump? => true) }
+        it { is_expected.to be_truthy }
+      end
+
+      context "when neither matcher _specifies_ that it expects a call-stack jump" do
+        let(:matcher_1) { Object.new }
+        let(:matcher_2) { Object.new }
+        it { is_expected.to be_falsey }
+      end
+    end
   end
 end

--- a/spec/rspec/matchers/built_in/include_spec.rb
+++ b/spec/rspec/matchers/built_in/include_spec.rb
@@ -178,15 +178,21 @@ RSpec.describe "#include matcher" do
     end
 
     context "for an arbitrary object that responds to `include?`" do
-      it 'delegates to `include?`' do
-        container = double("Container")
-        allow(container).to receive(:include?) { |arg| arg == :stuff }
+      let(:container) { double("Container") }
+      before { allow(container).to receive(:include?) { |arg| arg == :stuff } }
 
+      it 'delegates to `include?`' do
         expect(container).to include(:stuff)
 
         expect {
           expect(container).to include(:space)
         }.to fail_matching("to include :space")
+      end
+
+      it 'refuses to count inclusions' do
+        expect {
+          expect(container).to include(:stuff).once
+        }.to raise_error(NotImplementedError, /Count constraints/)
       end
     end
 

--- a/spec/rspec/matchers/built_in/operators_spec.rb
+++ b/spec/rspec/matchers/built_in/operators_spec.rb
@@ -228,22 +228,36 @@ RSpec.describe "operator matchers", :uses_should do
   end
 
   describe RSpec::Matchers::BuiltIn::PositiveOperatorMatcher do
+    let(:o) { Object.new }
+    before { def o.send(*_args); raise "DOH! Library developers shouldn't use #send!"; end }
+
     it "works when the target has implemented #send" do
-      o = Object.new
-      def o.send(*_args); raise "DOH! Library developers shouldn't use #send!" end
       expect {
         o.should == o
       }.not_to raise_error
     end
+
+    it "complains when negated" do
+      expect {
+        o.should != o
+      }.to raise_error(/does not support `should != .*Use `should_not ==/)
+    end
   end
 
   describe RSpec::Matchers::BuiltIn::NegativeOperatorMatcher do
+    let(:o) { Object.new }
+    before { def o.send(*_args); raise "DOH! Library developers shouldn't use #send!"; end }
+
     it "works when the target has implemented #send" do
-      o = Object.new
-      def o.send(*_args); raise "DOH! Library developers shouldn't use #send!" end
       expect {
         o.should_not == :foo
       }.not_to raise_error
+    end
+
+    it "complains when negated" do
+      expect {
+        o.should_not != :foo
+      }.to raise_error(/does not support `should_not != .*Use `should ==/)
     end
   end
 end

--- a/spec/rspec/matchers/built_in/operators_spec.rb
+++ b/spec/rspec/matchers/built_in/operators_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe "operator matchers", :uses_should do
       }.not_to raise_error
     end
 
-    it "complains when negated", :if => RUBY_VERSION.to_f >= 1.9 do
+    it "complains when negated", :skip => RUBY_VERSION.to_f < 1.9 do
       expect {
         o.should !~ o
       }.to raise_error(/does not support `should !~ .*Use `should_not =~/)
@@ -260,7 +260,7 @@ RSpec.describe "operator matchers", :uses_should do
       }.not_to raise_error
     end
 
-    it "complains when negated", :if => RUBY_VERSION.to_f >= 1.9 do
+    it "complains when negated", :skip => RUBY_VERSION.to_f < 1.9 do
       expect {
         o.should_not !~ :foo
       }.to raise_error(/does not support `should_not !~ .*Use `should =~/)

--- a/spec/rspec/matchers/built_in/operators_spec.rb
+++ b/spec/rspec/matchers/built_in/operators_spec.rb
@@ -242,6 +242,12 @@ RSpec.describe "operator matchers", :uses_should do
         o.should != o
       }.to raise_error(/does not support `should != .*Use `should_not ==/)
     end
+
+    it "is described correctly" do
+      matcher = 7.should
+      matcher.==(7)
+      expect(matcher.description).to eq("== 7")
+    end
   end
 
   describe RSpec::Matchers::BuiltIn::NegativeOperatorMatcher do
@@ -258,6 +264,12 @@ RSpec.describe "operator matchers", :uses_should do
       expect {
         o.should_not != :foo
       }.to raise_error(/does not support `should_not != .*Use `should ==/)
+    end
+
+    it "is described correctly" do
+      matcher = 7.should_not
+      matcher.==(8)
+      expect(matcher.description).to eq("== 8")
     end
   end
 end

--- a/spec/rspec/matchers/built_in/operators_spec.rb
+++ b/spec/rspec/matchers/built_in/operators_spec.rb
@@ -237,10 +237,10 @@ RSpec.describe "operator matchers", :uses_should do
       }.not_to raise_error
     end
 
-    it "complains when negated" do
+    it "complains when negated", :if => RUBY_VERSION.to_f >= 1.9 do
       expect {
-        o.should != o
-      }.to raise_error(/does not support `should != .*Use `should_not ==/)
+        o.should !~ o
+      }.to raise_error(/does not support `should !~ .*Use `should_not =~/)
     end
 
     it "is described correctly" do
@@ -260,10 +260,10 @@ RSpec.describe "operator matchers", :uses_should do
       }.not_to raise_error
     end
 
-    it "complains when negated" do
+    it "complains when negated", :if => RUBY_VERSION.to_f >= 1.9 do
       expect {
-        o.should_not != :foo
-      }.to raise_error(/does not support `should_not != .*Use `should ==/)
+        o.should_not !~ :foo
+      }.to raise_error(/does not support `should_not !~ .*Use `should =~/)
     end
 
     it "is described correctly" do

--- a/spec/rspec/matchers/built_in/operators_spec.rb
+++ b/spec/rspec/matchers/built_in/operators_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe "operator matchers", :uses_should do
 
     it "is described correctly" do
       matcher = 7.should
-      matcher.==(7)
+      expect(matcher == 7).to be_truthy
       expect(matcher.description).to eq("== 7")
     end
   end
@@ -268,7 +268,7 @@ RSpec.describe "operator matchers", :uses_should do
 
     it "is described correctly" do
       matcher = 7.should_not
-      matcher.==(8)
+      expect(matcher == 8).to be_falsey
       expect(matcher.description).to eq("== 8")
     end
   end

--- a/spec/rspec/matchers/composable_spec.rb
+++ b/spec/rspec/matchers/composable_spec.rb
@@ -12,6 +12,13 @@ module RSpec
         }.to fail_with(STDOUT.inspect)
       end
 
+      it "behaves correctly when surfacing descriptions from a readable IO object" do
+        allow(STDOUT).to receive(:each).and_yield
+        expect {
+          expect(3).to matcher_using_surface_descriptions_in(STDOUT)
+        }.to fail_with(STDOUT.to_s)
+      end
+
       it "does not blow up when surfacing descriptions from an unreadable Range object" do
         infinity = (1.0/0.0)
         infinite_range = -infinity..infinity

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'rspec/support/spec'
 require 'rspec/support/spec/in_sub_process'
 
 RSpec::Support::Spec.setup_simplecov do
-  minimum_coverage 92
+  minimum_coverage 100
 end
 
 Dir['./spec/support/**/*.rb'].each do |f|


### PR DESCRIPTION
Well, aside from a few lines in two other PRs (https://github.com/rspec/rspec-expectations/pull/1457 and https://github.com/rspec/rspec-expectations/pull/1456) that needed non-spec changes.

First, I found and marked all of the segments that seem to be ruby-version specific, and set them off with `:nocov:` tags. That's in the first commit. Then I started tackling the remaining uncovered lines one at a time, adding tests  I believe there to be no non-spec, non-comment changes in this PR, but I'm confident that some of the specs can be done more elegantly. Please, enhance my approaches, rspec wizards :-D