### PR TITLE
Fix `include(/regexp/)` when used without a count.

### DIFF
--- a/features/built_in_matchers/include.feature
+++ b/features/built_in_matchers/include.feature
@@ -4,6 +4,7 @@ Feature: `include` matcher
 
   ```ruby
   expect("a string").to include("a")
+  expect("a string").to include(/str..g/)
   expect("a string").to include(/a|str/).twice
   expect("a string").to include("str", "g")
   expect("a string").not_to include("foo")
@@ -80,6 +81,7 @@ Feature: `include` matcher
       RSpec.describe "a string" do
         it { is_expected.to include("str") }
         it { is_expected.to include("a", "str", "ng") }
+        it { is_expected.to include(/str..g/) }
         it { is_expected.to include(/a|str/).twice }
         it { is_expected.not_to include("foo") }
         it { is_expected.not_to include("foo", "bar") }
@@ -87,6 +89,7 @@ Feature: `include` matcher
         # deliberate failures
         it { is_expected.to include("foo") }
         it { is_expected.not_to include("str") }
+        it { is_expected.not_to include(/str..g/) }
         it { is_expected.to include("str").at_least(:twice) }
         it { is_expected.to include("str", "foo") }
         it { is_expected.not_to include("str", "foo") }
@@ -94,8 +97,9 @@ Feature: `include` matcher
       """
     When I run `rspec string_include_matcher_spec.rb`
     Then the output should contain all of these:
-      | 10 examples, 5 failures                                                     |
+      | 12 examples, 6 failures                                                     |
       | expected "a string" to include "foo"                                        |
+      | expected "a string" not to include /str..g/                                 |
       | expected "a string" not to include "str"                                    |
       | expected "a string" to include "str" at least twice but it is included once |
       | expected "a string" to include "foo"                                        |

--- a/lib/rspec/matchers/built_in/include.rb
+++ b/lib/rspec/matchers/built_in/include.rb
@@ -166,6 +166,7 @@ module RSpec
         end
 
         def actual_collection_includes?(expected_item)
+          return actual.scan(expected_item).size > 0 if Regexp === expected_item && String === actual
           return true if actual.include?(expected_item)
 
           # String lacks an `any?` method...
@@ -200,6 +201,7 @@ module RSpec
 
         def diff_would_wrongly_highlight_matched_item?
           return false unless actual.is_a?(String) && expected.is_a?(Array)
+          return false if Regexp === expecteds.first
 
           lines = actual.split("\n")
           expected.any? do |str|

--- a/spec/rspec/matchers/built_in/include_spec.rb
+++ b/spec/rspec/matchers/built_in/include_spec.rb
@@ -215,6 +215,10 @@ RSpec.describe "#include matcher" do
         expect("abc").to include("a")
       end
 
+      it "passes if target matches a regexp" do
+        expect("abc").to include(/[cba]{3}/)
+      end
+
       it "fails if target does not include expected" do
         expect {
           expect("abc").to include("d")
@@ -240,16 +244,20 @@ RSpec.describe "#include matcher" do
       end
 
       context "with exact count" do
-        it 'fails if the block yields wrong number of times' do
+        it 'fails if the string contains the wrong number of occurences' do
           expect {
             expect('foo bar foo').to include('foo').once
           }.to fail_with(/expected "foo bar foo" to include "foo" once but it is included twice/)
+          expect {
+            expect('foo bar foo').to include(/[of]{3}/).once
+          }.to fail_with(/expected "foo bar foo" to include \/\[of\]\{3\}\/ once but it is included twice/)
         end
 
-        it 'passes if the block yields the specified number of times' do
+        it 'passes if the string contains the correct number of occurences' do
           expect('fooo bar').to include('oo').once
           expect('fooo bar').to include('o').thrice
           expect('fooo ooo oo bar foo').to include('oo').exactly(4).times
+          expect('fooo ooo oo bar foo').to include(/fo{2}/).exactly(2).times
         end
       end
 


### PR DESCRIPTION
Fixes #1481 there was a bug where a regexp and a count contraint would work with the `include` matcher, but not a bare regexp e.g.

```
# worked
expect("astring").to include(/a/).once

# failed
expect("astring").to include(/a/)
```

This makes this consistent with the docs as working, in another version of RSpec we may look to deprecate this usage as it is not doing an `include?` call but using scan instead.