### PR TITLE
Fix issues on Ruby 3.4.0-preview1

### DIFF
--- a/spec/rspec/expectations/block_snippet_extractor_spec.rb
+++ b/spec/rspec/expectations/block_snippet_extractor_spec.rb
@@ -14,7 +14,7 @@ module RSpec::Expectations
       @proc_object = block
     end
 
-    def another_method(*)
+    def another_method(*, &_block)
     end
 
     before do

--- a/spec/rspec/expectations/failure_aggregator_spec.rb
+++ b/spec/rspec/expectations/failure_aggregator_spec.rb
@@ -457,7 +457,11 @@ module RSpec::Expectations
       # Each Ruby version return a different exception complement.
       # This method gets the current version and return the
       # right complement.
-      if RSpec::Support::Ruby.mri? && RUBY_VERSION > "1.8.7"
+      if RSpec::Support::Ruby.mri? && RUBY_VERSION.to_f > 3.3
+        def exception_complement(block_levels)
+          ":in 'block (#{block_levels} levels) in <module:Expectations>'"
+        end
+      elsif RSpec::Support::Ruby.mri? && RUBY_VERSION > "1.8.7"
         def exception_complement(block_levels)
           ":in `block (#{block_levels} levels) in <module:Expectations>'"
         end

--- a/spec/rspec/matchers/built_in/eq_spec.rb
+++ b/spec/rspec/matchers/built_in/eq_spec.rb
@@ -62,7 +62,7 @@ module RSpec
 
           it "provides message, expected and actual with encoding details on #failure_message when string encoding is different" do
             matcher = eq('abc'.encode('UTF-16LE'))
-            matcher.matches?('abc'.force_encoding('ASCII-8BIT'))
+            matcher.matches?('abc'.dup.force_encoding('ASCII-8BIT'))
             expect(matcher.failure_message).to eq "\nexpected: #<Encoding:UTF-16LE> \"abc\"\n     got: #<Encoding:ASCII-8BIT> \"abc\"\n\n(compared using ==)\n"
           end
 

--- a/spec/rspec/matchers/built_in/eql_spec.rb
+++ b/spec/rspec/matchers/built_in/eql_spec.rb
@@ -50,7 +50,7 @@ module RSpec
 
           it "provides message, expected and actual with encoding details on #failure_message when string encoding is different" do
             matcher = eql('abc'.encode('UTF-16LE'))
-            matcher.matches?('abc'.force_encoding('ASCII-8BIT'))
+            matcher.matches?('abc'.dup.force_encoding('ASCII-8BIT'))
             expect(matcher.failure_message).to eq "\nexpected: #<Encoding:UTF-16LE> \"abc\"\n     got: #<Encoding:ASCII-8BIT> \"abc\"\n\n(compared using eql?)\n"
           end
 

--- a/spec/rspec/matchers/built_in/yield_spec.rb
+++ b/spec/rspec/matchers/built_in/yield_spec.rb
@@ -789,7 +789,7 @@ RSpec.describe "yield_successive_args matcher" do
         %w[ food barn ].each do |eventual|
           initial = ''
           _yield_with_args(initial, &b)
-          initial << eventual
+          initial += eventual
         end
       }.not_to yield_successive_args(a_string_matching(/foo/), a_string_matching(/bar/))
     end

--- a/spec/rspec/matchers/built_in/yield_spec.rb
+++ b/spec/rspec/matchers/built_in/yield_spec.rb
@@ -1,14 +1,14 @@
 module YieldHelpers
   # these helpers are prefixed with an underscore to prevent
   # collisions with the matchers (some of which have the same names)
-  def _dont_yield
+  def _dont_yield(&_block)
   end
 
   def _yield_with_no_args
     yield
   end
 
-  def _yield_with_args(*args)
+  def _yield_with_args(*args, &_block)
     yield(*args)
   end
 end


### PR DESCRIPTION
Continuing a theme from other PRs... fix some of the issues with the build on Ruby 3.4:

- Add block parameters to remove warnings
- Prevent string mutation with `<<` in favour of `+=`
- Fix output assertion for Ruby 3.4
- Prevent force_encoding warning with string literals by using `dup`