### PR TITLE
Support compound stream matchers

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ Enhancements:
 
 * Improve the IO emulation in the output capture matchers (`output(...).to_stdout` et al)
   by adding `as_tty` and `as_not_tty` to change the `tty?` flags. (Sergio Gil Pérez de la Manga, #1459)
+* Add support for compound output matchers. (Eric Mueller, #1460)
 
 ### 3.13.1 / 2024-06-13
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.13.0...v3.13.1)

--- a/lib/rspec/matchers/built_in/output.rb
+++ b/lib/rspec/matchers/built_in/output.rb
@@ -257,9 +257,9 @@ module RSpec
 
         private
 
-        def read_contents(strm)
-          strm.rewind
-          strm.read
+        def read_contents(captured_stream)
+          captured_stream.rewind
+          captured_stream.read
         end
 
         def clean_up_tempfile(tempfile)

--- a/lib/rspec/matchers/built_in/output.rb
+++ b/lib/rspec/matchers/built_in/output.rb
@@ -186,6 +186,7 @@ module RSpec
           captured_stream.string
         ensure
           $stdout = original_stream
+          $stdout.write(captured_stream.string) unless $stdout == STDOUT
         end
       end
 
@@ -209,6 +210,7 @@ module RSpec
           captured_stream.string
         ensure
           $stderr = original_stream
+          $stderr.write(captured_stream.string) unless $stderr == STDERR
         end
       end
 

--- a/spec/rspec/matchers/built_in/output_spec.rb
+++ b/spec/rspec/matchers/built_in/output_spec.rb
@@ -139,6 +139,12 @@ RSpec.shared_examples "output_to_stream" do |stream_name, matcher_method, helper
       }.to fail_including("expected block to not output a string starting with \"f\" to #{stream_name}, but output \"foo\"\nDiff")
     end
   end
+
+  context "expect { ... }.to output(matcher1).#{matcher_method}.and output(matcher2).#{matcher_method}" do
+    it "passes if the block outputs lines to #{stream_name} matching both matchers" do
+      expect { print_to_stream "foo_bar" }.to matcher(/foo/).and matcher(/bar/)
+    end
+  end
 end
 
 module RSpec

--- a/spec/rspec/matchers/built_in/output_spec.rb
+++ b/spec/rspec/matchers/built_in/output_spec.rb
@@ -141,7 +141,7 @@ RSpec.shared_examples "output_to_stream" do |stream_name, matcher_method, helper
   end
 
   context "expect { ... }.to output(matcher1).#{matcher_method}.and output(matcher2).#{matcher_method}" do
-    it "passes if the block outputs lines to #{stream_name} matching both matchers" do
+    it "passes if the block outputs lines to #{stream_name} matching both matchers", :pending => RSpec::Support::Ruby.jruby? && matcher_method =~ /any_process/ do
       expect { print_to_stream "foo_bar" }.to matcher(/foo/).and matcher(/bar/)
     end
   end


### PR DESCRIPTION
Currently, compound stream matchers aren't properly supported, because when the CompoundMatcher nests them, the inner matcher doesn't expose the captured output to the outer matcher. This results in rspec/rspec#89.

While resolving the issue for the `to_stderr_from_any_process` though, I found an additional problem, which is that this matcher didn't properly _restore_ the `RSpec::Support::StdErrSplitter` to its original state after capturing (it leaves it pointed at a now-dead Tempfile stream).

This PR will be in draft state until I work out a resolution for that.

Fixes rspec/rspec#89