### PR TITLE
output matcher: add `as_tty` method to make the simulated stream behave as a TTY

### DIFF
--- a/lib/rspec/matchers/built_in/output.rb
+++ b/lib/rspec/matchers/built_in/output.rb
@@ -69,6 +69,17 @@ module RSpec
           self
         end
 
+        # @api public
+        # Tells the matcher to simulate the output stream not being a TTY.
+        # Note that that's the default behaviour if you don't call `as_tty`
+        # (since `StringIO` is not a TTY).
+        def as_not_tty
+          raise ArgumentError, '`as_not_tty` can only be used after `to_stdout` or `to_stderr`' unless @stream_capturer.respond_to?(:as_tty=)
+
+          @stream_capturer.as_tty = false
+          self
+        end
+
         # @api private
         # @return [String]
         def failure_message

--- a/lib/rspec/matchers/built_in/output.rb
+++ b/lib/rspec/matchers/built_in/output.rb
@@ -150,7 +150,8 @@ module RSpec
         attr_accessor :as_tty
 
         def tty?
-          as_tty || super
+          return super if as_tty.nil?
+          as_tty
         end
       end
 

--- a/lib/rspec/matchers/built_in/output.rb
+++ b/lib/rspec/matchers/built_in/output.rb
@@ -63,7 +63,7 @@ module RSpec
         # Tells the matcher to simulate the output stream being a TTY.
         # This is useful to test code like `puts '...' if $stdout.tty?`.
         def as_tty
-          raise '`as_tty` can only be used with `to_stdout` or `to_stderr`' unless @stream_capturer.respond_to?(:as_tty=)
+          raise ArgumentError, '`as_tty` can only be used after `to_stdout` or `to_stderr`' unless @stream_capturer.respond_to?(:as_tty=)
 
           @stream_capturer.as_tty = true
           self

--- a/lib/rspec/matchers/built_in/output.rb
+++ b/lib/rspec/matchers/built_in/output.rb
@@ -29,7 +29,7 @@ module RSpec
         # Tells the matcher to match against stdout.
         # Works only when the main Ruby process prints to stdout
         def to_stdout
-          @stream_capturer = CaptureStdout
+          @stream_capturer = CaptureStdout.new
           self
         end
 
@@ -37,7 +37,7 @@ module RSpec
         # Tells the matcher to match against stderr.
         # Works only when the main Ruby process prints to stderr
         def to_stderr
-          @stream_capturer = CaptureStderr
+          @stream_capturer = CaptureStderr.new
           self
         end
 
@@ -56,6 +56,16 @@ module RSpec
         # This is significantly (~30x) slower than `to_stderr`
         def to_stderr_from_any_process
           @stream_capturer = CaptureStreamToTempfile.new("stderr", $stderr)
+          self
+        end
+
+        # @api public
+        # Tells the matcher to simulate the output stream being a TTY.
+        # This is useful to test code like `puts '...' if $stdout.tty?`.
+        def as_tty
+          raise '`as_tty` can only be used with `to_stdout` or `to_stderr`' unless @stream_capturer.respond_to?(:as_tty=)
+
+          @stream_capturer.as_tty = true
           self
         end
 
@@ -137,19 +147,24 @@ module RSpec
 
       # @private
       class CapturedStream < StringIO
+        attr_accessor :as_tty
+
         def tty?
-          true
+          as_tty || super
         end
       end
 
       # @private
-      module CaptureStdout
-        def self.name
+      class CaptureStdout
+        attr_accessor :as_tty
+
+        def name
           'stdout'
         end
 
-        def self.capture(block)
+        def capture(block)
           captured_stream = CapturedStream.new
+          captured_stream.as_tty = as_tty
 
           original_stream = $stdout
           $stdout = captured_stream
@@ -163,13 +178,16 @@ module RSpec
       end
 
       # @private
-      module CaptureStderr
-        def self.name
+      class CaptureStderr
+        attr_accessor :as_tty
+
+        def name
           'stderr'
         end
 
-        def self.capture(block)
+        def capture(block)
           captured_stream = CapturedStream.new
+          captured_stream.as_tty = as_tty
 
           original_stream = $stderr
           $stderr = captured_stream

--- a/lib/rspec/matchers/built_in/output.rb
+++ b/lib/rspec/matchers/built_in/output.rb
@@ -136,13 +136,20 @@ module RSpec
       end
 
       # @private
+      class CapturedStream < StringIO
+        def tty?
+          true
+        end
+      end
+
+      # @private
       module CaptureStdout
         def self.name
           'stdout'
         end
 
         def self.capture(block)
-          captured_stream = StringIO.new
+          captured_stream = CapturedStream.new
 
           original_stream = $stdout
           $stdout = captured_stream
@@ -162,7 +169,7 @@ module RSpec
         end
 
         def self.capture(block)
-          captured_stream = StringIO.new
+          captured_stream = CapturedStream.new
 
           original_stream = $stderr
           $stderr = captured_stream

--- a/spec/rspec/matchers/built_in/output_spec.rb
+++ b/spec/rspec/matchers/built_in/output_spec.rb
@@ -159,6 +159,14 @@ module RSpec
       }
     end
 
+    RSpec.describe "output.to_stdout matcher when printing only if stdout is a TTY" do
+      include_examples "output_to_stream", :stdout, :to_stdout, Module.new {
+        def print_to_stream(msg)
+          $stdout.print(msg) if $stdout.tty?
+        end
+      }
+    end
+
     RSpec.describe "output.to_stderr_from_any_process matcher" do
       include_examples "output_to_stream", :stderr, :to_stderr_from_any_process, Module.new {
         def print_to_stream(msg)

--- a/spec/rspec/matchers/built_in/output_spec.rb
+++ b/spec/rspec/matchers/built_in/output_spec.rb
@@ -231,7 +231,7 @@ module RSpec
       it "errors out nicely when attempting it without having set the stream" do
         expect {
           expect { print "foo" }.to output("foo").as_tty # <- wrong call, `to_std(out|err)` is missing
-        }.to raise_error(/can only be used with `to_stdout` or `to_stderr`/)
+        }.to raise_error(/can only be used after `to_stdout` or `to_stderr`/)
       end
 
       it "errors out nicely when attempting it with *_from_any_process" do

--- a/spec/rspec/matchers/built_in/output_spec.rb
+++ b/spec/rspec/matchers/built_in/output_spec.rb
@@ -237,7 +237,7 @@ module RSpec
       it "errors out nicely when attempting it with *_from_any_process" do
         expect {
           expect { print "foo" }.to output("foo").to_stdout_from_any_process.as_tty
-        }.to raise_error(/can only be used with `to_stdout` or `to_stderr`/)
+        }.to raise_error(/can only be used after `to_stdout` or `to_stderr`/)
       end
 
       it "can be chained" do

--- a/spec/rspec/matchers/built_in/output_spec.rb
+++ b/spec/rspec/matchers/built_in/output_spec.rb
@@ -220,8 +220,12 @@ module RSpec
         expect { print "foo" if $stdout.tty? }.to output("foo").to_stdout.as_tty
       end
 
-      it "does not capture output only written to a TTY" do
+      it "does not capture output only written to a TTY by default" do
         expect { print "foo" if $stdout.tty? }.to_not output("foo").to_stdout
+      end
+
+      it "does not capture output only written to a TTY when forcing the stream to not be a TTY" do
+        expect { print "foo" if $stdout.tty? }.to_not output("foo").to_stdout.as_not_tty
       end
 
       it "captures output written to a TTY through stderr" do

--- a/spec/rspec/matchers/built_in/output_spec.rb
+++ b/spec/rspec/matchers/built_in/output_spec.rb
@@ -233,6 +233,18 @@ module RSpec
           expect { print "foo" }.to output("foo").as_tty # <- wrong call, `to_std(out|err)` is missing
         }.to raise_error(/can only be used with `to_stdout` or `to_stderr`/)
       end
+
+      it "errors out nicely when attempting it with *_from_any_process" do
+        expect {
+          expect { print "foo" }.to output("foo").to_stdout_from_any_process.as_tty
+        }.to raise_error(/can only be used with `to_stdout` or `to_stderr`/)
+      end
+
+      it "can be chained" do
+        expect { print "foo" if $stdout.tty?; $stderr.print "bar" if $stderr.tty? }.
+          to output("foo").to_stdout.as_tty.
+          and output("bar").to_stderr.as_tty
+      end
     end
   end
 end


### PR DESCRIPTION
## The problem

I have an app which prints some output only if the standard output is a TTY. I'd say it's a relative standard practice:

```ruby
puts "Whatever" if $stdout.tty?
```

Currently, this can't be tested with `expect { ... }.to output(...).to_stdout` because `$stdout` is replaced with a `StringIO`, which always returns `false` for `.tty?`, so the code never prints.

If this is a problem RSpec wants to fix (I guess you can argue that it's an antipattern and should be implemented in a different way), this PR does it.

## The fix

~`$stdout` is still replaced with a `StringIO` and the matcher works the same, but some specific methods are called on the original stream. I only added `.tty?` because that's my usecase, but I guess there are other methods for which this could make sense (now or in the future).~

~I haven't contributed to RSpec before so I'm not familiar with coding standards, style, etc., so I appreciate any feedback, particularly on the following problem: I had to add an exception for the libraries allowed to be loaded for `delegate` (in fact there is another one for `stringio` for the same reason). Is this acceptable? If not, there are at least two alternatives I could implement:~

* ~Do some trick to require `delegate` and define the class on runtime only once `output` has been called. This is already  done for the `tempfile` require, although it would be a bit trickier than that because the class needs to be defined to.~
* ~Not use `SimpleDelegator` and implement the behavior using `method_missing`.~

~Is any of these approaches preferred?~

Update: the description above no longer mathes the implementation, which I've changed according to the feedback received. It's simpler now and doesn't need such a long explanation :sweat_smile: 

