### PR TITLE
Require an argument for the Include matcher

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ Bug Fixes:
   (Eric Mueller, #1455)
 * Use `RSpec.warning` for an expectation warning rather than `Kernel.warn`. (Jon Rowe, #1472)
 * Prevent mismatched use of block and value matchers in compound expectations. (Phil Pirozhkov, #1476)
+* Raise an error when passing no arguments to the `include` matcher. (Eric Mueller, #1479)
 
 Enhancements:
 

--- a/lib/rspec/matchers/built_in/include.rb
+++ b/lib/rspec/matchers/built_in/include.rb
@@ -13,6 +13,7 @@ module RSpec
 
         # @api private
         def initialize(*expecteds)
+          raise(ArgumentError, 'Include matcher requires at least one argument') if expecteds.empty?
           @expecteds = expecteds
         end
 

--- a/lib/rspec/matchers/built_in/include.rb
+++ b/lib/rspec/matchers/built_in/include.rb
@@ -13,7 +13,7 @@ module RSpec
 
         # @api private
         def initialize(*expecteds)
-          raise(ArgumentError, 'Include matcher requires at least one argument') if expecteds.empty?
+          raise(ArgumentError, 'include() is not supported, please supply an argument') if expecteds.empty?
           @expecteds = expecteds
         end
 

--- a/spec/rspec/matchers/built_in/include_spec.rb
+++ b/spec/rspec/matchers/built_in/include_spec.rb
@@ -161,6 +161,12 @@ RSpec.describe "#include matcher" do
     end
   end
 
+  describe "expect(...).to include(with_no_args)" do
+    it "fails correctly" do
+      expect { expect([1, 2, 3]).to include }.to raise_error(ArgumentError)
+    end
+  end
+
   describe "expect(...).to include(with_one_arg)" do
     it_behaves_like "an RSpec value matcher", :valid_value => [1, 2], :invalid_value => [1] do
       let(:matcher) { include(2) }


### PR DESCRIPTION
Resolves #1478 

## Purpose

There are some edge-case ways you can try to invoke this matcher that end up parsing as an argument-less call and a separate expression; this will stop that from happening.

## Implementation
Treat instantiation of the `Include` matcher with no arguments as an ArgumentError.

### Note

This might count as a breaking change - while it _seems_ like something nobody would ever want to do, the case where this can happen legitimately comes up when the caller is taking an array to splat _into_ the `include` matcher, and ignoring the empty case because it currently passes.